### PR TITLE
Feature: Implementing data query builder

### DIFF
--- a/packages/serve/src/lib/data-query/builder/commonTypes.ts
+++ b/packages/serve/src/lib/data-query/builder/commonTypes.ts
@@ -1,0 +1,35 @@
+export enum ComparisonPredicate {
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  IS_NULL = 'IS_NULL',
+  EXISTS = 'EXISTS',
+}
+
+export enum LogicalOperator {
+  AND = 'AND',
+  OR = 'OR',
+  NOT = 'NOT',
+}
+
+export type ComparisonOperator = '=' | '!=' | '>' | '<' | '>=' | '<=';
+
+export const isOfComparisonOperator = (
+  source: string
+): source is ComparisonOperator => {
+  return ['=', '!=', '>', '<', '>=', '<='].includes(source);
+};
+
+export interface BetweenPredicateInput {
+  column: string;
+  min: number;
+  max: number;
+}
+
+export interface InPredicateInput {
+  column: string;
+  values: string[] | number[];
+}
+
+export interface NullPredicateInput {
+  column: string;
+}

--- a/packages/serve/src/lib/data-query/builder/dataQueryBuilder.ts
+++ b/packages/serve/src/lib/data-query/builder/dataQueryBuilder.ts
@@ -1,0 +1,1137 @@
+import { find, isEmpty } from 'lodash';
+import {
+  ComparisonPredicate,
+  ComparisonOperator,
+  LogicalOperator,
+  BetweenPredicateInput,
+  InPredicateInput,
+  NullPredicateInput,
+  isOfComparisonOperator,
+} from './commonTypes';
+import {
+  IJoinOnClause,
+  JoinOnClause,
+  JoinOnClauseOperation,
+} from './joinOnClause';
+
+export enum SelectCommandType {
+  SELECT = 'SELECT',
+  SELECT_DISTINCT = 'SELECT_DISTINCT',
+}
+
+export enum AggregateFuncType {
+  COUNT = 'COUNT',
+  SUM = 'SUM',
+  AVG = 'AVG',
+  MIN = 'MIN',
+  MAX = 'MAX',
+}
+
+export enum JoinCommandType {
+  INNER_JOIN = 'INNER_JOIN',
+  LEFT_JOIN = 'LEFT_JOIN',
+  RIGHT_JOIN = 'RIGHT_JOIN',
+  FULL_JOIN = 'FULL_JOIN',
+}
+
+export enum WherePredicate {
+  WRAPPED = 'WRAPPED',
+  LIKE = 'LIKE',
+}
+
+export interface AliasColumn {
+  // original column name
+  name: string;
+  // alias column name
+  as?: string;
+}
+
+export interface SelectedColumn extends AliasColumn {
+  aggregateType?: AggregateFuncType;
+}
+
+export interface SelectClauseOperation {
+  command: SelectCommandType;
+  columns: Array<SelectedColumn>;
+}
+
+export interface AliasDataQueryBuilder {
+  // the join builder
+  builder: IDataQueryBuilder;
+  // alias builder name for join builder
+  as: string;
+}
+
+export interface JoinClauseOperation {
+  command: JoinCommandType;
+  // the join on clause operations e.g: on, onBetween...
+  onClauses: Array<JoinOnClauseOperation>;
+  joinBuilder: AliasDataQueryBuilder;
+}
+
+export type JoinClauseCallback = (clause: IJoinOnClause) => void;
+
+// Where clause Operation
+export interface WhereOperatorInput {
+  column: string;
+  operator: ComparisonOperator;
+  value: string | number | boolean | IDataQueryBuilder;
+}
+
+export type BuilderClauseCallback = (builder: IDataQueryBuilder) => void;
+
+export type WhereInPredicateInput = InPredicateInput & {
+  values: string[] | number[] | IDataQueryBuilder;
+};
+
+export interface WhereLikePredicateInput {
+  column: string;
+  searchValue: string;
+}
+
+export type WherePredicateInput =
+  | WhereOperatorInput
+  | BetweenPredicateInput
+  | WhereInPredicateInput
+  | NullPredicateInput
+  | WhereLikePredicateInput
+  | IDataQueryBuilder;
+
+export interface WhereClauseOperation {
+  // null means using ComparisonOperator
+  command: WherePredicate | ComparisonPredicate | LogicalOperator | null;
+  /*  If command is LogicalOperator type, data will be undefined or, data multi possible cases, including:
+    - command is WHERE => data will be NormalWhereClauseOperation type
+    - command is WHERE_WRAPPED => data will be Array<WhereClauseOperation> type
+    - command is WHERE_EXIST => data will be AliasDataQueryBuilder type
+    */
+  data?:
+    | WherePredicateInput
+    | Array<WhereClauseOperation>
+    | AliasDataQueryBuilder;
+}
+
+// Group by clause Operation
+export type GroupByClauseOperations = Array<string>;
+
+// Having clause Operation
+export interface HavingOperatorInput {
+  column: SelectedColumn;
+  operator: ComparisonOperator;
+  value: string | number | boolean | IDataQueryBuilder;
+}
+
+export type HavingInPredicateInput = InPredicateInput & {
+  column: SelectedColumn;
+};
+
+export interface HavingBetweenPredicateInput {
+  column: SelectedColumn;
+  min: number;
+  max: number;
+}
+
+export type HavingPredicateInput =
+  | HavingOperatorInput
+  | HavingBetweenPredicateInput
+  | HavingInPredicateInput
+  | NullPredicateInput
+  | IDataQueryBuilder;
+
+export interface HavingClauseOperation {
+  // null means using ComparisonOperator
+  command: ComparisonPredicate | LogicalOperator | null;
+  // data could be normal value, object or wrapped where operations
+  data?: HavingPredicateInput | AliasDataQueryBuilder;
+}
+
+// Order by clause operation
+export enum Direction {
+  ASC = 'ASCENDING',
+  DESC = 'DESCENDING',
+}
+export interface OrderByClauseOperation {
+  column: string;
+  direction: Direction;
+}
+
+export interface SQLClauseOperation {
+  // record select clause operations, null means select *
+  select: SelectClauseOperation | null;
+  // record where clause operations
+  where: Array<WhereClauseOperation>;
+  // record join clause operations => ok
+  join: Array<JoinClauseOperation>;
+  // record groupBy clause operations, array is column name
+  groupBy: GroupByClauseOperations;
+  // recode having clause operations
+  having: Array<HavingClauseOperation>;
+  // record orderBy operations
+  orderBy: Array<OrderByClauseOperation>;
+  // null means not set the value
+  limit: number | null;
+  // null means not set the value
+  offset: number | null;
+}
+
+export interface IDataQueryBuilder {
+  readonly statement: string;
+  readonly operations: SQLClauseOperation;
+  // Select clause methods
+  select(...columns: Array<SelectedColumn | string>): DataQueryBuilder;
+  distinct(...columns: Array<SelectedColumn | string>): DataQueryBuilder;
+  column(...columns: Array<SelectedColumn | string>): DataQueryBuilder;
+  first(...columns: Array<SelectedColumn | string>): DataQueryBuilder;
+  count(column: AliasColumn | string): DataQueryBuilder;
+  min(column: AliasColumn | string): DataQueryBuilder;
+  max(column: AliasColumn | string): DataQueryBuilder;
+  sum(column: AliasColumn | string): DataQueryBuilder;
+  avg(column: AliasColumn | string): DataQueryBuilder;
+  // Join clause methods
+  innerJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ): DataQueryBuilder;
+  leftJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ): DataQueryBuilder;
+  rightJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ): DataQueryBuilder;
+  fullJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ): DataQueryBuilder;
+  // Where clause methods
+  where(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  whereNot(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  whereWrapped(builderCallback: BuilderClauseCallback): DataQueryBuilder;
+  whereNotWrapped(builderCallback: BuilderClauseCallback): DataQueryBuilder;
+  whereBetween(column: string, min: number, max: number): DataQueryBuilder;
+  whereNotBetween(column: string, min: number, max: number): DataQueryBuilder;
+  whereIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ): DataQueryBuilder;
+  whereNotIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ): DataQueryBuilder;
+  whereNull(column: string): DataQueryBuilder;
+  whereNotNull(column: string): DataQueryBuilder;
+  whereLike(column: string, searchValue: string): DataQueryBuilder;
+  whereExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  whereNotExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  // And Where clause methods
+  andWhere(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  andWhereNot(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  andWhereWrapped(builderCallback: BuilderClauseCallback): DataQueryBuilder;
+  andWhereNotWrapped(builderCallback: BuilderClauseCallback): DataQueryBuilder;
+  andWhereBetween(column: string, min: number, max: number): DataQueryBuilder;
+  andWhereNotBetween(
+    column: string,
+    min: number,
+    max: number
+  ): DataQueryBuilder;
+  andWhereIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ): DataQueryBuilder;
+  andWhereNotIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ): DataQueryBuilder;
+  andWhereNull(column: string): DataQueryBuilder;
+  andWhereNotNull(column: string): DataQueryBuilder;
+  andWhereLike(column: string, searchValue: string): DataQueryBuilder;
+  andWhereExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  andWhereNotExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  // Or Where clause methods
+  orWhere(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  orWhereNot(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  orWhereWrapped(builderCallback: BuilderClauseCallback): DataQueryBuilder;
+  orWhereNotWrapped(builderCallback: BuilderClauseCallback): DataQueryBuilder;
+  orWhereBetween(column: string, min: number, max: number): DataQueryBuilder;
+  orWhereNotBetween(column: string, min: number, max: number): DataQueryBuilder;
+  orWhereIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ): DataQueryBuilder;
+  orWhereNotIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ): DataQueryBuilder;
+  orWhereNull(column: string): DataQueryBuilder;
+  orWhereNotNull(column: string): DataQueryBuilder;
+  orWhereLike(column: string, searchValue: string): DataQueryBuilder;
+  orWhereExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  orWhereNotExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+
+  // Group by clause method
+  groupBy(...columns: string[]): DataQueryBuilder;
+
+  // Having clause methods
+  having(
+    column: SelectedColumn | string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  havingIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ): DataQueryBuilder;
+  havingNotIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ): DataQueryBuilder;
+  havingBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ): DataQueryBuilder;
+  havingNotBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ): DataQueryBuilder;
+  havingNull(column: string): DataQueryBuilder;
+  havingNotNull(column: string): DataQueryBuilder;
+  havingExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  havingNotExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  // And Having clause methods
+  andHaving(
+    column: SelectedColumn | string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  andHavingIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ): DataQueryBuilder;
+  andHavingNotIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ): DataQueryBuilder;
+  andHavingBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ): DataQueryBuilder;
+  andHavingNotBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ): DataQueryBuilder;
+  andHavingNull(column: string): DataQueryBuilder;
+  andHavingNotNull(column: string): DataQueryBuilder;
+  andHavingExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  andHavingNotExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  // Or Having clause methods
+  orHaving(
+    column: SelectedColumn | string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ): DataQueryBuilder;
+  orHavingIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ): DataQueryBuilder;
+  orHavingNotIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ): DataQueryBuilder;
+  orHavingBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ): DataQueryBuilder;
+  orHavingNotBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ): DataQueryBuilder;
+  orHavingNull(column: string): DataQueryBuilder;
+  orHavingNotNull(column: string): DataQueryBuilder;
+  orHavingExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  orHavingNotExists(subQueryBuilder: AliasDataQueryBuilder): DataQueryBuilder;
+  // Order by clause method
+  orderBy(column: string, direction: Direction): DataQueryBuilder;
+  // Limit and Offset clause method
+  limit(size: number): DataQueryBuilder;
+  offset(move: number): DataQueryBuilder;
+  take(size: number, move: number): DataQueryBuilder;
+}
+
+export class DataQueryBuilder implements IDataQueryBuilder {
+  public readonly statement: string;
+  // record all operations for different SQL clauses
+  public readonly operations: SQLClauseOperation;
+
+  constructor({
+    statement,
+    operations,
+  }: {
+    statement: string;
+    operations?: SQLClauseOperation;
+  }) {
+    this.statement = statement;
+    this.operations = operations || {
+      select: null,
+      where: [],
+      join: [],
+      groupBy: [],
+      having: [],
+      orderBy: [],
+      limit: null,
+      offset: null,
+    };
+  }
+
+  // Select clause methods
+  public select(...columns: Array<SelectedColumn | string>) {
+    // if columns is empty, set to select all
+    if (isEmpty(columns)) columns = ['*'];
+    // skip current select if select only '*' value and has existed select '*' in record.
+    const isSelectAllExist = (column: SelectedColumn) => column.name === '*';
+    const isAllColumns = (column: string | SelectedColumn) =>
+      ['*', ''].includes(column as string) ||
+      [{ name: '*' }, { name: '' }].includes(column as SelectedColumn);
+    if (
+      columns.length === 1 &&
+      isAllColumns(columns[0]) &&
+      this.operations.select &&
+      find(this.operations.select.columns, isSelectAllExist)
+    ) {
+      return this;
+    }
+
+    this.recordSelect({ command: SelectCommandType.SELECT, columns });
+    return this;
+  }
+  public distinct(...columns: Array<SelectedColumn | string>) {
+    this.recordSelect({ command: SelectCommandType.SELECT_DISTINCT, columns });
+    return this;
+  }
+
+  // alias name method for select
+  public column(...columns: Array<SelectedColumn | string>) {
+    return this.select(...columns);
+  }
+  // select and limit 1
+  public first(...columns: Array<SelectedColumn | string>) {
+    this.select(...columns);
+    this.limit(1);
+    return this;
+  }
+
+  public count(column: AliasColumn | string = '*') {
+    const normalized: SelectedColumn =
+      typeof column === 'string'
+        ? {
+            name: '*',
+            aggregateType: AggregateFuncType.COUNT,
+          }
+        : {
+            ...column,
+            aggregateType: AggregateFuncType.COUNT,
+          };
+    this.select(normalized);
+    return this;
+  }
+
+  public min(column: AliasColumn | string) {
+    const normalized: SelectedColumn =
+      typeof column === 'string'
+        ? {
+            name: column,
+            aggregateType: AggregateFuncType.MIN,
+          }
+        : {
+            ...column,
+            aggregateType: AggregateFuncType.MIN,
+          };
+    this.select(normalized);
+    return this;
+  }
+
+  public max(column: AliasColumn | string) {
+    const normalized: SelectedColumn =
+      typeof column === 'string'
+        ? {
+            name: column,
+            aggregateType: AggregateFuncType.MAX,
+          }
+        : {
+            ...column,
+            aggregateType: AggregateFuncType.MAX,
+          };
+    this.select(normalized);
+    return this;
+  }
+  public avg(column: AliasColumn | string) {
+    const normalized: SelectedColumn =
+      typeof column === 'string'
+        ? {
+            name: column,
+            aggregateType: AggregateFuncType.AVG,
+          }
+        : {
+            ...column,
+            aggregateType: AggregateFuncType.AVG,
+          };
+    this.select(normalized);
+    return this;
+  }
+  public sum(column: AliasColumn | string) {
+    const normalized: SelectedColumn =
+      typeof column === 'string'
+        ? {
+            name: column,
+            aggregateType: AggregateFuncType.SUM,
+          }
+        : {
+            ...column,
+            aggregateType: AggregateFuncType.SUM,
+          };
+    this.select(normalized);
+    return this;
+  }
+  // Join clause methods
+  public innerJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ) {
+    this.recordJoin({
+      command: JoinCommandType.INNER_JOIN,
+      builder,
+      joinCallback,
+    });
+    return this;
+  }
+
+  public leftJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ) {
+    this.recordJoin({
+      command: JoinCommandType.LEFT_JOIN,
+      builder,
+      joinCallback,
+    });
+    return this;
+  }
+
+  public rightJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ) {
+    this.recordJoin({
+      command: JoinCommandType.RIGHT_JOIN,
+      builder,
+      joinCallback,
+    });
+    return this;
+  }
+  public fullJoin(
+    builder: AliasDataQueryBuilder,
+    joinCallback: JoinClauseCallback
+  ) {
+    this.recordJoin({
+      command: JoinCommandType.FULL_JOIN,
+      builder,
+      joinCallback,
+    });
+    return this;
+  }
+
+  // Where clause methods
+  public where(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    if (!isOfComparisonOperator(operator))
+      throw new Error(`'There is no ${operator}  operator.`);
+
+    this.recordWhere({
+      command: null,
+      data: {
+        column,
+        operator,
+        value,
+      } as WherePredicateInput,
+    });
+    return this;
+  }
+  public whereNot(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.NOT });
+    return this.where(column, operator, value);
+  }
+
+  public whereWrapped(builderCallback: BuilderClauseCallback) {
+    const wrappedBuilder = new DataQueryBuilder({
+      statement: '',
+    });
+    builderCallback(wrappedBuilder);
+    this.recordWhere({
+      command: WherePredicate.WRAPPED,
+      data: wrappedBuilder.operations.where,
+    });
+    return this;
+  }
+  public whereNotWrapped(builderCallback: BuilderClauseCallback) {
+    this.recordWhere({ command: LogicalOperator.NOT });
+    return this.whereWrapped(builderCallback);
+  }
+  public whereBetween(column: string, min: number, max: number) {
+    this.recordWhere({
+      command: ComparisonPredicate.BETWEEN,
+      data: { column, min, max } as BetweenPredicateInput,
+    });
+    return this;
+  }
+
+  public whereNotBetween(column: string, min: number, max: number) {
+    this.recordWhere({ command: LogicalOperator.NOT });
+    return this.whereBetween(column, min, max);
+  }
+  public whereIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ) {
+    this.recordWhere({
+      command: ComparisonPredicate.IN,
+      data: { column, values: values } as WhereInPredicateInput,
+    });
+    return this;
+  }
+  public whereNotIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.NOT });
+    return this.whereIn(column, values);
+  }
+
+  public whereNull(column: string) {
+    this.recordWhere({
+      command: ComparisonPredicate.IS_NULL,
+      data: { column } as NullPredicateInput,
+    });
+    return this;
+  }
+  public whereNotNull(column: string) {
+    this.recordWhere({ command: LogicalOperator.NOT });
+    return this.whereNull(column);
+  }
+  public whereLike(column: string, searchValue: string) {
+    this.recordWhere({
+      command: WherePredicate.LIKE,
+      data: { column, searchValue } as WhereLikePredicateInput,
+    });
+    return this;
+  }
+  public whereExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordWhere({
+      command: ComparisonPredicate.EXISTS,
+      data: subQueryBuilder,
+    });
+    return this;
+  }
+  public whereNotExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordWhere({ command: LogicalOperator.NOT });
+    return this.whereExists(subQueryBuilder);
+  }
+
+  // and
+  public andWhere(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.where(column, operator, value);
+  }
+  public andWhereNot(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereNot(column, operator, value);
+  }
+  public andWhereWrapped(builderCallback: BuilderClauseCallback) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereWrapped(builderCallback);
+  }
+  public andWhereNotWrapped(builderCallback: BuilderClauseCallback) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereNotWrapped(builderCallback);
+  }
+  public andWhereBetween(column: string, min: number, max: number) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereBetween(column, min, max);
+  }
+  public andWhereNotBetween(column: string, min: number, max: number) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereNotBetween(column, min, max);
+  }
+  public andWhereIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereIn(column, values);
+  }
+  public andWhereNotIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereNotIn(column, values);
+  }
+  public andWhereNull(column: string) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereNull(column);
+  }
+  public andWhereNotNull(column: string) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereNotNull(column);
+  }
+  public andWhereLike(column: string, searchValue: string) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereLike(column, searchValue);
+  }
+  public andWhereExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereExists(subQueryBuilder);
+  }
+  public andWhereNotExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordWhere({ command: LogicalOperator.AND });
+    return this.whereNotExists(subQueryBuilder);
+  }
+
+  // or
+  public orWhere(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.where(column, operator, value);
+  }
+  public orWhereNot(
+    column: string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereNot(column, operator, value);
+  }
+  public orWhereWrapped(builderCallback: BuilderClauseCallback) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereWrapped(builderCallback);
+  }
+  public orWhereNotWrapped(builderCallback: BuilderClauseCallback) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereNotWrapped(builderCallback);
+  }
+  public orWhereBetween(column: string, min: number, max: number) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereBetween(column, min, max);
+  }
+  public orWhereNotBetween(column: string, min: number, max: number) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereNotBetween(column, min, max);
+  }
+  public orWhereIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereIn(column, values);
+  }
+  public orWhereNotIn(
+    column: string,
+    values: string[] | number[] | IDataQueryBuilder
+  ) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereNotIn(column, values);
+  }
+  public orWhereNull(column: string) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereNull(column);
+  }
+  public orWhereNotNull(column: string) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereNotNull(column);
+  }
+  public orWhereLike(column: string, searchValue: string) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereLike(column, searchValue);
+  }
+  public orWhereExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereExists(subQueryBuilder);
+  }
+  public orWhereNotExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordWhere({ command: LogicalOperator.OR });
+    return this.whereNotExists(subQueryBuilder);
+  }
+
+  // Group by clause method
+  public groupBy(...columns: string[]) {
+    this.operations.groupBy = this.operations.groupBy.concat(columns);
+    return this;
+  }
+
+  public having(
+    column: SelectedColumn | string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    const normalized = typeof column === 'string' ? { name: column } : column;
+    if (!isOfComparisonOperator(operator))
+      throw new Error(`'There is no ${operator}  operator.`);
+
+    this.recordHaving({
+      command: null,
+      data: {
+        column: normalized,
+        operator,
+        value,
+      } as HavingOperatorInput,
+    });
+    return this;
+  }
+
+  public havingIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ) {
+    const normalized = typeof column === 'string' ? { name: column } : column;
+    this.recordHaving({
+      command: ComparisonPredicate.IN,
+      data: {
+        column: normalized,
+        values,
+      } as HavingInPredicateInput,
+    });
+    return this;
+  }
+
+  public havingNotIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ) {
+    this.recordHaving({ command: LogicalOperator.NOT });
+    return this.havingIn(column, values);
+  }
+
+  public havingBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ) {
+    const normalized = typeof column === 'string' ? { name: column } : column;
+    this.recordHaving({
+      command: ComparisonPredicate.BETWEEN,
+      data: {
+        column: normalized,
+        min,
+        max,
+      } as HavingBetweenPredicateInput,
+    });
+    return this;
+  }
+
+  public havingNotBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ) {
+    this.recordHaving({ command: LogicalOperator.NOT });
+    return this.havingBetween(column, min, max);
+  }
+
+  public havingNull(column: string) {
+    this.recordHaving({
+      command: ComparisonPredicate.IS_NULL,
+      data: { column } as NullPredicateInput,
+    });
+    return this;
+  }
+  public havingNotNull(column: string) {
+    this.recordHaving({ command: LogicalOperator.NOT });
+    return this.havingNull(column);
+  }
+  public havingExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordHaving({
+      command: ComparisonPredicate.EXISTS,
+      data: subQueryBuilder,
+    });
+    return this;
+  }
+  public havingNotExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordHaving({ command: LogicalOperator.NOT });
+    return this.havingExists(subQueryBuilder);
+  }
+
+  // And Having clause
+  public andHaving(
+    column: SelectedColumn | string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.having(column, operator, value);
+  }
+  public andHavingIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingIn(column, values);
+  }
+  public andHavingNotIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingNotIn(column, values);
+  }
+  public andHavingBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingBetween(column, min, max);
+  }
+  public andHavingNotBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingNotBetween(column, min, max);
+  }
+  public andHavingNull(column: string) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingNull(column);
+  }
+  public andHavingNotNull(column: string) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingNotNull(column);
+  }
+  public andHavingExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingExists(subQueryBuilder);
+  }
+  public andHavingNotExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordHaving({ command: LogicalOperator.AND });
+    return this.havingNotExists(subQueryBuilder);
+  }
+  // Or Having clause
+  public orHaving(
+    column: SelectedColumn | string,
+    operator: string,
+    value: string | number | boolean | IDataQueryBuilder
+  ) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.having(column, operator, value);
+  }
+  public orHavingIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingIn(column, values);
+  }
+  public orHavingNotIn(
+    column: SelectedColumn | string,
+    values: number[] | string[]
+  ) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingNotIn(column, values);
+  }
+  public orHavingBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingBetween(column, min, max);
+  }
+  public orHavingNotBetween(
+    column: SelectedColumn | string,
+    min: number,
+    max: number
+  ) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingNotBetween(column, min, max);
+  }
+  public orHavingNull(column: string) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingNull(column);
+  }
+  public orHavingNotNull(column: string) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingNotNull(column);
+  }
+  public orHavingExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingExists(subQueryBuilder);
+  }
+  public orHavingNotExists(subQueryBuilder: AliasDataQueryBuilder) {
+    this.recordHaving({ command: LogicalOperator.OR });
+    return this.havingNotExists(subQueryBuilder);
+  }
+  // Order by clause method
+  public orderBy(column: string, direction: Direction = Direction.ASC) {
+    this.operations.orderBy.push({
+      column,
+      direction,
+    });
+    return this;
+  }
+
+  // Limit and Offset clause
+  public limit(size: number) {
+    this.operations.limit = size;
+    return this;
+  }
+
+  public offset(move: number) {
+    this.operations.offset = move;
+    return this;
+  }
+
+  public take(size: number, move: number) {
+    this.operations.limit = size;
+    this.operations.offset = move;
+    return this;
+  }
+
+  // record Select-On related operations
+  private recordSelect({
+    command,
+    columns,
+  }: {
+    command: SelectCommandType;
+    columns: Array<SelectedColumn | string>;
+  }) {
+    const normalized = columns.map((column) => {
+      if (typeof column === 'string') return { name: column };
+      return column as SelectedColumn;
+    });
+    if (this.operations.select === null) {
+      this.operations.select = {
+        command,
+        columns: normalized,
+      };
+      return;
+    }
+    // distinct will replace previous select command,
+    // even builder call select method in later of the distinct method, it not influence distinct.
+    if (command === SelectCommandType.SELECT_DISTINCT)
+      this.operations.select.command = command;
+
+    this.operations.select.columns =
+      this.operations.select.columns.concat(normalized);
+  }
+
+  private recordJoin({
+    command,
+    builder,
+    joinCallback,
+  }: {
+    command: JoinCommandType;
+    builder: AliasDataQueryBuilder;
+    joinCallback: JoinClauseCallback;
+  }) {
+    const joinOnClause = new JoinOnClause();
+    joinCallback(joinOnClause);
+    this.operations.join.push({
+      command,
+      onClauses: joinOnClause.operations,
+      joinBuilder: builder,
+    });
+  }
+
+  private recordWhere({
+    command,
+    data,
+  }: {
+    command: WherePredicate | ComparisonPredicate | LogicalOperator | null;
+    data?:
+      | WherePredicateInput
+      | Array<WhereClauseOperation>
+      | AliasDataQueryBuilder;
+  }) {
+    this.operations.where.push({
+      command,
+      data,
+    });
+  }
+
+  private recordHaving({
+    command,
+    data,
+  }: {
+    command: ComparisonPredicate | LogicalOperator | null;
+    data?: HavingPredicateInput | AliasDataQueryBuilder;
+  }) {
+    this.operations.having.push({
+      command,
+      data,
+    });
+  }
+
+  private resetOperations() {
+    this.operations.select = null;
+    this.operations.where = [];
+    this.operations.join = [];
+    this.operations.groupBy = [];
+    this.operations.having = [];
+    this.operations.orderBy = [];
+    this.operations.limit = null;
+    this.operations.offset = null;
+  }
+  public value() {
+    // TODO: call Driver
+
+    // Reset operations
+    this.resetOperations();
+  }
+}

--- a/packages/serve/src/lib/data-query/builder/index.ts
+++ b/packages/serve/src/lib/data-query/builder/index.ts
@@ -1,0 +1,3 @@
+export * from './commonTypes';
+export * from './joinOnClause';
+export * from './dataQueryBuilder';

--- a/packages/serve/src/lib/data-query/builder/joinOnClause.ts
+++ b/packages/serve/src/lib/data-query/builder/joinOnClause.ts
@@ -1,0 +1,187 @@
+import {
+  ComparisonPredicate,
+  ComparisonOperator,
+  LogicalOperator,
+  BetweenPredicateInput,
+  InPredicateInput,
+  NullPredicateInput,
+  isOfComparisonOperator,
+} from './commonTypes';
+
+export interface JoinOnOperatorInput {
+  leftColumn: string;
+  operator: ComparisonOperator;
+  rightColumn: string;
+}
+
+export interface JoinOnClauseOperation {
+  // null means using ComparisonOperator
+  command: ComparisonPredicate | LogicalOperator | null;
+  data?:
+    | JoinOnOperatorInput
+    | BetweenPredicateInput
+    | InPredicateInput
+    | NullPredicateInput;
+}
+
+export interface IJoinOnClause {
+  operations: Array<JoinOnClauseOperation>;
+  on(leftColumn: string, operator: string, rightColumn: string): JoinOnClause;
+  onBetween(column: string, min: number, max: number): JoinOnClause;
+  onNotBetween(column: string, min: number, max: number): JoinOnClause;
+  onIn(column: string, values: string[] | number[]): JoinOnClause;
+  onNotIn(column: string, values: string[] | number[]): JoinOnClause;
+  onNull(column: string): JoinOnClause;
+  onNotNull(column: string): JoinOnClause;
+  // and
+  andOn(
+    leftColumn: string,
+    operator: string,
+    rightColumn: string
+  ): JoinOnClause;
+  andOnBetween(column: string, min: number, max: number): JoinOnClause;
+  andOnNotBetween(column: string, min: number, max: number): JoinOnClause;
+  andOnIn(column: string, values: string[] | number[]): JoinOnClause;
+  andOnNotIn(column: string, values: string[] | number[]): JoinOnClause;
+  andOnNull(column: string): JoinOnClause;
+  andOnNotNull(column: string): JoinOnClause;
+  // or
+  orOn(leftColumn: string, operator: string, rightColumn: string): JoinOnClause;
+  orOnBetween(column: string, min: number, max: number): JoinOnClause;
+  orOnNotBetween(column: string, min: number, max: number): JoinOnClause;
+  orOnIn(column: string, values: string[] | number[]): JoinOnClause;
+  orOnNotIn(column: string, values: string[] | number[]): JoinOnClause;
+  orOnNull(column: string): JoinOnClause;
+  orOnNotNull(column: string): JoinOnClause;
+}
+
+export class JoinOnClause implements IJoinOnClause {
+  private _operations: Array<JoinOnClauseOperation>;
+
+  constructor() {
+    this._operations = [];
+  }
+
+  get operations() {
+    return this._operations;
+  }
+
+  public on(leftColumn: string, operator: string, rightColumn: string) {
+    if (!isOfComparisonOperator(operator))
+      throw new Error(`'There is no ${operator} operator.`);
+
+    this.recordOn({
+      command: null,
+      data: { leftColumn, operator, rightColumn },
+    });
+    return this;
+  }
+
+  public onBetween(column: string, min: number, max: number) {
+    if (min > max)
+      throw new Error(`min value ${min} not smaller than max value ${max}.`);
+
+    this.recordOn({
+      command: ComparisonPredicate.BETWEEN,
+      data: { column, min, max },
+    });
+    return this;
+  }
+  public onNotBetween(column: string, min: number, max: number) {
+    this.recordOn({ command: LogicalOperator.NOT });
+    return this.onBetween(column, min, max);
+  }
+
+  public onIn(column: string, values: number[] | string[]) {
+    this.recordOn({
+      command: ComparisonPredicate.IN,
+      data: { column, values },
+    });
+    return this;
+  }
+  public onNotIn(column: string, values: number[] | string[]) {
+    this.recordOn({ command: LogicalOperator.NOT });
+    return this.onIn(column, values);
+  }
+
+  public onNull(column: string) {
+    this.recordOn({
+      command: ComparisonPredicate.IS_NULL,
+      data: { column },
+    });
+    return this;
+  }
+  public onNotNull(column: string) {
+    this.recordOn({ command: LogicalOperator.NOT });
+    return this.onNull(column);
+  }
+
+  // and
+  public andOn(leftColumn: string, operator: string, rightColumn: string) {
+    this.recordOn({ command: LogicalOperator.AND });
+    return this.on(leftColumn, operator, rightColumn);
+  }
+  public andOnBetween(column: string, min: number, max: number) {
+    this.recordOn({ command: LogicalOperator.AND });
+    return this.onBetween(column, min, max);
+  }
+  public andOnNotBetween(column: string, min: number, max: number) {
+    this.recordOn({ command: LogicalOperator.AND });
+    return this.onNotBetween(column, min, max);
+  }
+  public andOnIn(column: string, values: number[] | string[]) {
+    this.recordOn({ command: LogicalOperator.AND });
+    return this.onIn(column, values);
+  }
+  public andOnNotIn(column: string, values: number[] | string[]) {
+    this.recordOn({ command: LogicalOperator.AND });
+    return this.onNotIn(column, values);
+  }
+  public andOnNull(column: string) {
+    this.recordOn({ command: LogicalOperator.AND });
+    return this.onNull(column);
+  }
+  public andOnNotNull(column: string) {
+    this.recordOn({ command: LogicalOperator.AND });
+    return this.onNotNull(column);
+  }
+
+  // or
+  public orOn(leftColumn: string, operator: string, rightColumn: string) {
+    this.recordOn({ command: LogicalOperator.OR });
+    return this.on(leftColumn, operator, rightColumn);
+  }
+  public orOnBetween(column: string, min: number, max: number) {
+    this.recordOn({ command: LogicalOperator.OR });
+    return this.onBetween(column, min, max);
+  }
+  public orOnNotBetween(column: string, min: number, max: number) {
+    this.recordOn({ command: LogicalOperator.OR });
+    return this.onNotBetween(column, min, max);
+  }
+  public orOnIn(column: string, values: number[] | string[]) {
+    this.recordOn({ command: LogicalOperator.OR });
+    return this.onIn(column, values);
+  }
+  public orOnNotIn(column: string, values: number[] | string[]) {
+    this.recordOn({ command: LogicalOperator.OR });
+    return this.onNotIn(column, values);
+  }
+  public orOnNull(column: string) {
+    this.recordOn({ command: LogicalOperator.OR });
+    return this.onNull(column);
+  }
+  public orOnNotNull(column: string) {
+    this.recordOn({ command: LogicalOperator.OR });
+    return this.onNotNull(column);
+  }
+
+  // record Join-On related operations
+  private recordOn(operation: JoinOnClauseOperation) {
+    const { command, data } = operation;
+    this._operations.push({
+      command,
+      data,
+    });
+  }
+}

--- a/packages/serve/src/lib/data-query/factory.ts
+++ b/packages/serve/src/lib/data-query/factory.ts
@@ -1,0 +1,10 @@
+import {
+  DataQueryBuilder,
+  IDataQueryBuilder,
+} from './builder/dataQueryBuilder';
+
+export const dataQuery = (sqlStatement: string): IDataQueryBuilder => {
+  return new DataQueryBuilder({
+    statement: sqlStatement,
+  });
+};

--- a/packages/serve/src/lib/data-query/index.ts
+++ b/packages/serve/src/lib/data-query/index.ts
@@ -1,0 +1,2 @@
+export * from './builder';
+export * from './factory';

--- a/packages/serve/src/lib/route/route-component/baseRoute.ts
+++ b/packages/serve/src/lib/route/route-component/baseRoute.ts
@@ -2,7 +2,7 @@ import { Next as KoaNext } from 'koa';
 import { RouterContext as KoaRouterContext } from 'koa-router';
 import { IRequestTransformer, RequestParameters } from './requestTransformer';
 import { IRequestValidator } from './requestValidator';
-import { APISchema } from '@vulcan/core';
+import { APISchema, TemplateEngine } from '@vulcan/core';
 export { KoaRouterContext, KoaNext };
 
 interface IRoute {
@@ -13,19 +13,23 @@ export abstract class BaseRoute implements IRoute {
   public readonly apiSchema: APISchema;
   private readonly reqTransformer: IRequestTransformer;
   private readonly reqValidator: IRequestValidator;
+  private readonly templateEngine: TemplateEngine;
 
   constructor({
     apiSchema,
     reqTransformer,
     reqValidator,
+    templateEngine,
   }: {
     apiSchema: APISchema;
     reqTransformer: IRequestTransformer;
     reqValidator: IRequestValidator;
+    templateEngine: TemplateEngine;
   }) {
     this.apiSchema = apiSchema;
     this.reqTransformer = reqTransformer;
     this.reqValidator = reqValidator;
+    this.templateEngine = templateEngine;
   }
 
   public async respond(ctx: KoaRouterContext) {
@@ -38,4 +42,14 @@ export abstract class BaseRoute implements IRoute {
     ctx: KoaRouterContext,
     reqParams: RequestParameters
   ): Promise<any>;
+
+  protected async runQuery(reqParams: RequestParameters) {
+    // could template name or template path, use for template engine
+    const { templateSource } = this.apiSchema;
+    const statement = await this.templateEngine.render(
+      templateSource,
+      reqParams
+    );
+    return statement;
+  }
 }

--- a/packages/serve/src/lib/route/route-component/graphQLRoute.ts
+++ b/packages/serve/src/lib/route/route-component/graphQLRoute.ts
@@ -1,4 +1,4 @@
-import { APISchema } from '@vulcan/core';
+import { APISchema, TemplateEngine } from '@vulcan/core';
 import { IRequestTransformer, RequestParameters } from './requestTransformer';
 import { IRequestValidator } from './requestValidator';
 import { BaseRoute, KoaRouterContext } from './baseRoute';
@@ -10,12 +10,14 @@ export class GraphQLRoute extends BaseRoute {
     apiSchema,
     reqTransformer,
     reqValidator,
+    templateEngine,
   }: {
     apiSchema: APISchema;
     reqTransformer: IRequestTransformer;
     reqValidator: IRequestValidator;
+    templateEngine: TemplateEngine;
   }) {
-    super({ apiSchema, reqTransformer, reqValidator });
+    super({ apiSchema, reqTransformer, reqValidator, templateEngine });
 
     this.operationName = apiSchema.operationName;
   }

--- a/packages/serve/src/lib/route/route-component/restfulRoute.ts
+++ b/packages/serve/src/lib/route/route-component/restfulRoute.ts
@@ -1,4 +1,4 @@
-import { APISchema } from '@vulcan/core';
+import { APISchema, TemplateEngine } from '@vulcan/core';
 import { IRequestTransformer, RequestParameters } from './requestTransformer';
 import { IRequestValidator } from './requestValidator';
 import { BaseRoute, KoaRouterContext } from './baseRoute';
@@ -10,12 +10,14 @@ export class RestfulRoute extends BaseRoute {
     apiSchema,
     reqTransformer,
     reqValidator,
+    templateEngine,
   }: {
     apiSchema: APISchema;
     reqTransformer: IRequestTransformer;
     reqValidator: IRequestValidator;
+    templateEngine: TemplateEngine;
   }) {
-    super({ apiSchema, reqTransformer, reqValidator });
+    super({ apiSchema, reqTransformer, reqValidator, templateEngine });
 
     this.urlPath = apiSchema.urlPath;
   }

--- a/packages/serve/src/lib/route/routeGenerator.ts
+++ b/packages/serve/src/lib/route/routeGenerator.ts
@@ -1,4 +1,4 @@
-import { APISchema } from '@vulcan/core';
+import { APISchema, TemplateEngine } from '@vulcan/core';
 
 import {
   RestfulRoute,
@@ -21,6 +21,7 @@ type APIRouteBuilderOption = {
 export class RouteGenerator {
   private reqValidator: IRequestValidator;
   private reqTransformer: IRequestTransformer;
+  private templateEngine: TemplateEngine;
   private apiOptions: APIRouteBuilderOption = {
     [APIProviderType.RESTFUL]: RestfulRoute,
     [APIProviderType.GRAPHQL]: GraphQLRoute,
@@ -29,12 +30,15 @@ export class RouteGenerator {
   constructor({
     reqValidator,
     reqTransformer,
+    templateEngine,
   }: {
     reqValidator: IRequestValidator;
     reqTransformer: IRequestTransformer;
+    templateEngine: TemplateEngine;
   }) {
     this.reqValidator = reqValidator;
     this.reqTransformer = reqTransformer;
+    this.templateEngine = templateEngine;
   }
 
   public async generate(apiSchema: APISchema, optionType: APIProviderType) {
@@ -45,6 +49,7 @@ export class RouteGenerator {
       apiSchema,
       reqTransformer: this.reqTransformer,
       reqValidator: this.reqValidator,
+      templateEngine: this.templateEngine,
     });
   }
 

--- a/packages/serve/test/app.spec.ts
+++ b/packages/serve/test/app.spec.ts
@@ -9,6 +9,7 @@ import {
   FieldDataType,
   FieldInType,
   RequestSchema,
+  TemplateEngine,
   ValidatorDefinition,
 } from '@vulcan/core';
 
@@ -23,7 +24,7 @@ import {
 
 describe('Test vulcan server to call restful APIs', () => {
   let server: VulcanServer;
-
+  let stubTemplateEngine: sinon.StubbedInstance<TemplateEngine>;
   const fakeSchemas: Array<APISchema> = [
     {
       ...sinon.stubInterface<APISchema>(),
@@ -174,10 +175,12 @@ describe('Test vulcan server to call restful APIs', () => {
   beforeAll(async () => {
     const reqTransformer = new RequestTransformer();
     const reqValidator = new RequestValidator();
+    stubTemplateEngine = sinon.stubInterface<TemplateEngine>();
 
     const generator = new RouteGenerator({
       reqTransformer,
       reqValidator,
+      templateEngine: stubTemplateEngine,
     });
     const routes = await generator.multiGenerate(
       fakeSchemas,

--- a/packages/serve/test/data-query/builder/group-by-clause.spec.ts
+++ b/packages/serve/test/data-query/builder/group-by-clause.spec.ts
@@ -1,0 +1,50 @@
+import { GroupByClauseOperations, DataQueryBuilder } from '@data-query/.';
+import faker from '@faker-js/faker';
+
+describe('Test data query builder > group by clause', () => {
+  it.each([
+    {
+      columns: [faker.database.column()],
+    },
+    {
+      columns: [faker.database.column(), faker.database.column()],
+    },
+  ])(
+    'Should record successfully when call group by with $columns',
+    async ({ columns }) => {
+      // Arrange
+      const expected: GroupByClauseOperations = columns;
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      columns.map((column) => {
+        builder = builder.groupBy(column);
+      });
+
+      // Assert
+      expect(builder.operations.groupBy).toEqual(expected);
+    }
+  );
+
+  it.each([
+    [faker.database.column(), faker.database.column(), faker.database.column()],
+    [faker.database.column(), faker.database.column(), faker.database.column()],
+  ])(
+    'Should record successfully when call group by with %p, %p, %p',
+    async (first: string, second: string, third: string) => {
+      // Arrange
+      const expected: GroupByClauseOperations = [first, second, third];
+
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      builder.groupBy(first, second, third);
+
+      // Assert
+      expect(builder.operations.groupBy).toEqual(expected);
+    }
+  );
+});

--- a/packages/serve/test/data-query/builder/having-clause.spec.ts
+++ b/packages/serve/test/data-query/builder/having-clause.spec.ts
@@ -1,0 +1,866 @@
+import faker from '@faker-js/faker';
+import {
+  DataQueryBuilder,
+  WhereClauseOperation,
+  LogicalOperator,
+  ComparisonPredicate,
+  AliasDataQueryBuilder,
+  SelectedColumn,
+  AggregateFuncType,
+  HavingClauseOperation,
+  HavingPredicateInput,
+} from '@data-query/.';
+
+const normalized = (column: string | SelectedColumn) => {
+  if (typeof column === 'string') return { name: column };
+  return column as SelectedColumn;
+};
+
+describe('Test data query builder > having clause', () => {
+  it.each([
+    {
+      having: {
+        column: faker.database.column(),
+        operator: '!=',
+        value: faker.datatype.boolean(),
+      },
+      and: {
+        column: faker.database.column(),
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select * from products' }),
+      },
+    },
+    {
+      having: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.AVG,
+        } as SelectedColumn,
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select avg(*) from users' }),
+      },
+      and: {
+        column: faker.database.column(),
+        operator: '>=',
+        value: faker.random.word(),
+      },
+    },
+    {
+      having: {
+        column: faker.database.column(),
+        operator: '=',
+        value: faker.random.word(),
+      },
+      and: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+        } as SelectedColumn,
+        operator: '>=',
+        value: faker.datatype.number({ max: 1000 }),
+      },
+    },
+  ])(
+    'Should record successfully when call having(...).andHaving(...)',
+    async ({ having, and }) => {
+      // Arrange
+
+      const expected: Array<HavingClauseOperation> = [
+        {
+          command: null,
+          data: {
+            column: normalized(having.column),
+            operator: having.operator,
+            value: having.value,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.AND },
+        {
+          command: null,
+          data: {
+            column: normalized(and.column),
+            operator: and.operator,
+            value: and.value,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (having) builder.having(having.column, having.operator, having.value);
+      if (and) builder.andHaving(and.column, and.operator, and.value);
+
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      having: {
+        column: faker.database.column(),
+        operator: '!=',
+        value: faker.datatype.boolean(),
+      },
+      or: {
+        column: faker.database.column(),
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select * from products' }),
+      },
+    },
+    {
+      having: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.AVG,
+        } as SelectedColumn,
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select avg(*) from users' }),
+      },
+      or: {
+        column: faker.database.column(),
+        operator: '>=',
+        value: faker.random.word(),
+      },
+    },
+    {
+      having: {
+        column: faker.database.column(),
+        operator: '=',
+        value: faker.random.word(),
+      },
+      or: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+        } as SelectedColumn,
+        operator: '>=',
+        value: faker.datatype.number({ max: 1000 }),
+      },
+    },
+  ])(
+    'Should record successfully when call having(...).orHaving(...)',
+    async ({ having, or }) => {
+      // Arrange
+
+      const expected: Array<HavingClauseOperation> = [
+        {
+          command: null,
+          data: {
+            column: normalized(having.column),
+            operator: having.operator,
+            value: having.value,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.OR },
+        {
+          command: null,
+          data: {
+            column: normalized(or.column),
+            operator: or.operator,
+            value: or.value,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (having) builder.having(having.column, having.operator, having.value);
+      if (or) builder.orHaving(or.column, or.operator, or.value);
+
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      havingIn: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+        ]),
+      },
+      and: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.SUM,
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      andNot: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+        ]),
+      },
+    },
+    {
+      havingIn: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      and: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      andNot: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.AVG,
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+        ]),
+      },
+    },
+  ])(
+    'Should record successfully when call havingIn(...).andHavingIn(...).andHavingNotIn(...)',
+    async ({ havingIn, and, andNot }) => {
+      // Arrange
+      const expected: Array<HavingClauseOperation> = [
+        {
+          command: ComparisonPredicate.IN,
+          data: {
+            column: normalized(havingIn.column),
+            values: havingIn.values,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.AND },
+        {
+          command: ComparisonPredicate.IN,
+          data: {
+            column: normalized(and.column),
+            values: and.values,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.IN,
+          data: {
+            column: normalized(andNot.column),
+            values: andNot.values,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (havingIn) builder.havingIn(havingIn.column, havingIn.values);
+      if (and) builder.andHavingIn(and.column, and.values);
+      if (andNot) builder.andHavingNotIn(andNot.column, andNot.values);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notIn: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+        ]),
+      },
+      or: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.SUM,
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      orNot: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+        ]),
+      },
+    },
+    {
+      notIn: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      or: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      orNot: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.AVG,
+        } as SelectedColumn,
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+        ]),
+      },
+    },
+  ])(
+    'Should record successfully when call havingNotIn(...).orHavingIn(...).orHavingNotIn(...)',
+    async ({ notIn, or, orNot }) => {
+      // Arrange
+      const expected: Array<HavingClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.IN,
+          data: {
+            column: normalized(notIn.column),
+            values: notIn.values,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.OR },
+        {
+          command: ComparisonPredicate.IN,
+          data: {
+            column: normalized(or.column),
+            values: or.values,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.IN,
+          data: {
+            column: normalized(orNot.column),
+            values: orNot.values,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notIn) builder.havingNotIn(notIn.column, notIn.values);
+      if (or) builder.orHavingIn(or.column, or.values);
+      if (orNot) builder.orHavingNotIn(orNot.column, orNot.values);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      between: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.MIN,
+        } as SelectedColumn,
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      and: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      andNot: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+    {
+      between: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      and: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.SUM,
+        } as SelectedColumn,
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      andNot: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.AVG,
+        } as SelectedColumn,
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+  ])(
+    'Should record successfully when call havingBetween(...).andHavingBetween(...).andHavingNotBetween(...)',
+    async ({ between, and, andNot }) => {
+      // Arrange
+      const expected: Array<HavingClauseOperation> = [
+        {
+          command: ComparisonPredicate.BETWEEN,
+          data: {
+            column: normalized(between.column),
+            min: between.min,
+            max: between.max,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.AND },
+        {
+          command: ComparisonPredicate.BETWEEN,
+          data: {
+            column: normalized(and.column),
+            min: and.min,
+            max: and.max,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.BETWEEN,
+          data: {
+            column: normalized(andNot.column),
+            min: andNot.min,
+            max: andNot.max,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (between)
+        builder.havingBetween(between.column, between.min, between.max);
+      if (and) builder.andHavingBetween(and.column, and.min, and.max);
+      if (andNot)
+        builder.andHavingNotBetween(andNot.column, andNot.min, andNot.max);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notBetween: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.MIN,
+        } as SelectedColumn,
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      or: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      orNot: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+    {
+      notBetween: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      or: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.SUM,
+        } as SelectedColumn,
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      orNot: {
+        column: {
+          name: faker.database.column(),
+          as: faker.random.word(),
+          aggregateType: AggregateFuncType.AVG,
+        } as SelectedColumn,
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+  ])(
+    'Should record successfully when call havingNotBetween(...).orHavingBetween(...).orHavingNotBetween(...)',
+    async ({ notBetween, or, orNot }) => {
+      // Arrange
+      const expected: Array<HavingClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.BETWEEN,
+          data: {
+            column: normalized(notBetween.column),
+            min: notBetween.min,
+            max: notBetween.max,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.OR },
+        {
+          command: ComparisonPredicate.BETWEEN,
+          data: {
+            column: normalized(or.column),
+            min: or.min,
+            max: or.max,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.BETWEEN,
+          data: {
+            column: normalized(orNot.column),
+            min: orNot.min,
+            max: orNot.max,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notBetween)
+        builder.havingNotBetween(
+          notBetween.column,
+          notBetween.min,
+          notBetween.max
+        );
+      if (or) builder.orHavingBetween(or.column, or.min, or.max);
+      if (orNot) builder.orHavingNotBetween(orNot.column, orNot.min, orNot.max);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      isNull: {
+        column: faker.database.column(),
+      },
+      and: {
+        column: faker.database.column(),
+      },
+      andNot: {
+        column: faker.database.column(),
+      },
+    },
+    {
+      isNull: {
+        column: faker.database.column(),
+      },
+      and: {
+        column: faker.database.column(),
+      },
+      andNot: {
+        column: faker.database.column(),
+      },
+    },
+  ])(
+    'Should record successfully when call havingNull(...).andHavingNull(...).andHavingNotNull(...)',
+    async ({ isNull, and, andNot }) => {
+      // Arrange
+      const expected: Array<HavingClauseOperation> = [
+        {
+          command: ComparisonPredicate.IS_NULL,
+          data: {
+            column: isNull.column,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.AND },
+        {
+          command: ComparisonPredicate.IS_NULL,
+          data: {
+            column: and.column,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.IS_NULL,
+          data: {
+            column: andNot.column,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (isNull) builder.havingNull(isNull.column);
+      if (and) builder.andHavingNull(and.column);
+      if (andNot) builder.andHavingNotNull(andNot.column);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notNull: {
+        column: faker.database.column(),
+      },
+      or: {
+        column: faker.database.column(),
+      },
+      orNot: {
+        column: faker.database.column(),
+      },
+    },
+    {
+      notNull: {
+        column: faker.database.column(),
+      },
+      or: {
+        column: faker.database.column(),
+      },
+      orNot: {
+        column: faker.database.column(),
+      },
+    },
+  ])(
+    'Should record successfully when call havingNotNull(...).orHavingNull(...).orHavingNotNull(...)',
+    async ({ notNull, or, orNot }) => {
+      // Arrange
+      const expected: Array<HavingClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.IS_NULL,
+          data: {
+            column: notNull.column,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.OR },
+        {
+          command: ComparisonPredicate.IS_NULL,
+          data: {
+            column: or.column,
+          } as HavingPredicateInput,
+        },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        {
+          command: ComparisonPredicate.IS_NULL,
+          data: {
+            column: orNot.column,
+          } as HavingPredicateInput,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notNull) builder.havingNotNull(notNull.column);
+      if (or) builder.orHavingNull(or.column);
+      if (orNot) builder.orHavingNotNull(orNot.column);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      exists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+      and: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+      andNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+    {
+      exists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+      and: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+      andNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+  ])(
+    'Should record successfully when call havingExists(...).andHavingExists(...).andHavingNotExists(...)',
+    async ({ exists, and, andNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: ComparisonPredicate.EXISTS, data: exists },
+        { command: LogicalOperator.AND },
+        { command: ComparisonPredicate.EXISTS, data: and },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.EXISTS, data: andNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (exists) builder.havingExists(exists);
+      if (and) builder.andHavingExists(and);
+      if (andNot) builder.andHavingNotExists(andNot);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      exists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+      or: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+      orNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+    {
+      exists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+      or: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+      orNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+  ])(
+    'Should record successfully when call havingNotExists(...).orHavingExists(...).orHavingExists(...)',
+    async ({ exists, or, orNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.EXISTS, data: exists },
+        { command: LogicalOperator.OR },
+        { command: ComparisonPredicate.EXISTS, data: or },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.EXISTS, data: orNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (exists) builder.havingNotExists(exists);
+      if (or) builder.orHavingExists(or);
+      if (orNot) builder.orHavingNotExists(orNot);
+      // Asset
+      expect(builder.operations.having).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+});

--- a/packages/serve/test/data-query/builder/join-clause.spec.ts
+++ b/packages/serve/test/data-query/builder/join-clause.spec.ts
@@ -1,0 +1,131 @@
+import {
+  BetweenPredicateInput,
+  ComparisonPredicate,
+  DataQueryBuilder,
+  IDataQueryBuilder,
+  IJoinOnClause,
+  InPredicateInput,
+  JoinClauseOperation,
+  JoinCommandType,
+  JoinOnClauseOperation,
+  JoinOnOperatorInput,
+  LogicalOperator,
+  NullPredicateInput,
+} from '@data-query/.';
+
+describe('Test data query builder > join clause', () => {
+  const joinBuilder = new DataQueryBuilder({
+    statement: 'select * from products',
+  });
+  const alias = 'products';
+  const joinOnClauseOperations: Array<JoinOnClauseOperation> = [
+    {
+      command: null,
+      data: {
+        leftColumn: 'orders.product_id',
+        operator: '=',
+        rightColumn: 'products.id',
+      } as JoinOnOperatorInput,
+    },
+    { command: LogicalOperator.AND },
+    {
+      command: ComparisonPredicate.BETWEEN,
+      data: {
+        column: 'orders.price',
+        min: 1000,
+        max: 2000,
+      } as BetweenPredicateInput,
+    },
+    { command: LogicalOperator.AND },
+    { command: LogicalOperator.NOT },
+    {
+      command: ComparisonPredicate.IN,
+      data: {
+        column: 'orders.payment',
+        values: ['cash', 'e-pay'],
+      } as InPredicateInput,
+    },
+    { command: LogicalOperator.AND },
+    { command: LogicalOperator.NOT },
+    {
+      command: ComparisonPredicate.IS_NULL,
+      data: {
+        column: 'phone',
+      } as NullPredicateInput,
+    },
+  ];
+
+  it.each([
+    {
+      command: JoinCommandType.INNER_JOIN,
+    },
+    {
+      command: JoinCommandType.LEFT_JOIN,
+    },
+    {
+      command: JoinCommandType.RIGHT_JOIN,
+    },
+    {
+      command: JoinCommandType.FULL_JOIN,
+    },
+  ])(
+    'Should record successfully when call $command',
+    async ({ command }: { command: JoinCommandType }) => {
+      // Arrange
+      const statement = 'select * from orders';
+
+      const expected: JoinClauseOperation = {
+        command,
+        onClauses: joinOnClauseOperations,
+        joinBuilder: {
+          builder: joinBuilder,
+          as: alias,
+        },
+      };
+
+      const joinOnInput = joinOnClauseOperations[0].data as JoinOnOperatorInput;
+      const joinOnBetweenInput = joinOnClauseOperations[2]
+        .data as BetweenPredicateInput;
+      const joinOnNotInInput = joinOnClauseOperations[5]
+        .data as InPredicateInput;
+      const joinOnNotNullInput = joinOnClauseOperations[8]
+        .data as NullPredicateInput;
+      const joinParameters = {
+        joinBuilder: { builder: joinBuilder, as: alias },
+        clause: (clause: IJoinOnClause) => {
+          clause
+            .on(
+              joinOnInput.leftColumn,
+              joinOnInput.operator,
+              joinOnInput.rightColumn
+            )
+            .andOnBetween(
+              joinOnBetweenInput.column,
+              joinOnBetweenInput.min,
+              joinOnBetweenInput.max
+            )
+            .andOnNotIn(joinOnNotInInput.column, joinOnNotInInput.values)
+            .andOnNotNull(joinOnNotNullInput.column);
+        },
+      };
+
+      // Act
+      const queryBuilder = new DataQueryBuilder({
+        statement,
+      });
+      const joinCallMapper = {
+        [JoinCommandType.INNER_JOIN]: (builder: IDataQueryBuilder) =>
+          builder.innerJoin(joinParameters.joinBuilder, joinParameters.clause),
+        [JoinCommandType.LEFT_JOIN]: (builder: IDataQueryBuilder) =>
+          builder.leftJoin(joinParameters.joinBuilder, joinParameters.clause),
+        [JoinCommandType.RIGHT_JOIN]: (builder: IDataQueryBuilder) =>
+          builder.rightJoin(joinParameters.joinBuilder, joinParameters.clause),
+        [JoinCommandType.FULL_JOIN]: (builder: IDataQueryBuilder) =>
+          builder.fullJoin(joinParameters.joinBuilder, joinParameters.clause),
+      };
+      joinCallMapper[command](queryBuilder);
+      // Assert
+      expect(queryBuilder.operations.join[0]).toEqual(expected);
+    }
+  );
+});

--- a/packages/serve/test/data-query/builder/limit-offset-clause.spec.ts
+++ b/packages/serve/test/data-query/builder/limit-offset-clause.spec.ts
@@ -1,0 +1,125 @@
+import { DataQueryBuilder } from '@data-query/.';
+import faker from '@faker-js/faker';
+
+describe('Test data query builder > limit-offset by clause', () => {
+  it.each([
+    {
+      limit: faker.datatype.number({ max: 10 }),
+      offset: faker.datatype.number({ max: 1000 }),
+    },
+    {
+      limit: faker.datatype.number({ max: 10 }),
+      offset: faker.datatype.number({ max: 1000 }),
+    },
+  ])(
+    'Should record successfully when call limit($limit).offset($offset)',
+    async ({ limit, offset }) => {
+      // Arrange
+      const expected = {
+        limit,
+        offset,
+      };
+
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      builder.limit(limit).offset(offset);
+
+      // Assert
+      expect(builder.operations.limit).toEqual(expected.limit);
+      expect(builder.operations.offset).toEqual(expected.offset);
+    }
+  );
+
+  it.each([
+    {
+      first: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+      second: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+    },
+    {
+      first: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+      second: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+    },
+  ])(
+    'Should record successfully when call limit($first.limit).offset($first.offset).offset($second.offset).limit($second.limit)',
+    async ({ first, second }) => {
+      // Arrange
+      const expected = {
+        limit: second.limit,
+        offset: second.offset,
+      };
+
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      builder
+        .limit(first.limit)
+        .offset(first.offset)
+        .offset(second.offset)
+        .limit(second.limit);
+
+      // Assert
+      expect(builder.operations.limit).toEqual(expected.limit);
+      expect(builder.operations.offset).toEqual(expected.offset);
+    }
+  );
+
+  it.each([
+    {
+      first: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+      second: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+    },
+    {
+      first: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+      second: {
+        limit: faker.datatype.number({ max: 10 }),
+        offset: faker.datatype.number({ max: 1000 }),
+      },
+    },
+  ])(
+    'Should record successfully when call limit($first.limit).offset($first.offset).take($second.limit, $second.offset)',
+    async ({ first, second }) => {
+      // Arrange
+      const expected = {
+        limit: second.limit,
+        offset: second.offset,
+      };
+
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      builder
+        .limit(first.limit)
+        .offset(first.offset)
+        .take(second.limit, second.offset);
+
+      // Assert
+      expect(builder.operations.limit).toEqual(expected.limit);
+      expect(builder.operations.offset).toEqual(expected.offset);
+    }
+  );
+});

--- a/packages/serve/test/data-query/builder/order-by-clause.spec.ts
+++ b/packages/serve/test/data-query/builder/order-by-clause.spec.ts
@@ -1,0 +1,79 @@
+import {
+  DataQueryBuilder,
+  Direction,
+  OrderByClauseOperation,
+} from '@data-query/.';
+import faker from '@faker-js/faker';
+
+describe('Test data query builder > order by clause', () => {
+  it.each([
+    {
+      column: faker.database.column(),
+      direction: Direction.ASC,
+    },
+    {
+      column: faker.database.column(),
+      direction: Direction.DESC,
+    },
+  ])(
+    'Should record successfully when call order by with $column, $direction',
+    async ({ column, direction }) => {
+      // Arrange
+      const expected: Array<OrderByClauseOperation> = [
+        {
+          column,
+          direction,
+        },
+      ];
+
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      builder.orderBy(column, direction);
+
+      // Assert
+      expect(builder.operations.orderBy).toEqual(expected);
+    }
+  );
+
+  it.each([
+    [
+      {
+        column: faker.database.column(),
+        direction: Direction.DESC,
+      },
+      {
+        column: faker.database.column(),
+        direction: Direction.ASC,
+      },
+    ],
+    [
+      {
+        column: faker.database.column(),
+        direction: Direction.ASC,
+      },
+      {
+        column: faker.database.column(),
+        direction: Direction.DESC,
+      },
+    ],
+  ])(
+    'Should record successfully when call orderBy(%p).orderBy(%p)',
+    async (first, second) => {
+      // Arrange
+      const expected: Array<OrderByClauseOperation> = [first, second];
+
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      builder
+        .orderBy(first.column, first.direction)
+        .orderBy(second.column, second.direction);
+
+      // Assert
+      expect(builder.operations.orderBy).toEqual(expected);
+    }
+  );
+});

--- a/packages/serve/test/data-query/builder/select-clause.spec.ts
+++ b/packages/serve/test/data-query/builder/select-clause.spec.ts
@@ -1,0 +1,572 @@
+import faker from '@faker-js/faker';
+import {
+  AggregateFuncType,
+  AliasColumn,
+  DataQueryBuilder,
+  SelectClauseOperation,
+  SelectCommandType,
+  SelectedColumn,
+} from '@data-query/.';
+import { find, isEmpty } from 'lodash';
+
+// Use to generate select record expected results
+const generateSelectRecords = (
+  command: SelectCommandType,
+  columns: Array<string | SelectedColumn | undefined>
+) => {
+  // prepared used function for generating expected result
+  const normalized = (column: string | SelectedColumn) => {
+    if (typeof column === 'string') return { name: column };
+    return column as SelectedColumn;
+  };
+  const isSelectAllExist = (column: SelectedColumn) => column.name === '*';
+  const result: SelectClauseOperation = {
+    command,
+    columns: columns.reduce(
+      (operations, currColumn: string | SelectedColumn | undefined) => {
+        if (!currColumn || currColumn === '') currColumn = '*';
+        if (!(currColumn === '*' && find(operations, isSelectAllExist)))
+          operations.push(normalized(currColumn));
+        return operations;
+      },
+      [] as Array<SelectedColumn>
+    ),
+  };
+  return result;
+};
+
+describe('Test data query builder > select clause', () => {
+  it.each([
+    ['*', '*', '*'],
+    [undefined, '*', '*'],
+    [{ name: '*' }, '*'],
+    [{ name: '' }, '*'],
+    ['*', { name: '' }],
+    [{ name: '*' }, ''],
+    [`*`, undefined, ''],
+    ['', '', ''],
+    [undefined, undefined, undefined],
+    ['*', `${faker.database.column()}`, '*'],
+    ['*', `${faker.database.column()}`, undefined],
+    [undefined, `${faker.database.column()}`, '*'],
+    [`${faker.database.column()}`, `${faker.database.column()}`, undefined],
+    [`${faker.database.column()}`, '*', '*'],
+    [
+      `${faker.database.column()}`,
+      '*',
+      { name: faker.database.column(), as: 'alias' } as SelectedColumn,
+    ],
+    [
+      `${faker.database.column()}`,
+      '*',
+      {
+        name: faker.database.column(),
+        aggregateType: AggregateFuncType.COUNT,
+      } as SelectedColumn,
+    ],
+  ])(
+    'Should record successfully when call select %p, %p, %p',
+    async (...columns: Array<string | SelectedColumn | undefined>) => {
+      // Arrange
+      const statement = 'select * from table1';
+      const expected: SelectClauseOperation = generateSelectRecords(
+        SelectCommandType.SELECT,
+        columns
+      );
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+      columns.map((column) => {
+        builder = column ? builder.select(column) : builder.select();
+      });
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+    }
+  );
+
+  it.each([
+    {
+      select: ['*', faker.database.column()],
+      column: [faker.database.column()],
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      column: ['*'],
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      column: [],
+    },
+
+    {
+      select: [],
+      column: [faker.database.column()],
+    },
+
+    {
+      select: [
+        {
+          name: faker.database.column(),
+          aggregateType: AggregateFuncType.COUNT,
+        } as SelectedColumn,
+        '*',
+      ],
+      column: [
+        {
+          name: faker.database.column(),
+        } as SelectedColumn,
+        faker.database.column(),
+      ],
+    },
+  ])(
+    'Should record successfully when call select($select).column($column)',
+    async (fakeInputParam: {
+      select: Array<string | SelectedColumn>;
+      column: Array<string | SelectedColumn>;
+    }) => {
+      // Arrange
+      const { select, column } = fakeInputParam;
+      const statement = 'select * from table1';
+      const selectParam = isEmpty(select) ? ['*'] : select;
+      const columnParam = isEmpty(column) ? ['*'] : column;
+      const expected = generateSelectRecords(
+        SelectCommandType.SELECT,
+        selectParam.concat(columnParam)
+      );
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+
+      builder = !isEmpty(selectParam)
+        ? builder.select(...selectParam)
+        : builder.select();
+      builder = !isEmpty(columnParam)
+        ? builder.column(...columnParam)
+        : builder.column();
+
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+    }
+  );
+
+  it.each([
+    {
+      select: ['*', faker.database.column()],
+      first: [faker.database.column()],
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      first: ['*'],
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      first: [],
+    },
+
+    {
+      select: [],
+      first: [faker.database.column()],
+    },
+
+    {
+      select: [
+        {
+          name: faker.database.column(),
+          aggregateType: AggregateFuncType.COUNT,
+        } as SelectedColumn,
+        '*',
+      ],
+      first: [
+        {
+          name: faker.database.column(),
+        } as SelectedColumn,
+        faker.database.column(),
+      ],
+    },
+  ])(
+    'Should record successfully when call select($select).first($first)',
+    async (fakeInputParam: {
+      select: Array<string | SelectedColumn>;
+      first: Array<string | SelectedColumn>;
+    }) => {
+      // Arrange
+      const { select, first } = fakeInputParam;
+      const statement = 'select * from table1';
+      const selectParam = isEmpty(select) ? ['*'] : select;
+      const firstParam = isEmpty(first) ? ['*'] : first;
+      const expected = generateSelectRecords(
+        SelectCommandType.SELECT,
+        selectParam.concat(firstParam)
+      );
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+
+      builder = !isEmpty(selectParam)
+        ? builder.select(...selectParam)
+        : builder.select();
+      builder = !isEmpty(firstParam)
+        ? builder.first(...firstParam)
+        : builder.first();
+
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+      expect(builder.operations.limit).toEqual(1);
+    }
+  );
+
+  it.each([
+    {
+      select: ['*', faker.database.column()],
+      count: faker.database.column(),
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      count: '*',
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      count: undefined,
+    },
+
+    {
+      select: [],
+      count: faker.database.column(),
+    },
+
+    {
+      select: ['*'],
+      count: {
+        name: faker.database.column(),
+        as: 'alias',
+      } as AliasColumn,
+    },
+  ])(
+    'Should record successfully when call select($select).count($count)',
+    async (fakeInputParam: {
+      select: Array<string | SelectedColumn>;
+      count?: string | AliasColumn;
+    }) => {
+      // Arrange
+      const { select, count } = fakeInputParam;
+      const statement = 'select * from table1';
+      const selectParam = isEmpty(select) ? ['*'] : select;
+      const countParam: SelectedColumn = count
+        ? typeof count === 'string'
+          ? {
+              name: count,
+              aggregateType: AggregateFuncType.COUNT,
+            }
+          : {
+              ...(count as AliasColumn),
+              aggregateType: AggregateFuncType.COUNT,
+            }
+        : { name: '*', aggregateType: AggregateFuncType.COUNT };
+
+      const expected = generateSelectRecords(
+        SelectCommandType.SELECT,
+        selectParam.concat(countParam)
+      );
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+
+      builder = !isEmpty(selectParam)
+        ? builder.select(...selectParam)
+        : builder.select();
+      builder = countParam ? builder.count(countParam) : builder.count();
+
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+    }
+  );
+
+  it.each([
+    {
+      select: ['*', faker.database.column()],
+      max: faker.database.column(),
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      max: '*',
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      max: '',
+    },
+
+    {
+      select: [],
+      max: faker.database.column(),
+    },
+
+    {
+      select: ['*'],
+      max: {
+        name: faker.database.column(),
+        as: 'alias',
+      } as AliasColumn,
+    },
+  ])(
+    'Should record successfully when call select($select).max($max)',
+    async (fakeInputParam: {
+      select: Array<string | SelectedColumn>;
+      max: string | AliasColumn;
+    }) => {
+      // Arrange
+      const { select, max } = fakeInputParam;
+      const statement = 'select * from table1';
+      const selectParam = isEmpty(select) ? ['*'] : select;
+      const maxParam: SelectedColumn = max
+        ? typeof max === 'string'
+          ? {
+              name: max,
+              aggregateType: AggregateFuncType.MAX,
+            }
+          : {
+              ...(max as AliasColumn),
+              aggregateType: AggregateFuncType.MAX,
+            }
+        : { name: '*', aggregateType: AggregateFuncType.MAX };
+
+      const expected = generateSelectRecords(
+        SelectCommandType.SELECT,
+        selectParam.concat(maxParam)
+      );
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+
+      builder = !isEmpty(selectParam)
+        ? builder.select(...selectParam)
+        : builder.select();
+      builder.max(maxParam);
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+    }
+  );
+
+  it.each([
+    {
+      select: ['*', faker.database.column()],
+      min: faker.database.column(),
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      min: '*',
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      min: '',
+    },
+
+    {
+      select: [],
+      min: faker.database.column(),
+    },
+
+    {
+      select: ['*'],
+      min: {
+        name: faker.database.column(),
+        as: 'alias',
+      } as AliasColumn,
+    },
+  ])(
+    'Should record successfully when call select($select).min($min)',
+    async (fakeInputParam: {
+      select: Array<string | SelectedColumn>;
+      min: string | AliasColumn;
+    }) => {
+      // Arrange
+      const { select, min } = fakeInputParam;
+      const statement = 'select * from table1';
+      const selectParam = isEmpty(select) ? ['*'] : select;
+      const minParam: SelectedColumn = min
+        ? typeof min === 'string'
+          ? {
+              name: min,
+              aggregateType: AggregateFuncType.MIN,
+            }
+          : {
+              ...(min as AliasColumn),
+              aggregateType: AggregateFuncType.MIN,
+            }
+        : { name: '*', aggregateType: AggregateFuncType.MIN };
+
+      const expected = generateSelectRecords(
+        SelectCommandType.SELECT,
+        selectParam.concat(minParam)
+      );
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+
+      builder = !isEmpty(selectParam)
+        ? builder.select(...selectParam)
+        : builder.select();
+      builder.min(minParam);
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+    }
+  );
+
+  it.each([
+    {
+      select: ['*', faker.database.column()],
+      avg: faker.database.column(),
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      avg: '*',
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      avg: '',
+    },
+
+    {
+      select: [],
+      avg: faker.database.column(),
+    },
+
+    {
+      select: ['*'],
+      avg: {
+        name: faker.database.column(),
+        as: 'alias',
+      } as AliasColumn,
+    },
+  ])(
+    'Should record successfully when call select($select).avg($avg)',
+    async (fakeInputParam: {
+      select: Array<string | SelectedColumn>;
+      avg: string | AliasColumn;
+    }) => {
+      // Arrange
+      const { select, avg } = fakeInputParam;
+      const statement = 'select * from table1';
+      const selectParam = isEmpty(select) ? ['*'] : select;
+      const avgParam: SelectedColumn = avg
+        ? typeof avg === 'string'
+          ? {
+              name: avg,
+              aggregateType: AggregateFuncType.AVG,
+            }
+          : {
+              ...(avg as AliasColumn),
+              aggregateType: AggregateFuncType.AVG,
+            }
+        : { name: '*', aggregateType: AggregateFuncType.AVG };
+
+      const expected = generateSelectRecords(
+        SelectCommandType.SELECT,
+        selectParam.concat(avgParam)
+      );
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+
+      builder = !isEmpty(selectParam)
+        ? builder.select(...selectParam)
+        : builder.select();
+      builder.avg(avgParam);
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+    }
+  );
+
+  it.each([
+    {
+      select: ['*', faker.database.column()],
+      sum: faker.database.column(),
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      sum: '*',
+    },
+
+    {
+      select: [faker.database.column(), faker.database.column()],
+      sum: '',
+    },
+
+    {
+      select: [],
+      sum: faker.database.column(),
+    },
+
+    {
+      select: ['*'],
+      sum: {
+        name: faker.database.column(),
+        as: 'alias',
+      } as AliasColumn,
+    },
+  ])(
+    'Should record successfully when call select($select).sum($sum)',
+    async (fakeInputParam: {
+      select: Array<string | SelectedColumn>;
+      sum: string | AliasColumn;
+    }) => {
+      // Arrange
+      const { select, sum } = fakeInputParam;
+      const statement = 'select * from table1';
+      const selectParam = isEmpty(select) ? ['*'] : select;
+      const sumParam: SelectedColumn = sum
+        ? typeof sum === 'string'
+          ? {
+              name: sum,
+              aggregateType: AggregateFuncType.SUM,
+            }
+          : {
+              ...(sum as AliasColumn),
+              aggregateType: AggregateFuncType.SUM,
+            }
+        : { name: '*', aggregateType: AggregateFuncType.SUM };
+
+      const expected = generateSelectRecords(
+        SelectCommandType.SELECT,
+        selectParam.concat(sumParam)
+      );
+
+      // Act
+      let builder = new DataQueryBuilder({
+        statement,
+      });
+
+      builder = !isEmpty(selectParam)
+        ? builder.select(...selectParam)
+        : builder.select();
+      builder.sum(sumParam);
+      // Assert
+      expect(builder.operations.select).toEqual(expected);
+    }
+  );
+});

--- a/packages/serve/test/data-query/builder/where-clause.spec.ts
+++ b/packages/serve/test/data-query/builder/where-clause.spec.ts
@@ -1,0 +1,891 @@
+import faker from '@faker-js/faker';
+import {
+  DataQueryBuilder,
+  WhereClauseOperation,
+  LogicalOperator,
+  ComparisonPredicate,
+  WherePredicate,
+  AliasDataQueryBuilder,
+  IDataQueryBuilder,
+} from '@data-query/.';
+
+describe('Test data query builder > where clause', () => {
+  it.each([
+    {
+      where: {
+        column: faker.database.column(),
+        operator: '!=',
+        value: faker.random.word(),
+      },
+      and: {
+        column: faker.database.column(),
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select * from products' }),
+      },
+      andNot: {
+        column: faker.database.column(),
+        operator: '>',
+        value: faker.datatype.number({ max: 100 }),
+      },
+    },
+    {
+      where: {
+        column: faker.database.column(),
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select avg(*) from users' }),
+      },
+      and: {
+        column: faker.database.column(),
+        operator: '>=',
+        value: faker.datatype.number({ precision: 0.01 }),
+      },
+      andNot: {
+        column: faker.database.column(),
+        operator: '<=',
+        value: faker.datatype.number({ max: 100 }),
+      },
+    },
+  ])(
+    'Should record successfully when call where(...).andWhere(...).andNotWhere(...)',
+    async ({ where, and, andNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: null, data: where },
+        { command: LogicalOperator.AND },
+        { command: null, data: and },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        { command: null, data: andNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (where) builder.where(where.column, where.operator, where.value);
+      if (and) builder.andWhere(and.column, and.operator, and.value);
+      if (andNot)
+        builder.andWhereNot(andNot.column, andNot.operator, andNot.value);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      whereNot: {
+        column: faker.database.column(),
+        operator: '!=',
+        value: faker.random.word(),
+      },
+      or: {
+        column: faker.database.column(),
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select * from products' }),
+      },
+      orNot: {
+        column: faker.database.column(),
+        operator: '>',
+        value: faker.datatype.number({ max: 100 }),
+      },
+    },
+    {
+      whereNot: {
+        column: faker.database.column(),
+        operator: '=',
+        value: new DataQueryBuilder({ statement: 'select avg(*) from users' }),
+      },
+      or: {
+        column: faker.database.column(),
+        operator: '>=',
+        value: faker.datatype.number({ precision: 0.01 }),
+      },
+      orNot: {
+        column: faker.database.column(),
+        operator: '<=',
+        value: faker.datatype.number({ max: 100 }),
+      },
+    },
+  ])(
+    'Should record successfully when call whereNot(...).orWhere(...).orWhereNot(...)',
+    async ({ whereNot, or, orNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        { command: null, data: whereNot },
+        { command: LogicalOperator.OR },
+        { command: null, data: or },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        { command: null, data: orNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (whereNot)
+        builder.whereNot(whereNot.column, whereNot.operator, whereNot.value);
+      if (or) builder.orWhere(or.column, or.operator, or.value);
+      if (orNot) builder.orWhereNot(orNot.column, orNot.operator, orNot.value);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      whereIn: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+        ]),
+      },
+      and: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      andNot: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+        ]),
+      },
+    },
+    {
+      whereIn: {
+        column: faker.database.column(),
+        values: new DataQueryBuilder({
+          statement: 'select type from products',
+        }),
+      },
+      and: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      andNot: {
+        column: faker.database.column(),
+        values: new DataQueryBuilder({ statement: 'select age from users' }),
+      },
+    },
+  ])(
+    'Should record successfully when call whereIn(...).andWhereIn(...).andWhereNotIn(...)',
+    async ({ whereIn, and, andNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: ComparisonPredicate.IN, data: whereIn },
+        { command: LogicalOperator.AND },
+        { command: ComparisonPredicate.IN, data: and },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.IN, data: andNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (whereIn) builder.whereIn(whereIn.column, whereIn.values);
+      if (and) builder.andWhereIn(and.column, and.values);
+      if (andNot) builder.andWhereNotIn(andNot.column, andNot.values);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notIn: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+          faker.datatype.number({ max: 100 }),
+        ]),
+      },
+      or: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      orNot: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+          faker.datatype.number({ precision: 0.01 }),
+        ]),
+      },
+    },
+    {
+      notIn: {
+        column: faker.database.column(),
+        values: new DataQueryBuilder({
+          statement: 'select type from products',
+        }),
+      },
+      or: {
+        column: faker.database.column(),
+        values: faker.helpers.arrayElements([
+          faker.random.word(),
+          faker.random.word(),
+          faker.random.word(),
+        ]),
+      },
+      orNot: {
+        column: faker.database.column(),
+        values: new DataQueryBuilder({ statement: 'select age from users' }),
+      },
+    },
+  ])(
+    'Should record successfully when call whereNotIn(...).orWhereIn(...).orWhereNotIn(...)',
+    async ({ notIn, or, orNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.IN, data: notIn },
+        { command: LogicalOperator.OR },
+        { command: ComparisonPredicate.IN, data: or },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.IN, data: orNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notIn) builder.whereNotIn(notIn.column, notIn.values);
+      if (or) builder.orWhereIn(or.column, or.values);
+      if (orNot) builder.orWhereNotIn(orNot.column, orNot.values);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      between: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      and: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      andNot: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+    {
+      between: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      and: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      andNot: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+  ])(
+    'Should record successfully when call whereBetween(...).andWhereBetween(...).andWhereNotBetween(...)',
+    async ({ between, and, andNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: ComparisonPredicate.BETWEEN, data: between },
+        { command: LogicalOperator.AND },
+        { command: ComparisonPredicate.BETWEEN, data: and },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.BETWEEN, data: andNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (between)
+        builder.whereBetween(between.column, between.min, between.max);
+      if (and) builder.andWhereBetween(and.column, and.min, and.max);
+      if (andNot)
+        builder.andWhereNotBetween(andNot.column, andNot.min, andNot.max);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notBetween: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      or: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      orNot: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+    {
+      notBetween: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      or: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+      orNot: {
+        column: faker.database.column(),
+        min: faker.datatype.number({ min: 0, max: 10 }),
+        max: faker.datatype.number({ min: 10, max: 100 }),
+      },
+    },
+  ])(
+    'Should record successfully when call whereNotBetween(...).orWhereBetween(...).orWhereNotBetween(...)',
+    async ({ notBetween, or, orNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.BETWEEN, data: notBetween },
+        { command: LogicalOperator.OR },
+        { command: ComparisonPredicate.BETWEEN, data: or },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.BETWEEN, data: orNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notBetween)
+        builder.whereNotBetween(
+          notBetween.column,
+          notBetween.min,
+          notBetween.max
+        );
+      if (or) builder.orWhereBetween(or.column, or.min, or.max);
+      if (orNot) builder.orWhereNotBetween(orNot.column, orNot.min, orNot.max);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      isNull: {
+        column: faker.database.column(),
+      },
+      and: {
+        column: faker.database.column(),
+      },
+      andNot: {
+        column: faker.database.column(),
+      },
+    },
+    {
+      isNull: {
+        column: faker.database.column(),
+      },
+      and: {
+        column: faker.database.column(),
+      },
+      andNot: {
+        column: faker.database.column(),
+      },
+    },
+  ])(
+    'Should record successfully when call whereNull(...).andWhereNull(...).andWhereNotNull(...)',
+    async ({ isNull, and, andNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: ComparisonPredicate.IS_NULL, data: isNull },
+        { command: LogicalOperator.AND },
+        { command: ComparisonPredicate.IS_NULL, data: and },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.IS_NULL, data: andNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (isNull) builder.whereNull(isNull.column);
+      if (and) builder.andWhereNull(and.column);
+      if (andNot) builder.andWhereNotNull(andNot.column);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notNull: {
+        column: faker.database.column(),
+      },
+      or: {
+        column: faker.database.column(),
+      },
+      orNot: {
+        column: faker.database.column(),
+      },
+    },
+    {
+      notNull: {
+        column: faker.database.column(),
+      },
+      or: {
+        column: faker.database.column(),
+      },
+      orNot: {
+        column: faker.database.column(),
+      },
+    },
+  ])(
+    'Should record successfully when call whereNotNull(...).orWhereNull(...).orWhereNotNull(...)',
+    async ({ notNull, or, orNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.IS_NULL, data: notNull },
+        { command: LogicalOperator.OR },
+        { command: ComparisonPredicate.IS_NULL, data: or },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.IS_NULL, data: orNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notNull) builder.whereNotNull(notNull.column);
+      if (or) builder.orWhereNull(or.column);
+      if (orNot) builder.orWhereNotNull(orNot.column);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      like: {
+        column: faker.database.column(),
+        searchValue: faker.random.word() + '%',
+      },
+      and: {
+        column: faker.database.column(),
+        searchValue: '%' + faker.random.word() + '%',
+      },
+    },
+    {
+      like: {
+        column: faker.database.column(),
+        searchValue: '%' + faker.random.word() + '%',
+      },
+      and: {
+        column: faker.database.column(),
+        searchValue: '%' + faker.random.word(),
+      },
+    },
+  ])(
+    'Should record successfully when call whereLike(...).andWhereLike(...)',
+    async ({ like, and }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: WherePredicate.LIKE, data: like },
+        { command: LogicalOperator.AND },
+        { command: WherePredicate.LIKE, data: and },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (like) builder.whereLike(like.column, like.searchValue);
+      if (and) builder.andWhereLike(and.column, and.searchValue);
+
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      like: {
+        column: faker.database.column(),
+        searchValue: faker.random.word() + '%',
+      },
+      or: {
+        column: faker.database.column(),
+        searchValue: '%' + faker.random.word() + '%',
+      },
+    },
+    {
+      like: {
+        column: faker.database.column(),
+        searchValue: '%' + faker.random.word() + '%',
+      },
+      or: {
+        column: faker.database.column(),
+        searchValue: '%' + faker.random.word(),
+      },
+    },
+  ])(
+    'Should record successfully when call whereLike(...).orWhereLike(...)',
+    async ({ like, or }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: WherePredicate.LIKE, data: like },
+        { command: LogicalOperator.OR },
+        { command: WherePredicate.LIKE, data: or },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (like) builder.whereLike(like.column, like.searchValue);
+      if (or) builder.orWhereLike(or.column, or.searchValue);
+
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      exists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+      and: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+      andNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+    {
+      exists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+
+      and: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+
+      andNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+  ])(
+    'Should record successfully when call whereExists(...).andWhereExists(...).andWhereNotExists(...)',
+    async ({ exists, and, andNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: ComparisonPredicate.EXISTS, data: exists },
+        { command: LogicalOperator.AND },
+        { command: ComparisonPredicate.EXISTS, data: and },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.EXISTS, data: andNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (exists) builder.whereExists(exists);
+      if (and) builder.andWhereExists(and);
+      if (andNot) builder.andWhereNotExists(andNot);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notExists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+      or: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+      orNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+    {
+      notExists: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from products',
+        }),
+        as: 'products',
+      } as AliasDataQueryBuilder,
+      or: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from users',
+        }),
+        as: 'users',
+      } as AliasDataQueryBuilder,
+      orNot: {
+        builder: new DataQueryBuilder({
+          statement: 'select * from orders',
+        }),
+        as: 'orders',
+      } as AliasDataQueryBuilder,
+    },
+  ])(
+    'Should record successfully when call whereNotExists(...).orWhereExists(...).orWhereNotExists(...)',
+    async ({ notExists, or, orNot }) => {
+      // Arrange
+      const expected: Array<WhereClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.EXISTS, data: notExists },
+        { command: LogicalOperator.OR },
+        { command: ComparisonPredicate.EXISTS, data: or },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        { command: ComparisonPredicate.EXISTS, data: orNot },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notExists) builder.whereNotExists(notExists);
+      if (or) builder.orWhereExists(or);
+      if (orNot) builder.orWhereNotExists(orNot);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      wrapped: (builder: IDataQueryBuilder) => {
+        builder.where('items', '>', 5).andWhereNull('expired');
+      },
+      and: (builder: IDataQueryBuilder) => {
+        builder
+          .whereIn('type', ['3C', 'cloth', 'book'])
+          .andWhereNotNull('expired');
+      },
+      andNot: (builder: IDataQueryBuilder) => {
+        builder
+          .whereBetween('price', 1000, 3000)
+          .andWhereLike('comments', '%refund%');
+      },
+    },
+    {
+      wrapped: (builder: IDataQueryBuilder) => {
+        builder
+          .whereNot(
+            'tags',
+            '>',
+            new DataQueryBuilder({ statement: 'select count(*) from tags' })
+          )
+          .orWhereNotBetween('price', 1, 1000);
+      },
+      and: (builder: IDataQueryBuilder) => {
+        builder
+          .whereIn('tags', ['disney', 'marvel', 'jump'])
+          .andWhereNotBetween('price', 1, 1000);
+      },
+      andNot: (builder: IDataQueryBuilder) => {
+        builder
+          .whereNotIn('type', ['3C', 'cloth', 'book'])
+          .orWhereLike('comments', '%face to face%');
+      },
+    },
+  ])(
+    'Should record successfully when call whereWrapped(...).andWhereWrapped(...).andWhereNotWrapped(...)',
+    async ({ wrapped, and, andNot }) => {
+      // Arrange
+      const wrappedBuilder = new DataQueryBuilder({ statement: '' });
+      wrapped(wrappedBuilder);
+      const andBuilder = new DataQueryBuilder({ statement: '' });
+      and(andBuilder);
+      const andNotBuilder = new DataQueryBuilder({ statement: '' });
+      andNot(andNotBuilder);
+
+      const expected: Array<WhereClauseOperation> = [
+        {
+          command: WherePredicate.WRAPPED,
+          data: wrappedBuilder.operations.where,
+        },
+        { command: LogicalOperator.AND },
+        { command: WherePredicate.WRAPPED, data: andBuilder.operations.where },
+        { command: LogicalOperator.AND },
+        { command: LogicalOperator.NOT },
+        {
+          command: WherePredicate.WRAPPED,
+          data: andNotBuilder.operations.where,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (wrapped) builder.whereWrapped(wrapped);
+      if (and) builder.andWhereWrapped(and);
+      if (andNot) builder.andWhereNotWrapped(andNot);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+
+  it.each([
+    {
+      notWrapped: (builder: IDataQueryBuilder) => {
+        builder.where('items', '>', 5).andWhereNull('expired');
+      },
+      or: (builder: IDataQueryBuilder) => {
+        builder
+          .whereIn('type', ['3C', 'cloth', 'book'])
+          .andWhereNotNull('expired');
+      },
+      orNot: (builder: IDataQueryBuilder) => {
+        builder
+          .whereBetween('price', 1000, 3000)
+          .andWhereLike('comments', '%refund%');
+      },
+    },
+    {
+      notWrapped: (builder: IDataQueryBuilder) => {
+        builder
+          .whereNot(
+            'tags',
+            '>',
+            new DataQueryBuilder({ statement: 'select count(*) from tags' })
+          )
+          .orWhereNotBetween('price', 1, 1000);
+      },
+      or: (builder: IDataQueryBuilder) => {
+        builder
+          .whereIn('tags', ['disney', 'marvel', 'jump'])
+          .andWhereNotBetween('price', 1, 1000);
+      },
+      orNot: (builder: IDataQueryBuilder) => {
+        builder
+          .whereNotIn('type', ['3C', 'cloth', 'book'])
+          .orWhereLike('comments', '%face to face%');
+      },
+    },
+  ])(
+    'Should record successfully when call whereNotWrapped(...).orWhereWrapped(...).orWhereNotWrapped(...)',
+    async ({ notWrapped, or, orNot }) => {
+      // Arrange
+      const notWrappedBuilder = new DataQueryBuilder({ statement: '' });
+      notWrapped(notWrappedBuilder);
+      const orBuilder = new DataQueryBuilder({ statement: '' });
+      or(orBuilder);
+      const orNotBuilder = new DataQueryBuilder({ statement: '' });
+      orNot(orNotBuilder);
+
+      const expected: Array<WhereClauseOperation> = [
+        { command: LogicalOperator.NOT },
+        {
+          command: WherePredicate.WRAPPED,
+          data: notWrappedBuilder.operations.where,
+        },
+        { command: LogicalOperator.OR },
+        { command: WherePredicate.WRAPPED, data: orBuilder.operations.where },
+        { command: LogicalOperator.OR },
+        { command: LogicalOperator.NOT },
+        {
+          command: WherePredicate.WRAPPED,
+          data: orNotBuilder.operations.where,
+        },
+      ];
+      // Act
+      const builder = new DataQueryBuilder({
+        statement: 'select * from orders',
+      });
+      if (notWrapped) builder.whereNotWrapped(notWrapped);
+      if (or) builder.orWhereWrapped(or);
+      if (orNot) builder.orWhereNotWrapped(orNot);
+      // Asset
+      expect(builder.operations.where).toEqual(
+        expect.arrayContaining(expected)
+      );
+    }
+  );
+});

--- a/packages/serve/test/data-query/joinOnClause.spec.ts
+++ b/packages/serve/test/data-query/joinOnClause.spec.ts
@@ -1,0 +1,356 @@
+import faker from '@faker-js/faker';
+import {
+  JoinOnClause,
+  JoinOnClauseOperation,
+  JoinOnOperatorInput,
+  LogicalOperator,
+  BetweenPredicateInput,
+  ComparisonPredicate,
+  InPredicateInput,
+} from '@data-query/.';
+
+describe('Test join on clause > on operations', () => {
+  it.each([
+    [
+      `table1.${faker.database.column()}`,
+      '=',
+      `table2.${faker.database.column()}`,
+    ],
+    [
+      `table1.${faker.database.column()}`,
+      '>=',
+      `table2.${faker.database.column()}`,
+    ],
+    [
+      `table1.${faker.database.column()}`,
+      '>',
+      `table2.${faker.database.column()}`,
+    ],
+    [
+      `table1.${faker.database.column()}`,
+      '<=',
+      `table2.${faker.database.column()}`,
+    ],
+    [
+      `table1.${faker.database.column()}`,
+      '<',
+      `table2.${faker.database.column()}`,
+    ],
+    [
+      `table1.${faker.database.column()}`,
+      '!=',
+      `table2.${faker.database.column()}`,
+    ],
+  ])(
+    'Should record successfully when join on %p %p %p',
+    async (leftColumn: string, operator: string, rightColumn: string) => {
+      // Arrange
+      const expected: Array<JoinOnClauseOperation> = [
+        {
+          command: null,
+          data: {
+            leftColumn,
+            operator,
+            rightColumn,
+          } as JoinOnOperatorInput,
+        },
+      ];
+      // Act
+      const clause = new JoinOnClause();
+      clause.on(leftColumn, operator, rightColumn);
+      // Asset
+      expect(clause.operations).toEqual(expect.arrayContaining(expected));
+    }
+  );
+
+  it.each([
+    [
+      `table1.${faker.database.column()}`,
+      '<>',
+      `table2.${faker.database.column()}`,
+    ],
+    [
+      `table1.${faker.database.column()}`,
+      '!',
+      `table2.${faker.database.column()}`,
+    ],
+  ])(
+    'Should throw error when join on %p %p %p',
+    async (leftColumn: string, operator: string, rightColumn: string) => {
+      // Act
+      const clause = new JoinOnClause();
+      const callJoinOn = () => clause.on(leftColumn, operator, rightColumn);
+      // Asset
+      expect(callJoinOn).toThrow(Error);
+    }
+  );
+  it('Should record successfully when call join on(...).andOn(...).OrOn(...)', async () => {
+    // Arrange
+    const fakeInputParams = [
+      {
+        leftColumn: `table1.${faker.database.column()}`,
+        operator: '=',
+        rightColumn: `table2.${faker.database.column()}`,
+      },
+      {
+        leftColumn: `table3.${faker.database.column()}`,
+        operator: '>',
+        rightColumn: `table4.${faker.database.column()}`,
+      },
+      {
+        leftColumn: `table1.${faker.database.column()}`,
+        operator: '!=',
+        rightColumn: `table2.${faker.database.column()}`,
+      },
+    ];
+    const expected: Array<JoinOnClauseOperation> = fakeInputParams.map(
+      (params) => {
+        return {
+          command: null,
+          data: params as JoinOnOperatorInput,
+        };
+      }
+    );
+    // Act
+    const clause = new JoinOnClause();
+    clause
+      .on(
+        fakeInputParams[0].leftColumn,
+        fakeInputParams[0].operator,
+        fakeInputParams[0].rightColumn
+      )
+      .andOn(
+        fakeInputParams[1].leftColumn,
+        fakeInputParams[1].operator,
+        fakeInputParams[1].rightColumn
+      )
+      .orOn(
+        fakeInputParams[2].leftColumn,
+        fakeInputParams[2].operator,
+        fakeInputParams[2].rightColumn
+      );
+    // Asset
+    expect(clause.operations).toEqual(expect.arrayContaining(expected));
+  });
+});
+
+describe('Test join on clause > between operations', () => {
+  const fakeInputParams = [
+    {
+      column: `${faker.database.column()}`,
+      min: 14,
+      max: 30,
+    },
+    {
+      column: `${faker.database.column()}`,
+      min: -15,
+      max: 20,
+    },
+    {
+      column: `${faker.database.column()}`,
+      min: 1,
+      max: 100,
+    },
+  ];
+  it('Should throw error when call join onBetween with max value smaller than min value', async () => {
+    // Arrange
+    const fakeInputParam = {
+      column: `${faker.database.column()}`,
+      min: 30,
+      max: 1,
+    };
+    // Act
+    const clause = new JoinOnClause();
+    const joinOnBetween = () =>
+      clause.onBetween(
+        fakeInputParam.column,
+        fakeInputParam.min,
+        fakeInputParam.max
+      );
+
+    // Asset
+    expect(joinOnBetween).toThrow(Error);
+  });
+  it('Should record successfully when call join onBetween(...).andBetween(...).OrBetween(...)', async () => {
+    // Arrange
+    const expected: Array<JoinOnClauseOperation> = fakeInputParams.map(
+      (params) => {
+        return {
+          command: ComparisonPredicate.BETWEEN,
+          data: params as BetweenPredicateInput,
+        };
+      }
+    );
+    // Act
+    const clause = new JoinOnClause();
+    clause
+      .onBetween(
+        fakeInputParams[0].column,
+        fakeInputParams[0].min,
+        fakeInputParams[0].max
+      )
+      .andOnBetween(
+        fakeInputParams[1].column,
+        fakeInputParams[1].min,
+        fakeInputParams[1].max
+      )
+      .orOnBetween(
+        fakeInputParams[2].column,
+        fakeInputParams[2].min,
+        fakeInputParams[2].max
+      );
+    // Asset
+    expect(clause.operations).toEqual(expect.arrayContaining(expected));
+  });
+
+  it('Should record successfully when call join onNotBetween(...).andNotBetween(...).OrNotBetween(...)', async () => {
+    // Arrange
+    const expected: Array<JoinOnClauseOperation> = fakeInputParams.reduce(
+      (operations, currentParams) => {
+        operations.push({ command: LogicalOperator.NOT });
+        operations.push({
+          command: ComparisonPredicate.BETWEEN,
+          data: currentParams,
+        });
+        return operations;
+      },
+      [] as Array<JoinOnClauseOperation>
+    );
+    // Act
+    const clause = new JoinOnClause();
+    clause
+      .onNotBetween(
+        fakeInputParams[0].column,
+        fakeInputParams[0].min,
+        fakeInputParams[0].max
+      )
+      .andOnNotBetween(
+        fakeInputParams[1].column,
+        fakeInputParams[1].min,
+        fakeInputParams[1].max
+      )
+      .orOnNotBetween(
+        fakeInputParams[2].column,
+        fakeInputParams[2].min,
+        fakeInputParams[2].max
+      );
+    // Asset
+    expect(clause.operations).toEqual(expect.arrayContaining(expected));
+  });
+});
+
+describe('Test join on clause > in operations', () => {
+  const fakeInputParams = [
+    {
+      column: `${faker.database.column()}`,
+      values: faker.helpers.arrayElements(['US', 'TW', 'JP', 'CN'], 3),
+    },
+    {
+      column: `${faker.database.column()}`,
+      values: faker.helpers.arrayElements(['US', 'TW', 'JP', 'CN'], 3),
+    },
+    {
+      column: `${faker.database.column()}`,
+      values: faker.helpers.arrayElements([1, 50, 30, 100, 120], 3),
+    },
+  ];
+  it('Should record successfully when call join onIn(...).andIn(...).OrIn(...)', async () => {
+    // Arrange
+    const expected: Array<JoinOnClauseOperation> = fakeInputParams.map(
+      (params) => {
+        return {
+          command: ComparisonPredicate.IN,
+          data: params as InPredicateInput,
+        };
+      }
+    );
+    // Act
+    const clause = new JoinOnClause();
+    clause
+      .onIn(fakeInputParams[0].column, fakeInputParams[0].values)
+      .andOnIn(fakeInputParams[1].column, fakeInputParams[1].values)
+      .orOnIn(fakeInputParams[2].column, fakeInputParams[2].values);
+    // Asset
+    expect(clause.operations).toEqual(expect.arrayContaining(expected));
+  });
+
+  it('Should record successfully when call join onNotIn(...).andNotIn(...).OrNotIn(...)', async () => {
+    // Arrange
+
+    const expected: Array<JoinOnClauseOperation> = fakeInputParams.reduce(
+      (operations, currentParams) => {
+        operations.push({ command: LogicalOperator.NOT });
+        operations.push({
+          command: ComparisonPredicate.IN,
+          data: currentParams,
+        });
+        return operations;
+      },
+      [] as Array<JoinOnClauseOperation>
+    );
+    // Act
+    const clause = new JoinOnClause();
+    clause
+      .onNotIn(fakeInputParams[0].column, fakeInputParams[0].values)
+      .andOnNotIn(fakeInputParams[1].column, fakeInputParams[1].values)
+      .orOnNotIn(fakeInputParams[2].column, fakeInputParams[2].values);
+    // Asset
+    expect(clause.operations).toEqual(expect.arrayContaining(expected));
+  });
+});
+
+describe('Test join on clause > null operations', () => {
+  const fakeInputParams = [
+    {
+      column: `${faker.database.column()}`,
+    },
+    {
+      column: `${faker.database.column()}`,
+    },
+    {
+      column: `${faker.database.column()}`,
+    },
+  ];
+  it('Should record successfully when call join onNull(...).andNull(...).OrNull(...)', async () => {
+    // Arrange
+    const expected: Array<JoinOnClauseOperation> = fakeInputParams.map(
+      (params) => {
+        return {
+          command: ComparisonPredicate.IS_NULL,
+          data: params as BetweenPredicateInput,
+        };
+      }
+    );
+    // Act
+    const clause = new JoinOnClause();
+    clause
+      .onNull(fakeInputParams[0].column)
+      .andOnNull(fakeInputParams[1].column)
+      .orOnNull(fakeInputParams[2].column);
+    // Asset
+    expect(clause.operations).toEqual(expect.arrayContaining(expected));
+  });
+
+  it('Should record successfully when call join onNotBetween(...).andNotBetween(...).OrNotBetween(...)', async () => {
+    // Arrange
+    const expected: Array<JoinOnClauseOperation> = fakeInputParams.reduce(
+      (operations, currentParams) => {
+        operations.push({ command: LogicalOperator.NOT });
+        operations.push({
+          command: ComparisonPredicate.IS_NULL,
+          data: currentParams,
+        });
+        return operations;
+      },
+      [] as Array<JoinOnClauseOperation>
+    );
+    // Act
+    const clause = new JoinOnClause();
+    clause
+      .onNotNull(fakeInputParams[0].column)
+      .andOnNotNull(fakeInputParams[1].column)
+      .orOnNotNull(fakeInputParams[2].column);
+    // Asset
+    expect(clause.operations).toEqual(expect.arrayContaining(expected));
+  });
+});

--- a/packages/serve/test/route/routeGenerator.spec.ts
+++ b/packages/serve/test/route/routeGenerator.spec.ts
@@ -1,6 +1,6 @@
 import faker from '@faker-js/faker';
 import * as sinon from 'ts-sinon';
-import { APISchema } from '@vulcan/core';
+import { APISchema, TemplateEngine } from '@vulcan/core';
 import {
   APIProviderType,
   GraphQLRoute,
@@ -13,6 +13,7 @@ import {
 describe('Test route generator ', () => {
   let stubReqTransformer: sinon.StubbedInstance<IRequestTransformer>;
   let stubReqValidator: sinon.StubbedInstance<IRequestValidator>;
+  let stubTemplateEngine: sinon.StubbedInstance<TemplateEngine>;
   const fakeSchemas: Array<APISchema> = Array(
     faker.datatype.number({ min: 2, max: 4 })
   ).fill(sinon.stubInterface<APISchema>());
@@ -20,6 +21,7 @@ describe('Test route generator ', () => {
   beforeEach(() => {
     stubReqTransformer = sinon.stubInterface<IRequestTransformer>();
     stubReqValidator = sinon.stubInterface<IRequestValidator>();
+    stubTemplateEngine = sinon.stubInterface<TemplateEngine>();
   });
 
   it.each(fakeSchemas)(
@@ -30,10 +32,12 @@ describe('Test route generator ', () => {
         apiSchema,
         reqTransformer: stubReqTransformer,
         reqValidator: stubReqValidator,
+        templateEngine: stubTemplateEngine,
       });
       const routeGenerator = new RouteGenerator({
         reqTransformer: stubReqTransformer,
         reqValidator: stubReqValidator,
+        templateEngine: stubTemplateEngine,
       });
 
       // Act
@@ -58,10 +62,12 @@ describe('Test route generator ', () => {
         apiSchema,
         reqTransformer: stubReqTransformer,
         reqValidator: stubReqValidator,
+        templateEngine: stubTemplateEngine,
       });
       const routeGenerator = new RouteGenerator({
         reqTransformer: stubReqTransformer,
         reqValidator: stubReqValidator,
+        templateEngine: stubTemplateEngine,
       });
 
       // Act

--- a/packages/serve/tsconfig.json
+++ b/packages/serve/tsconfig.json
@@ -13,6 +13,7 @@
       // specify vulcan/core package for link and make us could import by @vulcan/core
       "@vulcan/core": ["packages/core/src/index.ts"],
       "@route/*": ["packages/serve/src/lib/route/*"],
+      "@data-query/*": ["packages/serve/src/lib/data-query/*"],
       "@app": ["packages/serve/src/lib/app.ts"]
     }
   },

--- a/packages/serve/tsconfig.lib.json
+++ b/packages/serve/tsconfig.lib.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "types": []
   },
-  "include": ["**/*.ts", "../../types/*.d.ts"],
+  "include": ["**/*.ts", "../../types/*.d.ts", "src/lib/data-query/builder"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Description
This PR includes some components for two parts:

### Implementing  `DataQueryBuilder`
Support providing SQL clauses of select, join, where, group-by, having, order-by, limit, and offset functions, the detailed samples could see our [Notion - SQL Template to API - Data Query Methods](https://www.notion.so/canner/SQL-Template-to-API-Data-Query-Methods-d2a17d03f71746bfb129a67bdd6a7d27), below is an example:

```ts
orderBuilder
  .where('type', '=', '3C')
  .andWhereWrapped((builder: IDataQueryBuilder) => {
    builder
      .where('view', '>', 10000)
      .andWhere('share', '>', 5000)
      .orWhereBetween('price', 5000, 20000);
  })
  .orWhere('saved', '>', 30000)
  .value();
```

The data query builder will keep all SQL operations in JSON format and pass them to the data source driver for executing SQL 
```json
{
   "select":null,
   "where":[
      {
         "command":null,
         "data":{
            "column":"type",
            "operator":"=",
            "value":"3C"
         }
      },
      { "command":"AND" },
      {
         "command":"WRAPPED",
         "data":[
            {
               "command":null,
               "data":{
                  "column":"view",
                  "operator":">",
                  "value":10000
               }
            },
            { "command":"AND" },
            {
               "command":null,
               "data":{
                  "column":"share",
                  "operator":">",
                  "value":5000
               }
            },
            { "command":"OR" },
            {
               "command":"BETWEEN",
               "data":{
                  "column":"price",
                  "min":5000,
                  "max":20000
               }
            }
         ]
      },
      { "command":"OR" },
      {
         "command":null,
         "data":{
            "column":"saved",
            "operator":">",
            "value":30000
         }
      }
   ],
   "join":[],
   "groupBy":[],
   "having":[],
   "orderBy":[],
   "limit":null,
   "offset":null
}
```

###  Implementing `JoinOnClause` 
The `JoinOnClause` providing join-on syntax like `On(...)`, `OnBetween(...)`, `OnIn(....)`...and so on, the detailed samples could see **JOIN > On Clause** of  [Notion - SQL Template to API - Data Query Methods](https://www.notion.so/canner/SQL-Template-to-API-Data-Query-Methods-d2a17d03f71746bfb129a67bdd6a7d27) , below is an example:

```ts
orderBuilder
  .innerJoin(
    { builder: productBuilder, as: 'products' },
    (clause: IJoinOnClause) => {
      clause
        .on('order.product_id', '=', 'product.id')
        .andOnBetween('order.price', 1000, 2000)
        .andOnNotIn('order.payment', ['cash', 'e-pay'])
        .andOnNotNull('phone');
    }
  )
  .value();
```

The join on clause also keeps all operations in JSON format:
```json
{
   "select":null,
   "where":[],
   "join":[
      {
         "command":"INNER_JOIN",
         "onClauses":[
            {
               "command":null,
               "data":{
                  "leftColumn":"order.product_id",
                  "operator":"=",
                  "rightColumn":"product.id"
               }
            },
            { "command":"AND" },
            {
               "command":"BETWEEN",
               "data":{
                  "column":"order.price",
                  "min":1000,
                  "max":2000
               }
            },
            { "command":"AND" },
            { "command":"NOT" },
            {
               "command":"IN",
               "data":{
                  "column":"order.payment",
                  "values":[
                     "cash",
                     "e-pay"
                  ]
               }
            },
            { "command":"AND" },
            { "command":"NOT" },
            {
               "command":"IS_NULL",
               "data":{
                  "column":"phone"
               }
            }
         ],
         "joinBuilder": {
             "builder":[Object IDataQueryBuilder]
            "as":"products"
         }
      }
   ],
   "groupBy":[],
   "having":[],
   "orderBy":[],
   "limit":null,
   "offset":null
}
```

## How To Test / Expected Results
For the test result, please see the below test cases that passed of the unit test:

<img width="804" alt="image" src="https://user-images.githubusercontent.com/5389253/172760504-81c32843-48fa-4ccd-b4eb-29212efb50e2.png">


## Commit Message
- https://github.com/Canner/vulcan/pull/11/commits/184e2aa272c3f0bde3a7e11c2046200df632253a - feat(serve): add data query builder and test cases.
    - add `DataQueryBuilder` to provide select, join, where, group, having, order, limit, offset by query chain
    - add `JoinOnClause` to provide join-on methods
    - add test cases of `DataQueryBuilder` providing select, join, where, group, having, order, limit, and offset clauses.
    - add test cases of `JoinOnClause`  providing on clauses.
    - refactor `BaseRoute` for passing template engine and use template engine.
    - fix test cases of `RouteGenerator` and `VulcanApplication`.

