### PR TITLE
Feature: Define Artifact and Validator contracts

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,3 @@
 export * from './lib/core';
+export * from './models';
+export * from './validators';

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -1,0 +1,57 @@
+/*
+=== Schema Sample Format ===
+name: user
+url: /user/:id
+request:
+  parameters:
+    id:
+      in: query # path / query / header
+      description: user id
+      validators:
+        - name: Date
+          args:
+            format: 'yyyy-MM-dd'
+        - name: required
+error:
+  - code: Forbidden
+    message: 'You are not allowed to access this resource'
+ */
+
+export enum FieldInType {
+  QUERY = 'QUERY',
+  HEADER = 'HEADER',
+}
+
+export interface ValidatorDefinition<T = any> {
+  name: string;
+  args: T;
+}
+
+export interface RequestParameter {
+  fieldName: string;
+  // the field put in query parameter or headers
+  fieldIn: FieldInType;
+  description: string;
+  validators: Array<ValidatorDefinition>;
+}
+
+export interface ErrorInfo {
+  code: string;
+  message: string;
+}
+
+export interface APISchema {
+  // graphql operation name
+  operationName: string;
+  // restful url path
+  urlPath: string;
+  // template, could be name or path
+  templateSource: string;
+  request: Array<RequestParameter>;
+  errors: Array<ErrorInfo>;
+  response: any;
+}
+
+export interface BuiltArtifact {
+  apiSchemas: Array<APISchema>;
+}

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './artifact';

--- a/packages/core/src/validators/index.ts
+++ b/packages/core/src/validators/index.ts
@@ -1,0 +1,1 @@
+export * from './interface';

--- a/packages/core/src/validators/interface.ts
+++ b/packages/core/src/validators/interface.ts
@@ -1,0 +1,8 @@
+export interface IValidator<T = any> {
+  // validator name
+  name: string;
+  // validate Schema format
+  validateSchema(args: T): boolean;
+  // validate input data
+  validateData(data: string, args: T): boolean;
+}


### PR DESCRIPTION
## Description
Define the contract of artifact type and `IValidator` interface for extending our built-in other validator and make the client could use it.

The artifact type from `schema.yaml` format:
```yaml
# The name used for graphQL
name: user
url: /user/:id
request:
  parameters:
    id:
      in: query # path / query / header
      description: user id
      validators:
        - name: Date
          args:
            format: 'yyyy-MM-dd'
        - name: required
error:
  - code: Forbidden
    message: 'You are not allowed to access this resource'
```
