### PR TITLE
Feature: Provide Validator Loader to load built-in and user-defined path validators

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,21 +1,3 @@
-// import built-in validators
-import builtInValidatorClasses from './lib/validators';
-import IValidator from './lib/validators/validator';
-
-// TODO: Import user-defined validators dynamically in specific directory
-
-// defined all validators and change to key-value object format for export
-const loadedValidators: { [name: string]: IValidator } = Object.assign(
-  {},
-  ...builtInValidatorClasses.map((validatorClass) => {
-    const validator = new validatorClass();
-    return {
-      [validator.name as string]: validator,
-    };
-  })
-);
-
-// export all other non-default objects of validators module
 export * from './lib/validators';
 // Export all other modules
 export * from './models';
@@ -23,5 +5,3 @@ export * from './lib/utils';
 export * from './lib/validators/validator';
 export * from './lib/template-engine';
 export * from './lib/artifact-builder';
-
-export { loadedValidators, IValidator };

--- a/packages/core/src/lib/validators/data-type-validators/dateTypeValidator.ts
+++ b/packages/core/src/lib/validators/data-type-validators/dateTypeValidator.ts
@@ -13,7 +13,7 @@ export interface DateInputArgs {
   format?: string;
 }
 
-export class DateTypeValidator implements IValidator {
+export default class DateTypeValidator implements IValidator {
   public readonly name = 'date';
   // Validator for arguments schema in schema.yaml, should match DateInputArgs
   private argsValidator = Joi.object({

--- a/packages/core/src/lib/validators/data-type-validators/index.ts
+++ b/packages/core/src/lib/validators/data-type-validators/index.ts
@@ -1,4 +1,0 @@
-export * from './integerTypeValidator';
-export * from './stringTypeValidator';
-export * from './dateTypeValidator';
-export * from './uuidTypeValidator';

--- a/packages/core/src/lib/validators/data-type-validators/integerTypeValidator.ts
+++ b/packages/core/src/lib/validators/data-type-validators/integerTypeValidator.ts
@@ -13,7 +13,7 @@ export interface IntInputArgs {
   less?: number;
 }
 
-export class IntegerTypeValidator implements IValidator {
+export default class IntegerTypeValidator implements IValidator {
   public readonly name = 'integer';
   // Validator for arguments schema in schema.yaml, should match IntInputArgs
   private argsValidator = Joi.object({

--- a/packages/core/src/lib/validators/data-type-validators/stringTypeValidator.ts
+++ b/packages/core/src/lib/validators/data-type-validators/stringTypeValidator.ts
@@ -13,7 +13,7 @@ export interface StringInputArgs {
   max?: number;
 }
 
-export class StringTypeValidator implements IValidator {
+export default class StringTypeValidator implements IValidator {
   public readonly name = 'string';
   // Validator for arguments schema in schema.yaml, should match StringInputArgs
   private argsValidator = Joi.object({

--- a/packages/core/src/lib/validators/data-type-validators/uuidTypeValidator.ts
+++ b/packages/core/src/lib/validators/data-type-validators/uuidTypeValidator.ts
@@ -10,7 +10,7 @@ export interface UUIDInputArgs {
   version?: UUIDVersion;
 }
 
-export class UUIDTypeValidator implements IValidator {
+export default class UUIDTypeValidator implements IValidator {
   public readonly name = 'uuid';
   // Validator for arguments schema in schema.yaml, should match UUIDInputArgs
   private argsValidator = Joi.object({

--- a/packages/core/src/lib/validators/index.ts
+++ b/packages/core/src/lib/validators/index.ts
@@ -1,18 +1,21 @@
-// Data Type Validators
-import { IntInputArgs, IntegerTypeValidator } from './data-type-validators';
-import { DateInputArgs, DateTypeValidator } from './data-type-validators';
-import { StringInputArgs, StringTypeValidator } from './data-type-validators';
-import { UUIDInputArgs, UUIDTypeValidator } from './data-type-validators';
+// export all other non-default objects of validators module
+export * from './data-type-validators/dateTypeValidator';
+export * from './data-type-validators/integerTypeValidator';
+export * from './data-type-validators/stringTypeValidator';
+export * from './data-type-validators/uuidTypeValidator';
+export * from './validatorLoader';
 
-// TODO: Other Built-in Validators
+// import default objects and export
+import IValidator from './validator';
+import DateTypeValidator from './data-type-validators/dateTypeValidator';
+import IntegerTypeValidator from './data-type-validators/integerTypeValidator';
+import StringTypeValidator from './data-type-validators/stringTypeValidator';
+import UUIDTypeValidator from './data-type-validators/uuidTypeValidator';
 
-// export all validators needed args interface
-export { IntInputArgs, DateInputArgs, StringInputArgs, UUIDInputArgs };
-
-// export default all validators of IValidator for use
-export default [
+export {
+  IValidator,
   DateTypeValidator,
   IntegerTypeValidator,
   StringTypeValidator,
   UUIDTypeValidator,
-];
+};

--- a/packages/core/src/lib/validators/validatorLoader.ts
+++ b/packages/core/src/lib/validators/validatorLoader.ts
@@ -1,0 +1,53 @@
+import IValidator from './validator';
+import * as glob from 'glob';
+import * as path from 'path';
+
+export interface IValidatorLoader {
+  load(validatorName: string): Promise<IValidator>;
+}
+
+export class ValidatorLoader implements IValidatorLoader {
+  // only found built-in validators in sub folders
+  private builtInFolderPath: string = path.resolve(__dirname, '*', '*.ts');
+  private userDefinedFolderPath?: string;
+
+  constructor(folderPath?: string) {
+    this.userDefinedFolderPath = folderPath;
+  }
+  public async load(validatorName: string) {
+    let validatorFiles = [
+      ...(await this.getValidatorFilePaths(this.builtInFolderPath)),
+    ];
+    if (this.userDefinedFolderPath) {
+      // include sub-folder or non sub-folders
+      const userDefinedValidatorFiles = await this.getValidatorFilePaths(
+        path.resolve(this.userDefinedFolderPath, '**', '*.ts')
+      );
+      validatorFiles = validatorFiles.concat(userDefinedValidatorFiles);
+    }
+
+    for (const file of validatorFiles) {
+      // import validator files to module
+      const validatorModule = await import(file);
+      // get validator class by getting default.
+      if (validatorModule && validatorModule.default) {
+        const validatorClass = validatorModule.default;
+        const validator = new validatorClass() as IValidator;
+        if (validator.name === validatorName) return validator;
+      }
+    }
+    // throw error if not found
+    throw new Error(
+      `The name "${validatorName}" of validator not defined in built-in validators and passed folder path, or the defined validator not export as default.`
+    );
+  }
+
+  private async getValidatorFilePaths(sourcePath: string): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+      glob(sourcePath, { nodir: true }, (err, files) => {
+        if (err) return reject(err);
+        else return resolve(files);
+      });
+    });
+  }
+}

--- a/packages/core/test/validators/data-type-validators/dataTypeValidator.spec.ts
+++ b/packages/core/test/validators/data-type-validators/dataTypeValidator.spec.ts
@@ -1,25 +1,19 @@
-import faker from '@faker-js/faker';
-import { StringTypeValidator } from '@validators/data-type-validators';
+import { DateTypeValidator } from '@validators/.';
 
-describe('Test "string" type validator', () => {
+describe('Test "date" type validator', () => {
   it.each([
     ['{}'],
-    ['{"format": "[a-z]"}'],
-    ['{"length": 10}'],
-    ['{"length": "10"}'],
-    ['{"min": 2}'],
-    ['{"max": 10}'],
-    ['{"format": "[A-Z]", "length": 10}'],
-    ['{"format": "[A-Z]", "min": "2"}'],
-    ['{"format": "[A-Z]", "max": 10}'],
+    ['{"format": "123"}'],
+    ['{"format": "DD/MM/YYYY"}'],
+    ['{"format": "YYYY-MM-DD"}'],
   ])(
     'Should be valid when validate args schema %p',
     async (inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
       // Act
-      const validator = new StringTypeValidator();
-
+      const validator = new DateTypeValidator();
+      const result = validator.validateSchema(args);
       // Assert
       expect(() => validator.validateSchema(args)).not.toThrow();
     }
@@ -27,17 +21,16 @@ describe('Test "string" type validator', () => {
 
   it.each([
     ['[]'],
-    ['{"non-key": 1}'],
-    ['{"key1": 1}'],
-    ['{"key2": 2}'],
-    ['{"key3": "value3"}'],
+    ['{"non-key": "non-value"}'],
+    ['{"key1": "value1"}'],
+    ['{"key2": "value2"}'],
   ])(
     'Should be invalid when validate args schema %p',
     async (inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
       // Act
-      const validator = new StringTypeValidator();
+      const validator = new DateTypeValidator();
 
       // Assert
       expect(() => validator.validateSchema(args)).toThrow();
@@ -45,34 +38,38 @@ describe('Test "string" type validator', () => {
   );
 
   it.each([
-    [faker.datatype.string(), '{}'],
-    ['abc', '{"format": "[a-z]"}'],
-    ['a123456789', '{"length": 10}'],
-    ['ABCDEFGHIJ', '{"format": "[A-Z]", "length": 10}'],
+    ['2022', '{"format": "YYYY"}'],
+    ['202210', '{"format": "YYYYMM"}'],
+    ['10/10/2021', '{"format": "DD/MM/YYYY"}'],
+    ['2021-10-10', '{"format": "YYYY-MM-DD"}'],
+    ['2021 10 10', '{"format": "YYYY MM DD"}'],
+    ['24 12 2019 09:15:00', '{"format": "DD MM YYYY hh:mm:ss"}'],
   ])(
     'Should be valid when validate data %p with args is %p',
     async (data: string, inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
+
       // Act
-      const validator = new StringTypeValidator();
+      const validator = new DateTypeValidator();
 
       // Assert
       expect(() => validator.validateData(data, args)).not.toThrow();
     }
   );
+
   it.each([
-    ['ABC', '{"format": "[a-z]"}'],
-    ['ab123456789', '{"length": "10"}'],
-    ['ABCDEFGHIJK', '{"format": "[A-Z]", "length": 10}'],
-    ['abcdefghijk', '{"format": "[A-Z]", "length": 10}'],
+    ['2021-10-10', '{"format": "DD/MM/YYYY"}'],
+    ['2021/10/10', '{"format": "YYYY-MM-DD"}'],
+    ['2021/10', '{"format": "YYYY-MM-DD"}'],
   ])(
     'Should be invalid when validate data %p with args is %p',
     async (data: string, inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
+
       // Act
-      const validator = new StringTypeValidator();
+      const validator = new DateTypeValidator();
 
       // Assert
       expect(() => validator.validateData(data, args)).toThrow();

--- a/packages/core/test/validators/data-type-validators/integerTypeValidator.spec.ts
+++ b/packages/core/test/validators/data-type-validators/integerTypeValidator.spec.ts
@@ -1,4 +1,4 @@
-import { IntegerTypeValidator } from '@validators/data-type-validators';
+import { IntegerTypeValidator } from '@validators/.';
 
 describe('Test "integer" type validator', () => {
   it.each([

--- a/packages/core/test/validators/data-type-validators/stringTypeValidator.spec.ts
+++ b/packages/core/test/validators/data-type-validators/stringTypeValidator.spec.ts
@@ -1,19 +1,25 @@
-import { DateTypeValidator } from '@validators/data-type-validators';
+import faker from '@faker-js/faker';
+import { StringTypeValidator } from '@validators/.';
 
-describe('Test "date" type validator', () => {
+describe('Test "string" type validator', () => {
   it.each([
     ['{}'],
-    ['{"format": "123"}'],
-    ['{"format": "DD/MM/YYYY"}'],
-    ['{"format": "YYYY-MM-DD"}'],
+    ['{"format": "[a-z]"}'],
+    ['{"length": 10}'],
+    ['{"length": "10"}'],
+    ['{"min": 2}'],
+    ['{"max": 10}'],
+    ['{"format": "[A-Z]", "length": 10}'],
+    ['{"format": "[A-Z]", "min": "2"}'],
+    ['{"format": "[A-Z]", "max": 10}'],
   ])(
     'Should be valid when validate args schema %p',
     async (inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
       // Act
-      const validator = new DateTypeValidator();
-      const result = validator.validateSchema(args);
+      const validator = new StringTypeValidator();
+
       // Assert
       expect(() => validator.validateSchema(args)).not.toThrow();
     }
@@ -21,16 +27,17 @@ describe('Test "date" type validator', () => {
 
   it.each([
     ['[]'],
-    ['{"non-key": "non-value"}'],
-    ['{"key1": "value1"}'],
-    ['{"key2": "value2"}'],
+    ['{"non-key": 1}'],
+    ['{"key1": 1}'],
+    ['{"key2": 2}'],
+    ['{"key3": "value3"}'],
   ])(
     'Should be invalid when validate args schema %p',
     async (inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
       // Act
-      const validator = new DateTypeValidator();
+      const validator = new StringTypeValidator();
 
       // Assert
       expect(() => validator.validateSchema(args)).toThrow();
@@ -38,38 +45,34 @@ describe('Test "date" type validator', () => {
   );
 
   it.each([
-    ['2022', '{"format": "YYYY"}'],
-    ['202210', '{"format": "YYYYMM"}'],
-    ['10/10/2021', '{"format": "DD/MM/YYYY"}'],
-    ['2021-10-10', '{"format": "YYYY-MM-DD"}'],
-    ['2021 10 10', '{"format": "YYYY MM DD"}'],
-    ['24 12 2019 09:15:00', '{"format": "DD MM YYYY hh:mm:ss"}'],
+    [faker.datatype.string(), '{}'],
+    ['abc', '{"format": "[a-z]"}'],
+    ['a123456789', '{"length": 10}'],
+    ['ABCDEFGHIJ', '{"format": "[A-Z]", "length": 10}'],
   ])(
     'Should be valid when validate data %p with args is %p',
     async (data: string, inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
-
       // Act
-      const validator = new DateTypeValidator();
+      const validator = new StringTypeValidator();
 
       // Assert
       expect(() => validator.validateData(data, args)).not.toThrow();
     }
   );
-
   it.each([
-    ['2021-10-10', '{"format": "DD/MM/YYYY"}'],
-    ['2021/10/10', '{"format": "YYYY-MM-DD"}'],
-    ['2021/10', '{"format": "YYYY-MM-DD"}'],
+    ['ABC', '{"format": "[a-z]"}'],
+    ['ab123456789', '{"length": "10"}'],
+    ['ABCDEFGHIJK', '{"format": "[A-Z]", "length": 10}'],
+    ['abcdefghijk', '{"format": "[A-Z]", "length": 10}'],
   ])(
     'Should be invalid when validate data %p with args is %p',
     async (data: string, inputArgs: string) => {
       // Arrange
       const args = JSON.parse(inputArgs);
-
       // Act
-      const validator = new DateTypeValidator();
+      const validator = new StringTypeValidator();
 
       // Assert
       expect(() => validator.validateData(data, args)).toThrow();

--- a/packages/core/test/validators/data-type-validators/uuidTypeValidator.spec.ts
+++ b/packages/core/test/validators/data-type-validators/uuidTypeValidator.spec.ts
@@ -1,5 +1,5 @@
 import * as uuid from 'uuid';
-import { UUIDTypeValidator } from '@validators/data-type-validators';
+import { UUIDTypeValidator } from '@validators/.';
 
 describe('Test "uuid" type validator ', () => {
   it.each([

--- a/packages/core/test/validators/test-custom-validators/ip-type-validator.ts
+++ b/packages/core/test/validators/test-custom-validators/ip-type-validator.ts
@@ -1,0 +1,44 @@
+import { IValidator } from '@validators/.';
+import * as Joi from 'joi';
+import { isUndefined } from 'lodash';
+
+type IPVersion = 'ipv4' | 'ipv6';
+
+export interface IPInputArgs {
+  version?: IPVersion[];
+}
+
+export default class IPTypeValidator implements IValidator {
+  public readonly name = 'ip';
+  // Validator for arguments schema in schema.yaml, should match DateInputArgs
+  private argsValidator = Joi.object({
+    version: Joi.string().optional(),
+  });
+  public validateSchema(args: IPInputArgs): boolean {
+    try {
+      // validate arguments schema
+      Joi.assert(args, this.argsValidator);
+      return true;
+    } catch {
+      throw new Error('The arguments schema for date type is incorrect');
+    }
+  }
+  public validateData(value: string, args: IPInputArgs): boolean {
+    let schema = Joi.string().ip();
+    // if there are args passed
+    if (!isUndefined(args)) {
+      schema = args.version
+        ? Joi.string().ip({
+            version: args.version,
+          })
+        : schema;
+    }
+    try {
+      // validate data value
+      Joi.assert(value, schema);
+      return true;
+    } catch {
+      throw new Error('The input parameter is invalid, it should be ip type');
+    }
+  }
+}

--- a/packages/core/test/validators/validatorLoader.spec.ts
+++ b/packages/core/test/validators/validatorLoader.spec.ts
@@ -1,0 +1,40 @@
+import { ValidatorLoader } from '@validators/.';
+import * as path from 'path';
+
+describe('Test validator loader ', () => {
+  it.each([
+    // built-in validator
+    { name: 'date', expected: 'date' },
+    { name: 'uuid', expected: 'uuid' },
+    { name: 'integer', expected: 'integer' },
+    { name: 'string', expected: 'string' },
+    // custom validator
+    { name: 'ip', expected: 'ip' },
+  ])(
+    'Should load successfully when loading validator name "$name".',
+    async ({ name, expected }) => {
+      // Arrange
+      const folderPath = path.resolve(__dirname, 'test-custom-validators');
+      const validatorLoader = new ValidatorLoader(folderPath);
+      // Act
+      const result = await validatorLoader.load(name);
+
+      // Assert
+      expect(result.name).toEqual(expected);
+    }
+  );
+
+  it.each([{ name: 'not-existed-validator' }])(
+    'Should load failed when loading validator name "$name".',
+    async ({ name }) => {
+      // Arrange
+      const folderPath = path.resolve(__dirname, 'test-custom-validators');
+      const validatorLoader = new ValidatorLoader(folderPath);
+      // Act
+      const loadAction = validatorLoader.load(name);
+
+      // Asset
+      await expect(loadAction).rejects.toThrow(Error);
+    }
+  );
+});

--- a/packages/serve/test/app.spec.ts
+++ b/packages/serve/test/app.spec.ts
@@ -11,6 +11,7 @@ import {
   RequestSchema,
   TemplateEngine,
   ValidatorDefinition,
+  ValidatorLoader,
 } from '@vulcan/core';
 
 import {
@@ -175,7 +176,7 @@ describe('Test vulcan server to call restful APIs', () => {
 
   beforeAll(async () => {
     const reqTransformer = new RequestTransformer();
-    const reqValidator = new RequestValidator();
+    const reqValidator = new RequestValidator(new ValidatorLoader());
     const paginationTransformer = new PaginationTransformer();
     stubTemplateEngine = sinon.stubInterface<TemplateEngine>();
 

--- a/packages/serve/test/route/route-component/requestValidator.spec.ts
+++ b/packages/serve/test/route/route-component/requestValidator.spec.ts
@@ -7,6 +7,7 @@ import {
   FieldInType,
   RequestSchema,
   ValidatorDefinition,
+  ValidatorLoader,
 } from '@vulcan/core';
 
 describe('Test request validator - validate successfully', () => {
@@ -141,7 +142,7 @@ describe('Test request validator - validate successfully', () => {
     'Should success when give matched request parameters and api schema',
     async (schema: APISchema, reqParams: RequestParameters) => {
       // Act
-      const validator = new RequestValidator();
+      const validator = new RequestValidator(new ValidatorLoader());
       const validateAction = validator.validate(reqParams, schema);
       const result = expect(validateAction).resolves;
       await result.not.toThrow();


### PR DESCRIPTION
## Description
This PR provides `ValidatorLoader`   to load the validator ( implementing `IValidator` ) according to the pass name, like below

```ts
const folderPath = "your user-defined custom validator folder";
const validatorName = 'uuid';
const validatorLoader = new ValidatorLoader(folderPath);
const validator = await validatorLoader.load(validatorName);

validator.validateSchema(...)
validator.validateData(...)
```

## How To Test / Expected Results
For the test result, please see the below test cases that passed the unit test:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/5389253/172820399-6842e4f6-5b8d-4ee4-86da-342a29fec67c.png">

## Commit Message
- https://github.com/Canner/vulcan/pull/14/commits/c1f2ca530ed473ac9d0bd217c54b71ab3de3dc00 - feat(core, serve): add validator loader to load validator according to name.
  - add `ValidatorLoader` to get the validator according to load validator by name.
  - refactor to export default for `DataTypeValidator`, `IntegerTypeValidator`, `UUIDTypeValidator`, `StringTypeValidator`.
  - refactor `RequestValidator` to validate data by using `ValidatorLoader`.
  - update related test cases in core and serve package.