### PR TITLE
Fix: Fix and enhance SQL injection prevention

### DIFF
--- a/labs/playground1/playground-exts/mockDb.js
+++ b/labs/playground1/playground-exts/mockDb.js
@@ -29,17 +29,7 @@ class MockDataSource extends DataSource {
     // handle parameterized query statement
     let query = statement;
 
-    const parameters =
-      // {$1: 'v1', $3: 'v3', $2: 'v2' }
-      _.chain(bindParams)
-        // [[$1, 'v1'], [$3, 'v3'], [$2, 'v2']]
-        .toPairs()
-        // [[$1, 'v1'], [$2, 'v2'], [$3, 'v3']]
-        .orderBy(([name,]) => Number(name.slice(1)))
-        // ['v1,'v2','v3']
-        .map(([_, value]) => value)
-        .value()
-
+    const parameters = Array.from(bindParams.values());
 
     return new Promise((resolve, reject) => {
       logger.info(query, parameters);
@@ -72,19 +62,7 @@ class MockDataSource extends DataSource {
   }
 
   async prepare(params) {
-    const identifiers = {};
-    const binds = {};
-    let index = 1;
-    for (const key of Object.keys(params)) {
-      const identifier = `$${index}`;
-      identifiers[key] = identifier;
-      binds[identifier] = params[key];
-      index += 1;
-    }
-    return {
-      identifiers,
-      binds,
-    };
+    return `$${params.parameterIndex}`
   }
 }
 

--- a/labs/playground1/sqls/artist/artist.yaml
+++ b/labs/playground1/sqls/artist/artist.yaml
@@ -5,3 +5,5 @@ request:
     description: constituent id
     validators:
       - required
+exampleParameter:
+  id: "1"

--- a/labs/playground1/sqls/artist/works.yaml
+++ b/labs/playground1/sqls/artist/works.yaml
@@ -5,3 +5,5 @@ request:
     description: constituent id
     validators:
       - required
+exampleParameter:
+  id: '1'

--- a/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
+++ b/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
@@ -12,15 +12,12 @@ import { unionBy } from 'lodash';
 
 export class ResponseSampler extends SchemaParserMiddleware {
   private templateEngine: TemplateEngine;
-  private dataSource: DataSource;
 
   constructor(
-    @inject(CORE_TYPES.TemplateEngine) templateEngine: TemplateEngine,
-    @inject(CORE_TYPES.DataSource) dataSource: DataSource
+    @inject(CORE_TYPES.TemplateEngine) templateEngine: TemplateEngine
   ) {
     super();
     this.templateEngine = templateEngine;
-    this.dataSource = dataSource;
   }
 
   public async handle(
@@ -31,11 +28,9 @@ export class ResponseSampler extends SchemaParserMiddleware {
     const schema = rawSchema as APISchema;
     if (!schema.exampleParameter) return;
 
-    const prepared = await this.dataSource.prepare(schema.exampleParameter);
-
     const response = await this.templateEngine.execute(
       schema.templateSource,
-      { ['_prepared']: prepared },
+      { context: { params: schema.exampleParameter } },
       // We only need the columns of this query, so we set offset/limit both to 0 here.
       {
         limit: 0,

--- a/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
+++ b/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
@@ -2,7 +2,6 @@ import { inject } from 'inversify';
 import { RawAPISchema, SchemaParserMiddleware } from './middleware';
 import {
   APISchema,
-  DataSource,
   FieldDataType,
   ResponseProperty,
   TemplateEngine,

--- a/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
+++ b/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
@@ -36,8 +36,7 @@ export class ResponseSampler extends SchemaParserMiddleware {
         offset: 0,
       }
     );
-    // TODO: I haven't known the response of queryBuilder.value(), assume that there is a "columns" property that indicates the columns' name and type here.
-    const columns: { name: string; type: string }[] = response.getColumns();
+    const columns = response.getColumns();
     const responseColumns = this.normalizeResponseColumns(columns);
     schema.response = this.mergeResponse(
       schema.response || [],

--- a/packages/build/test/schema-parser/middleware/responseSampler.spec.ts
+++ b/packages/build/test/schema-parser/middleware/responseSampler.spec.ts
@@ -1,6 +1,7 @@
 import { RawAPISchema } from '@vulcan-sql/build/schema-parser';
 import { ResponseSampler } from '@vulcan-sql/build/schema-parser/middleware/responseSampler';
 import { FieldDataType, TemplateEngine } from '@vulcan-sql/core';
+import { Stream } from 'stream';
 import * as sinon from 'ts-sinon';
 
 it('Should create response definition when example parameter is provided', async () => {
@@ -14,10 +15,11 @@ it('Should create response definition when example parameter is provided', async
   };
   const stubTemplateEngine = sinon.stubInterface<TemplateEngine>();
   stubTemplateEngine.execute.resolves({
-    columns: [
+    getColumns: () => [
       { name: 'id', type: 'string' },
       { name: 'age', type: 'number' },
     ],
+    getData: () => new Stream(),
   });
   const responseSampler = new ResponseSampler(stubTemplateEngine);
   // Act
@@ -38,10 +40,11 @@ it('Should create response definition when example parameter is a empty object',
   };
   const stubTemplateEngine = sinon.stubInterface<TemplateEngine>();
   stubTemplateEngine.execute.resolves({
-    columns: [
+    getColumns: () => [
       { name: 'id', type: 'string' },
       { name: 'age', type: 'number' },
     ],
+    getData: () => new Stream(),
   });
   const responseSampler = new ResponseSampler(stubTemplateEngine);
   // Act
@@ -61,10 +64,11 @@ it('Should not create response definition when example parameter is not provided
   };
   const stubTemplateEngine = sinon.stubInterface<TemplateEngine>();
   stubTemplateEngine.execute.resolves({
-    columns: [
+    getColumns: () => [
       { name: 'id', type: 'string' },
       { name: 'age', type: 'number' },
     ],
+    getData: () => new Stream(),
   });
   const responseSampler = new ResponseSampler(stubTemplateEngine);
   // Act
@@ -88,11 +92,12 @@ it('Should append response definition when there are some existed definitions', 
   };
   const stubTemplateEngine = sinon.stubInterface<TemplateEngine>();
   stubTemplateEngine.execute.resolves({
-    columns: [
+    getColumns: () => [
       { name: 'id', type: 'string' },
       { name: 'age', type: 'number' },
       { name: 'name', type: 'boolean' },
     ],
+    getData: () => new Stream(),
   });
   const responseSampler = new ResponseSampler(stubTemplateEngine);
   // Act

--- a/packages/core/src/lib/data-query/executor.ts
+++ b/packages/core/src/lib/data-query/executor.ts
@@ -8,6 +8,8 @@ export interface IExecutor {
     query: string,
     bindParams: BindParameters
   ): Promise<IDataQueryBuilder>;
+
+  getDataSource(): Promise<DataSource>;
 }
 
 @injectable()
@@ -16,6 +18,11 @@ export class QueryExecutor implements IExecutor {
   constructor(@inject(TYPES.DataSource) dataSource: DataSource) {
     this.dataSource = dataSource;
   }
+
+  public async getDataSource() {
+    return this.dataSource;
+  }
+
   /**
    * create data query builder
    * @returns

--- a/packages/core/src/lib/data-query/executor.ts
+++ b/packages/core/src/lib/data-query/executor.ts
@@ -1,7 +1,7 @@
 import {
   BindParameters,
   DataSource,
-  PrepareParameter,
+  PrepareParameterFunc,
   RequestParameter,
 } from '@vulcan-sql/core/models';
 import { inject, injectable } from 'inversify';
@@ -13,7 +13,7 @@ export interface IExecutor {
     query: string,
     bindParams: BindParameters
   ): Promise<IDataQueryBuilder>;
-  prepare: PrepareParameter;
+  prepare: PrepareParameterFunc;
 }
 
 @injectable()

--- a/packages/core/src/lib/data-query/executor.ts
+++ b/packages/core/src/lib/data-query/executor.ts
@@ -1,4 +1,9 @@
-import { BindParameters, DataSource } from '@vulcan-sql/core/models';
+import {
+  BindParameters,
+  DataSource,
+  PrepareParameter,
+  RequestParameter,
+} from '@vulcan-sql/core/models';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
 import { DataQueryBuilder, IDataQueryBuilder } from './builder';
@@ -8,8 +13,7 @@ export interface IExecutor {
     query: string,
     bindParams: BindParameters
   ): Promise<IDataQueryBuilder>;
-
-  getDataSource(): Promise<DataSource>;
+  prepare: PrepareParameter;
 }
 
 @injectable()
@@ -19,8 +23,8 @@ export class QueryExecutor implements IExecutor {
     this.dataSource = dataSource;
   }
 
-  public async getDataSource() {
-    return this.dataSource;
+  public async prepare(request: RequestParameter) {
+    return this.dataSource.prepare(request);
   }
 
   /**

--- a/packages/core/src/lib/data-source/pg.ts
+++ b/packages/core/src/lib/data-source/pg.ts
@@ -1,10 +1,8 @@
 import { Stream } from 'stream';
 import {
-  BindParameters,
   DataResult,
   DataSource,
   ExecuteOptions,
-  IdentifierParameters,
   RequestParameter,
   VulcanExtensionId,
   VulcanInternalExtension,

--- a/packages/core/src/lib/data-source/pg.ts
+++ b/packages/core/src/lib/data-source/pg.ts
@@ -5,7 +5,7 @@ import {
   DataSource,
   ExecuteOptions,
   IdentifierParameters,
-  RequestParameters,
+  RequestParameter,
   VulcanExtensionId,
   VulcanInternalExtension,
 } from '../../models/extensions';
@@ -24,19 +24,8 @@ export class PGDataSource extends DataSource {
       },
     };
   }
-  public async prepare(params: RequestParameters) {
-    const identifiers = {} as IdentifierParameters;
-    const binds = {} as BindParameters;
-    let index = 1;
-    for (const key of Object.keys(params)) {
-      const identifier = `$${index}`;
-      identifiers[key] = identifier;
-      binds[identifier] = params[key];
-      index += 1;
-    }
-    return {
-      identifiers,
-      binds,
-    };
+
+  public async prepare({ parameterIndex }: RequestParameter) {
+    return `$${parameterIndex}`;
   }
 }

--- a/packages/core/src/lib/template-engine/built-in-extensions/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/index.ts
@@ -4,3 +4,5 @@ import SqlHelper from './sql-helper';
 import Validator from './validator';
 
 export default [CustomError, QueryBuilder, SqlHelper, Validator];
+
+export * from './query-builder';

--- a/packages/core/src/lib/template-engine/built-in-extensions/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/index.ts
@@ -4,5 +4,3 @@ import SqlHelper from './sql-helper';
 import Validator from './validator';
 
 export default [CustomError, QueryBuilder, SqlHelper, Validator];
-
-export * from './query-builder';

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
@@ -5,3 +5,4 @@ export const EXECUTE_FILTER_NAME = 'execute';
 export const REFERENCE_SEARCH_MAX_DEPTH = 100;
 export const SANITIZER_NAME = 'sanitize';
 export const PARAMETERIZER_VAR_NAME = 'parameterizer';
+export const RAW_FILTER_NAME = 'raw';

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
@@ -3,6 +3,5 @@ export const METADATA_NAME = 'builder.vulcan.com';
 export const EXECUTE_COMMAND_NAME = 'value';
 export const EXECUTE_FILTER_NAME = 'execute';
 export const REFERENCE_SEARCH_MAX_DEPTH = 100;
-export const SANITIZE_SOURCES = ['context'];
 export const SANITIZER_NAME = 'sanitize';
 export const PARAMETERIZER_VAR_NAME = 'parameterizer';

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
@@ -3,3 +3,6 @@ export const METADATA_NAME = 'builder.vulcan.com';
 export const EXECUTE_COMMAND_NAME = 'value';
 export const EXECUTE_FILTER_NAME = 'execute';
 export const REFERENCE_SEARCH_MAX_DEPTH = 100;
+export const SANITIZE_SOURCES = ['context'];
+export const SANITIZER_NAME = 'sanitize';
+export const PARAMETERIZER_VAR_NAME = 'parameterizer';

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/executorRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/executorRunner.ts
@@ -1,12 +1,18 @@
 import { IDataQueryBuilder } from '@vulcan-sql/core/data-query';
-import { FilterRunner, VulcanInternalExtension } from '@vulcan-sql/core/models';
+import {
+  FilterRunner,
+  FilterRunnerTransformOptions,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
 import { EXECUTE_FILTER_NAME } from './constants';
 
 @VulcanInternalExtension()
 export class ExecutorRunner extends FilterRunner {
   public filterName = EXECUTE_FILTER_NAME;
 
-  public async transform({ value }: { value: any; args: any[] }): Promise<any> {
+  public async transform({
+    value,
+  }: FilterRunnerTransformOptions): Promise<any> {
     const builder: IDataQueryBuilder = value;
     return builder.value();
   }

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
@@ -4,6 +4,8 @@ import { ExecutorRunner } from './executorRunner';
 import { ExecutorBuilder } from './executorBuilder';
 import { SanitizerBuilder } from './sanitizerBuilder';
 import { SanitizerRunner } from './sanitizerRunner';
+import { RawBuilder } from './rawBuilder';
+import { RawRunner } from './rawRunner';
 
 export default [
   ReqTagBuilder,
@@ -12,4 +14,6 @@ export default [
   ExecutorBuilder,
   SanitizerBuilder,
   SanitizerRunner,
+  RawBuilder,
+  RawRunner,
 ];

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
@@ -2,5 +2,16 @@ import { ReqTagBuilder } from './reqTagBuilder';
 import { ReqTagRunner } from './reqTagRunner';
 import { ExecutorRunner } from './executorRunner';
 import { ExecutorBuilder } from './executorBuilder';
+import { SanitizerBuilder } from './sanitizerBuilder';
+import { SanitizerRunner } from './sanitizerRunner';
 
-export default [ReqTagBuilder, ReqTagRunner, ExecutorRunner, ExecutorBuilder];
+export default [
+  ReqTagBuilder,
+  ReqTagRunner,
+  ExecutorRunner,
+  ExecutorBuilder,
+  SanitizerBuilder,
+  SanitizerRunner,
+];
+
+export * from './templateInput';

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
@@ -13,5 +13,3 @@ export default [
   SanitizerBuilder,
   SanitizerRunner,
 ];
-
-export * from './templateInput';

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
@@ -1,4 +1,4 @@
-import { DataSource } from '@vulcan-sql/core/models';
+import { PrepareParameter } from '@vulcan-sql/core/models';
 
 export class Parameterizer {
   private parameterIndex = 1;
@@ -8,10 +8,10 @@ export class Parameterizer {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#description
   private idToValueMapping = new Map<string, any>();
   private valueToIdMapping = new Map<any, string>();
-  private dataSource: DataSource;
+  private prepare: PrepareParameter;
 
-  constructor(dataSource: DataSource) {
-    this.dataSource = dataSource;
+  constructor(prepare: PrepareParameter) {
+    this.prepare = prepare;
   }
 
   public async generateIdentifier(value: any): Promise<string> {
@@ -21,7 +21,7 @@ export class Parameterizer {
       );
     if (this.valueToIdMapping.has(value))
       return this.valueToIdMapping.get(value)!;
-    const id = await this.dataSource.prepare({
+    const id = await this.prepare({
       parameterIndex: this.parameterIndex++,
       value,
     });

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
@@ -1,0 +1,40 @@
+import { DataSource } from '@vulcan-sql/core/models';
+
+export class Parameterizer {
+  private parameterIndex = 1;
+  private sealed = false;
+  // We MUST not use pure object here because we care about the order of the keys.
+  // https://stackoverflow.com/questions/5525795/does-javascript-guarantee-object-property-order
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#description
+  private idToValueMapping = new Map<string, any>();
+  private valueToIdMapping = new Map<any, string>();
+  private dataSource: DataSource;
+
+  constructor(dataSource: DataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public async generateIdentifier(value: any): Promise<string> {
+    if (this.sealed)
+      throw new Error(
+        `This parameterizer has been sealed, we might use the parameterizer from a wrong request scope.`
+      );
+    if (this.valueToIdMapping.has(value))
+      return this.valueToIdMapping.get(value)!;
+    const id = await this.dataSource.prepare({
+      parameterIndex: this.parameterIndex++,
+      value,
+    });
+    this.idToValueMapping.set(id, value);
+    this.valueToIdMapping.set(value, id);
+    return id;
+  }
+
+  public seal() {
+    this.sealed = true;
+  }
+
+  public getBinding() {
+    return this.idToValueMapping;
+  }
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
@@ -1,4 +1,4 @@
-import { PrepareParameter } from '@vulcan-sql/core/models';
+import { PrepareParameterFunc } from '@vulcan-sql/core/models';
 
 export class Parameterizer {
   private parameterIndex = 1;
@@ -8,9 +8,9 @@ export class Parameterizer {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#description
   private idToValueMapping = new Map<string, any>();
   private valueToIdMapping = new Map<any, string>();
-  private prepare: PrepareParameter;
+  private prepare: PrepareParameterFunc;
 
-  constructor(prepare: PrepareParameter) {
+  constructor(prepare: PrepareParameterFunc) {
     this.prepare = prepare;
   }
 

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/rawBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/rawBuilder.ts
@@ -1,0 +1,10 @@
+import {
+  FilterBuilder,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+import { RAW_FILTER_NAME } from './constants';
+
+@VulcanInternalExtension()
+export class RawBuilder extends FilterBuilder {
+  public filterName = RAW_FILTER_NAME;
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/rawRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/rawRunner.ts
@@ -1,0 +1,18 @@
+import {
+  FilterRunner,
+  FilterRunnerTransformOptions,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+import { RAW_FILTER_NAME } from './constants';
+
+@VulcanInternalExtension()
+export class RawRunner extends FilterRunner {
+  public filterName = RAW_FILTER_NAME;
+
+  public async transform({
+    value,
+  }: FilterRunnerTransformOptions): Promise<any> {
+    // Do nothing, this filer is only a place holder to block sanitizer
+    return value;
+  }
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
@@ -6,7 +6,8 @@ import {
   TagRunnerOptions,
   VulcanInternalExtension,
 } from '@vulcan-sql/core/models';
-import { FINIAL_BUILDER_NAME } from './constants';
+import { FINIAL_BUILDER_NAME, PARAMETERIZER_VAR_NAME } from './constants';
+import { Parameterizer } from './parameterizer';
 
 @VulcanInternalExtension()
 export class ReqTagRunner extends TagRunner {
@@ -24,16 +25,26 @@ export class ReqTagRunner extends TagRunner {
 
   public async run({ context, args, contentArgs }: TagRunnerOptions) {
     const name = args[0];
+
+    const dataSource = await this.executor.getDataSource();
+
+    const parameterizer = new Parameterizer(dataSource);
+    // parameterizer from parent, we should set it back after rendered our context.
+    const parentParameterizer = context.lookup(PARAMETERIZER_VAR_NAME);
+    context.setVariable(PARAMETERIZER_VAR_NAME, parameterizer);
     let query = '';
     for (let index = 0; index < contentArgs.length; index++) {
       query += await contentArgs[index]();
     }
+    // Seal current parameterizer to avoid incorrect usage.
+    parameterizer.seal();
+    context.setVariable(PARAMETERIZER_VAR_NAME, parentParameterizer);
     query = query
       .split(/\r?\n/)
       .filter((line) => line.trim().length > 0)
       .join('\n');
     // Get bind real parameters and pass to data query builder for data source used.
-    const binds = (context.ctx || {})['_paramBinds'] || {};
+    const binds = parameterizer.getBinding();
     const builder = await this.executor.createBuilder(query, binds);
     context.setVariable(name, builder);
 

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
@@ -24,7 +24,7 @@ export class ReqTagRunner extends TagRunner {
   }
 
   public async run({ context, args, contentArgs }: TagRunnerOptions) {
-    const name = args[0];
+    const name = String(args[0]);
 
     const parameterizer = new Parameterizer(
       this.executor.prepare.bind(this.executor)

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
@@ -26,9 +26,9 @@ export class ReqTagRunner extends TagRunner {
   public async run({ context, args, contentArgs }: TagRunnerOptions) {
     const name = args[0];
 
-    const dataSource = await this.executor.getDataSource();
-
-    const parameterizer = new Parameterizer(dataSource);
+    const parameterizer = new Parameterizer(
+      this.executor.prepare.bind(this.executor)
+    );
     // parameterizer from parent, we should set it back after rendered our context.
     const parentParameterizer = context.lookup(PARAMETERIZER_VAR_NAME);
     context.setVariable(PARAMETERIZER_VAR_NAME, parameterizer);

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
@@ -6,6 +6,10 @@ import * as nunjucks from 'nunjucks';
 import { visitChildren } from '../../extension-utils';
 import { RAW_FILTER_NAME, SANITIZER_NAME } from './constants';
 
+/**
+ * Add a sanitizer filter after all "lookup" like nodes, e.g. LookupVal, FunctionCall ...etc. In order to do sql injection prevention.
+ * {{ context.params.id }} -> {{ context.params.id | sanitizer }}
+ */
 @VulcanInternalExtension()
 export class SanitizerBuilder extends FilterBuilder {
   public filterName = SANITIZER_NAME;

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
@@ -15,11 +15,7 @@ export class SanitizerBuilder extends FilterBuilder {
 
   private addSanitizer(node: nunjucks.nodes.Node, parentHasOutputNode = false) {
     visitChildren(node, (child, replace) => {
-      if (
-        child instanceof nunjucks.nodes.LookupVal ||
-        child instanceof nunjucks.nodes.FunCall ||
-        child instanceof nunjucks.nodes.Symbol
-      ) {
+      if (this.isNodeNeedToBeSanitize(child)) {
         if (!parentHasOutputNode && !(node instanceof nunjucks.nodes.Output))
           return;
         const filter = new nunjucks.nodes.Filter(node.lineno, node.colno);
@@ -40,5 +36,13 @@ export class SanitizerBuilder extends FilterBuilder {
         );
       }
     });
+  }
+
+  private isNodeNeedToBeSanitize(node: nunjucks.nodes.Node): boolean {
+    return (
+      node instanceof nunjucks.nodes.LookupVal ||
+      node instanceof nunjucks.nodes.FunCall ||
+      node instanceof nunjucks.nodes.Symbol
+    );
   }
 }

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
@@ -1,0 +1,48 @@
+import {
+  FilterBuilder,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+import * as nunjucks from 'nunjucks';
+import { visitChildren } from '../../extension-utils';
+import {
+  REFERENCE_SEARCH_MAX_DEPTH,
+  SANITIZER_NAME,
+  SANITIZE_SOURCES,
+} from './constants';
+
+@VulcanInternalExtension()
+export class SanitizerBuilder extends FilterBuilder {
+  public filterName = SANITIZER_NAME;
+  public override onVisit(node: nunjucks.nodes.Node): void {
+    if (node instanceof nunjucks.nodes.Root) this.addSanitizer(node);
+  }
+
+  private addSanitizer(node: nunjucks.nodes.Node, parentHasOutputNode = false) {
+    visitChildren(node, (child, replace) => {
+      if (
+        child instanceof nunjucks.nodes.LookupVal ||
+        child instanceof nunjucks.nodes.FunCall ||
+        child instanceof nunjucks.nodes.Symbol
+      ) {
+        if (!parentHasOutputNode && !(node instanceof nunjucks.nodes.Output))
+          return;
+        const filter = new nunjucks.nodes.Filter(node.lineno, node.colno);
+        filter.name = new nunjucks.nodes.Symbol(
+          node.lineno,
+          node.colno,
+          SANITIZER_NAME
+        );
+        const args = new nunjucks.nodes.NodeList(node.lineno, node.colno);
+        // The first argument is the target of the filter
+        args.addChild(child);
+        filter.args = args;
+        replace(filter);
+      } else {
+        this.addSanitizer(
+          child,
+          parentHasOutputNode || node instanceof nunjucks.nodes.Output
+        );
+      }
+    });
+  }
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerBuilder.ts
@@ -4,11 +4,7 @@ import {
 } from '@vulcan-sql/core/models';
 import * as nunjucks from 'nunjucks';
 import { visitChildren } from '../../extension-utils';
-import {
-  REFERENCE_SEARCH_MAX_DEPTH,
-  SANITIZER_NAME,
-  SANITIZE_SOURCES,
-} from './constants';
+import { SANITIZER_NAME } from './constants';
 
 @VulcanInternalExtension()
 export class SanitizerBuilder extends FilterBuilder {

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
@@ -4,6 +4,7 @@ import {
   VulcanInternalExtension,
 } from '@vulcan-sql/core/models';
 import { PARAMETERIZER_VAR_NAME, SANITIZER_NAME } from './constants';
+import { Parameterizer } from './parameterizer';
 import { TemplateInput } from './templateInput';
 
 @VulcanInternalExtension()
@@ -21,7 +22,7 @@ export class SanitizerRunner extends FilterRunner {
       input = new TemplateInput(value);
     }
     // Parameterizer should be set by req tag runner
-    const parameterizer = context.lookup(PARAMETERIZER_VAR_NAME);
+    const parameterizer = context.lookup<Parameterizer>(PARAMETERIZER_VAR_NAME);
     if (!parameterizer) throw new Error(`No parameterizer found`);
     return await input.parameterize(parameterizer);
   }

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
@@ -1,0 +1,28 @@
+import {
+  FilterRunner,
+  FilterRunnerTransformOptions,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+import { PARAMETERIZER_VAR_NAME, SANITIZER_NAME } from './constants';
+import { TemplateInput } from './templateInput';
+
+@VulcanInternalExtension()
+export class SanitizerRunner extends FilterRunner {
+  public filterName = SANITIZER_NAME;
+
+  public async transform({
+    value,
+    context,
+  }: FilterRunnerTransformOptions): Promise<any> {
+    let input: TemplateInput;
+    // Wrap the value to template input to parameterized
+    if (value instanceof TemplateInput) input = value;
+    else {
+      input = new TemplateInput(value);
+    }
+
+    const parameterizer = context.lookup(PARAMETERIZER_VAR_NAME);
+    if (!parameterizer) throw new Error(`No parameterizer found`);
+    return await input.parameterize(parameterizer);
+  }
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
@@ -20,7 +20,7 @@ export class SanitizerRunner extends FilterRunner {
     else {
       input = new TemplateInput(value);
     }
-
+    // Parameterizer should be set by req tag runner
     const parameterizer = context.lookup(PARAMETERIZER_VAR_NAME);
     if (!parameterizer) throw new Error(`No parameterizer found`);
     return await input.parameterize(parameterizer);

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/templateInput.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/templateInput.ts
@@ -1,0 +1,17 @@
+import { Parameterizer } from './parameterizer';
+
+export class TemplateInput {
+  private rawValue: any;
+
+  constructor(rawValue: any) {
+    this.rawValue = rawValue;
+  }
+
+  public raw() {
+    return this.rawValue;
+  }
+
+  public parameterize(parameterizer: Parameterizer) {
+    return parameterizer.generateIdentifier(this.rawValue);
+  }
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/uniqueFilterRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/uniqueFilterRunner.ts
@@ -1,4 +1,8 @@
-import { FilterRunner, VulcanInternalExtension } from '@vulcan-sql/core/models';
+import {
+  FilterRunner,
+  FilterRunnerTransformOptions,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
 import { uniq, uniqBy } from 'lodash';
 
 @VulcanInternalExtension()
@@ -7,10 +11,7 @@ export class UniqueFilterRunner extends FilterRunner {
   public async transform({
     value,
     args,
-  }: {
-    value: any[];
-    args: any[];
-  }): Promise<any> {
+  }: FilterRunnerTransformOptions): Promise<any> {
     if (args.length === 0) {
       return uniq(value);
     }

--- a/packages/core/src/lib/template-engine/compiler.ts
+++ b/packages/core/src/lib/template-engine/compiler.ts
@@ -1,3 +1,4 @@
+import { DataResult } from '@vulcan-sql/core/models';
 import { Pagination } from '../../models/pagination';
 
 export interface TemplateLocation {
@@ -32,5 +33,5 @@ export interface Compiler {
     templateName: string,
     data: T,
     pagination?: Pagination
-  ): Promise<any>;
+  ): Promise<DataResult>;
 }

--- a/packages/core/src/lib/template-engine/nunjucksCompiler.ts
+++ b/packages/core/src/lib/template-engine/nunjucksCompiler.ts
@@ -128,7 +128,10 @@ export class NunjucksCompiler implements Compiler {
     } else if (extension instanceof FilterRunner) {
       this.runtimeEnv.addFilter(
         extension.filterName,
-        extension.__transform.bind(extension),
+        function (this: any, value: any, ...args) {
+          // use classic function to receive context
+          extension.__transform(this, value, ...args);
+        },
         true
       );
     }

--- a/packages/core/src/lib/template-engine/templateEngine.ts
+++ b/packages/core/src/lib/template-engine/templateEngine.ts
@@ -4,10 +4,8 @@ import { TYPES } from '@vulcan-sql/core/types';
 import {
   CodeLoader,
   Pagination,
-  PreparedQueryParams,
   TemplateProvider,
 } from '@vulcan-sql/core/models';
-import { get, omit } from 'lodash';
 
 export type AllTemplateMetadata = Record<string, TemplateMetadata>;
 
@@ -66,17 +64,11 @@ export class TemplateEngine {
     data: T,
     pagination?: Pagination
   ): Promise<any> {
-    const others = omit(data, '_prepared');
-    const prepared: PreparedQueryParams | undefined = get(data, '_prepared');
     // wrap to context object
     return this.compiler.execute(
       templateName,
       {
-        context: {
-          ...others,
-          ['params']: prepared?.identifiers || {},
-        },
-        ['_paramBinds']: prepared?.binds || {},
+        context: data,
       },
       pagination
     );

--- a/packages/core/src/lib/template-engine/templateEngine.ts
+++ b/packages/core/src/lib/template-engine/templateEngine.ts
@@ -3,6 +3,7 @@ import { injectable, inject, optional } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
 import {
   CodeLoader,
+  DataResult,
   Pagination,
   TemplateProvider,
 } from '@vulcan-sql/core/models';
@@ -63,7 +64,7 @@ export class TemplateEngine {
     templateName: string,
     data: T,
     pagination?: Pagination
-  ): Promise<any> {
+  ): Promise<DataResult> {
     // wrap to context object
     return this.compiler.execute(
       templateName,

--- a/packages/core/src/lib/template-engine/templateEngine.ts
+++ b/packages/core/src/lib/template-engine/templateEngine.ts
@@ -66,12 +66,6 @@ export class TemplateEngine {
     pagination?: Pagination
   ): Promise<DataResult> {
     // wrap to context object
-    return this.compiler.execute(
-      templateName,
-      {
-        context: data,
-      },
-      pagination
-    );
+    return this.compiler.execute(templateName, data, pagination);
   }
 }

--- a/packages/core/src/models/extensions/dataSource.ts
+++ b/packages/core/src/models/extensions/dataSource.ts
@@ -15,11 +15,6 @@ export interface RequestParameter {
 
 export type BindParameters = Map<string, string>;
 
-export type IdentifierParameters = {
-  // the value is identifier
-  [paramName: string]: string;
-};
-
 export type DataColumn = { name: string; type: string };
 
 export interface DataResult {
@@ -35,7 +30,9 @@ export interface ExecuteOptions {
   pagination?: Pagination;
 }
 
-export type PrepareParameter = { (param: RequestParameter): Promise<string> };
+export type PrepareParameterFunc = {
+  (param: RequestParameter): Promise<string>;
+};
 
 @VulcanExtension(TYPES.Extension_DataSource, { enforcedId: true })
 export abstract class DataSource extends ExtensionBase {

--- a/packages/core/src/models/extensions/dataSource.ts
+++ b/packages/core/src/models/extensions/dataSource.ts
@@ -7,7 +7,9 @@ import { VulcanExtension } from './decorators';
 
 // Original request parameters
 export interface RequestParameter {
+  /** The index (starts from 1) of parameters, it's useful to generate parameter id like $1, $2 ...etc. */
   parameterIndex: number;
+  /** The raw value (not name) */
   value: any;
 }
 
@@ -28,9 +30,12 @@ export interface DataResult {
 export interface ExecuteOptions {
   statement: string;
   operations: SQLClauseOperation;
+  /** The parameter bindings, we guarantee the order of the keys in the map is the same as the order when they were used in queries. */
   bindParams: BindParameters;
   pagination?: Pagination;
 }
+
+export type PrepareParameter = { (param: RequestParameter): Promise<string> };
 
 @VulcanExtension(TYPES.Extension_DataSource, { enforcedId: true })
 export abstract class DataSource extends ExtensionBase {

--- a/packages/core/src/models/extensions/dataSource.ts
+++ b/packages/core/src/models/extensions/dataSource.ts
@@ -6,27 +6,17 @@ import { ExtensionBase } from './base';
 import { VulcanExtension } from './decorators';
 
 // Original request parameters
-export interface RequestParameters {
-  [name: string]: any;
+export interface RequestParameter {
+  parameterIndex: number;
+  value: any;
 }
 
-export type BindParameters = {
-  // the value is real param data
-  [identifier: string]: string;
-};
+export type BindParameters = Map<string, string>;
 
 export type IdentifierParameters = {
   // the value is identifier
   [paramName: string]: string;
 };
-
-// prepared query parameters for providing data source to prevent sql
-export interface PreparedQueryParams {
-  // e.g: params['members'] = '@members'
-  identifiers: IdentifierParameters;
-  // e.g: binds['@members'] = '17'
-  binds: BindParameters;
-}
 
 export type DataColumn = { name: string; type: string };
 
@@ -45,6 +35,6 @@ export interface ExecuteOptions {
 @VulcanExtension(TYPES.Extension_DataSource, { enforcedId: true })
 export abstract class DataSource extends ExtensionBase {
   abstract execute(options: ExecuteOptions): Promise<DataResult>;
-  // prepare parameterized format for query in the later
-  abstract prepare(params: RequestParameters): Promise<PreparedQueryParams>;
+  // prepare parameterized format for query later
+  abstract prepare(param: RequestParameter): Promise<string>;
 }

--- a/packages/core/src/models/extensions/filterRunner.ts
+++ b/packages/core/src/models/extensions/filterRunner.ts
@@ -2,23 +2,27 @@ import { TYPES } from '@vulcan-sql/core/types';
 import { VulcanExtension } from './decorators';
 import { RuntimeExtension } from './templateEngine';
 
+export interface FilterRunnerTransformOptions<V = any> {
+  value: V;
+  args: any;
+  context: any;
+}
+
 @VulcanExtension(TYPES.Extension_TemplateEngine)
 export abstract class FilterRunner<
   V = any,
   C = any
 > extends RuntimeExtension<C> {
   abstract filterName: string;
-  abstract transform(options: {
-    value: V;
-    args: Record<string, any>;
-  }): Promise<any>;
+  abstract transform(options: FilterRunnerTransformOptions<V>): Promise<any>;
 
-  public __transform(value: any, ...args: any[]) {
+  public __transform(context: any, value: any, ...args: any[]) {
     const callback = args[args.length - 1];
     const otherArgs = args.slice(0, args.length - 1);
     this.transform({
       value,
       args: otherArgs,
+      context,
     })
       .then((res) => callback(null, res))
       .catch((err) => callback(err, null));

--- a/packages/core/src/models/extensions/filterRunner.ts
+++ b/packages/core/src/models/extensions/filterRunner.ts
@@ -1,11 +1,12 @@
 import { TYPES } from '@vulcan-sql/core/types';
 import { VulcanExtension } from './decorators';
 import { RuntimeExtension } from './templateEngine';
+import { Context } from 'nunjucks';
 
 export interface FilterRunnerTransformOptions<V = any> {
   value: V;
   args: any;
-  context: any;
+  context: Context;
 }
 
 @VulcanExtension(TYPES.Extension_TemplateEngine)
@@ -16,7 +17,7 @@ export abstract class FilterRunner<
   abstract filterName: string;
   abstract transform(options: FilterRunnerTransformOptions<V>): Promise<any>;
 
-  public __transform(context: any, value: any, ...args: any[]) {
+  public __transform(context: Context, value: any, ...args: any[]) {
     const callback = args[args.length - 1];
     const otherArgs = args.slice(0, args.length - 1);
     this.transform({

--- a/packages/core/src/models/extensions/tagRunner.ts
+++ b/packages/core/src/models/extensions/tagRunner.ts
@@ -9,7 +9,7 @@ export type TagExtensionContentArgGetter = () => Promise<string>;
 export type TagExtensionArgTypes = string | number | boolean;
 
 export interface TagRunnerOptions {
-  context: any;
+  context: nunjucks.Context;
   args: TagExtensionArgTypes[];
   contentArgs: TagExtensionContentArgGetter[];
 }

--- a/packages/core/test/template-engine/built-in-extensions/query-builder/builder.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/query-builder/builder.spec.ts
@@ -5,7 +5,7 @@ it('Extension should execute correct query and set/export the variable', async (
   const { compiler, loader, builder, executor } = await createTestCompiler();
   const { compiledData } = await compiler.compile(`
 {% req userCount main %}
-select count(*) as count from user where user.id = '{{ params.userId }}';
+select count(*) as count from user where user.id = {{ params.userId }};
 {% endreq %}
   `);
   builder.value.onFirstCall().resolves([{ count: 1 }]);
@@ -16,8 +16,9 @@ select count(*) as count from user where user.id = '{{ params.userId }}';
   });
   // Assert
   expect(executor.createBuilder.firstCall.args[0]).toBe(
-    `select count(*) as count from user where user.id = 'user-id';`
+    `select count(*) as count from user where user.id = $1;`
   );
+  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(`user-id`);
   expect(result).toEqual([{ count: 1 }]);
 });
 

--- a/packages/core/test/template-engine/built-in-extensions/query-builder/execute.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/query-builder/execute.spec.ts
@@ -9,7 +9,7 @@ it('Extension should call the .value() function of builder', async () => {
 select * from users;
 {% endreq %}
 
-select * from group where userId = '{{ user.count(3).value()[0].id }}';
+select * from group where userId = {{ user.count(3).value()[0].id }};
 `
   );
   builder.value.onFirstCall().resolves([{ id: 'user-id' }]);
@@ -18,8 +18,9 @@ select * from group where userId = '{{ user.count(3).value()[0].id }}';
   await compiler.execute('test', {});
   // Assert
   expect(executor.createBuilder.secondCall.args[0]).toBe(
-    `select * from group where userId = 'user-id';`
+    `select * from group where userId = $1;`
   );
+  expect(executor.createBuilder.secondCall.args[1].get('$1')).toBe(`user-id`);
 });
 
 it('Extension should throw an error if the main builder failed to execute', async () => {
@@ -57,30 +58,4 @@ select * from group where userId = '{{ user.value()[0].id }}';
   await expect(compiler.execute('test', {})).rejects.toThrow(
     'something went wrong'
   );
-});
-
-it('Extension should create builder with query and bind parameters ', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `
-{% req userCount main %}
-select count(*) as count from user where user.id = '{{ context.params.userId }}';
-{% endreq %}
-    `
-  );
-  builder.value.onFirstCall().resolves([{ count: 1 }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { userId: '@userId' } },
-    ['_paramBinds']: { '@userId': '000000' },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe(
-    `select count(*) as count from user where user.id = '@userId';`
-  );
-  expect(executor.createBuilder.firstCall.args[1]).toEqual({
-    '@userId': '000000',
-  });
 });

--- a/packages/core/test/template-engine/built-in-extensions/query-builder/parameterize.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/query-builder/parameterize.spec.ts
@@ -1,0 +1,159 @@
+import { createTestCompiler } from '../../testCompiler';
+
+it('Should parameterize input parameters', async () => {
+  // Arrange
+  const { compiler, loader, builder, executor } = await createTestCompiler();
+  const { compiledData } = await compiler.compile(
+    `select * from users where id = {{ context.params.id }} or name = {{ context.params.name }}`
+  );
+  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
+  // Action
+  loader.setSource('test', compiledData);
+  await compiler.execute('test', {
+    context: { params: { id: 1, name: 'freda' } },
+  });
+  // Assert
+  expect(executor.createBuilder.firstCall.args[0]).toBe(
+    `select * from users where id = $1 or name = $2`
+  );
+  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
+  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe('freda');
+});
+
+it('Should parameterize all lookup or function call nodes', async () => {
+  // Arrange
+  const { compiler, loader, builder, executor } = await createTestCompiler();
+  const { compiledData } = await compiler.compile(
+    `{% set someVar = context.params.id %}
+{{ someVar }}
+{{ someVar + 1 }}
+{{ context.someFunction() }}
+{{ context.someFunction() + '!' }}
+{{ context.complexObj.func()().func2().a.b }}
+`
+  );
+  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
+  // Action
+  loader.setSource('test', compiledData);
+  await compiler.execute('test', {
+    context: {
+      params: { id: 1, name: 'freda' },
+      someFunction: () => 'functionResult',
+      complexObj: {
+        func: () => () => ({
+          func2: () => ({
+            a: { b: 'complexResult' },
+          }),
+        }),
+      },
+    },
+  });
+  // Assert
+  expect(executor.createBuilder.firstCall.args[0]).toBe(`$1\n$11\n$2\n$2!\n$3`);
+  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
+  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe(
+    'functionResult'
+  );
+  expect(executor.createBuilder.firstCall.args[1].get('$3')).toBe(
+    'complexResult'
+  );
+});
+
+it('Should reuse the parameter with same values', async () => {
+  // Arrange
+  const { compiler, loader, builder, executor } = await createTestCompiler();
+  const { compiledData } = await compiler.compile(
+    `{{ context.params.id }}{{ context.params.name }}{{ context.params.id }}`
+  );
+  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
+  // Action
+  loader.setSource('test', compiledData);
+  await compiler.execute('test', {
+    context: { params: { id: 1, name: 'freda' } },
+  });
+  // Assert
+  expect(executor.createBuilder.firstCall.args[0]).toBe(`$1$2$1`);
+  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
+  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe('freda');
+});
+
+it('Should reset the index with new request', async () => {
+  // Arrange
+  const { compiler, loader, builder, executor } = await createTestCompiler();
+  const { compiledData } = await compiler.compile(
+    `
+{% req user %}
+select * from users where name = {{ context.params.name }}
+{% endreq %}
+select * from groups where userId = {{ user.value()[0].id }}
+`
+  );
+  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
+  // Action
+  loader.setSource('test', compiledData);
+  await compiler.execute('test', {
+    context: { params: { name: 'freda' } },
+  });
+  // Assert
+  expect(executor.createBuilder.firstCall.args[0]).toBe(
+    `select * from users where name = $1`
+  );
+  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe('freda');
+  expect(executor.createBuilder.secondCall.args[0]).toBe(
+    `select * from groups where userId = $1`
+  );
+  expect(executor.createBuilder.secondCall.args[1].get('$1')).toBe(1);
+});
+
+it('Should use raw value to handle application logic', async () => {
+  // Arrange
+  const { compiler, loader, builder, executor } = await createTestCompiler();
+  const { compiledData } = await compiler.compile(
+    `{% if context.params.id == 1 %}This should be rendered - {{ context.params.id }}{% endif %}
+{% set someVar = context.params.id + 1 %}
+{% if someVar == 2 %}This should be rendered - {{ someVar }}{% endif %}
+{% set someArray = [5,6,7] %}
+{% for val in someArray %}
+{{ val }}
+{% endfor %}
+`
+  );
+  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
+  // Action
+  loader.setSource('test', compiledData);
+  await compiler.execute('test', {
+    context: { params: { id: 1 } },
+  });
+  // Assert
+  expect(executor.createBuilder.firstCall.args[0]).toBe(
+    `This should be rendered - $1
+This should be rendered - $2
+$3
+$4
+$5`
+  );
+  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
+  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe(2);
+  expect(executor.createBuilder.firstCall.args[1].get('$3')).toBe(5);
+  expect(executor.createBuilder.firstCall.args[1].get('$4')).toBe(6);
+  expect(executor.createBuilder.firstCall.args[1].get('$5')).toBe(7);
+});
+
+it('The binding keys should be in order which they are used', async () => {
+  // Arrange
+  const { compiler, loader, builder, executor } = await createTestCompiler();
+  const { compiledData } = await compiler.compile(
+    `{{ context.params.name }}{{ context.params.id }}`
+  );
+  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
+  // Action
+  loader.setSource('test', compiledData);
+  await compiler.execute('test', {
+    context: { params: { id: 1, name: 'freda' } },
+  });
+  // Assert
+  expect(Array.from(executor.createBuilder.firstCall.args[1].keys())).toEqual([
+    '$1',
+    '$2',
+  ]);
+});

--- a/packages/core/test/template-engine/built-in-extensions/query-builder/parameterize.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/query-builder/parameterize.spec.ts
@@ -1,42 +1,50 @@
 import { createTestCompiler } from '../../testCompiler';
 
-it('Should parameterize input parameters', async () => {
+const queryTest = async (
+  template: string,
+  expectedQueries: string[],
+  expectedBinding: any[][],
+  customContext?: Record<string, any>
+) => {
   // Arrange
   const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `select * from users where id = {{ context.params.id }} or name = {{ context.params.name }}`
-  );
+  const { compiledData } = await compiler.compile(template);
   builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
   // Action
   loader.setSource('test', compiledData);
   await compiler.execute('test', {
-    context: { params: { id: 1, name: 'freda' } },
+    context: customContext || { params: { id: 1, name: 'freda' } },
   });
   // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe(
-    `select * from users where id = $1 or name = $2`
+  expectedQueries.forEach((query, index) =>
+    expect(executor.createBuilder.getCall(index).args[0]).toBe(query)
   );
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
-  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe('freda');
+  expectedBinding.forEach((binding, index) => {
+    expect(
+      Array.from(executor.createBuilder.getCall(index).args[1].values())
+    ).toEqual(binding);
+  });
+};
+
+it('Should parameterize input parameters', async () => {
+  await queryTest(
+    `select * from users where id = {{ context.params.id }} or name = {{ context.params.name }}`,
+    [`select * from users where id = $1 or name = $2`],
+    [[1, 'freda']]
+  );
 });
 
 it('Should parameterize all lookup or function call nodes', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
+  await queryTest(
     `{% set someVar = context.params.id %}
 {{ someVar }}
 {{ someVar + 1 }}
 {{ context.someFunction() }}
 {{ context.someFunction() + '!' }}
-{{ context.complexObj.func()().func2().a.b }}
-`
-  );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: {
+{{ context.complexObj.func()().func2().a.b }}`,
+    [`$1\n$11\n$2\n$2!\n$3`],
+    [[1, 'functionResult', 'complexResult']],
+    {
       params: { id: 1, name: 'freda' },
       someFunction: () => 'functionResult',
       complexObj: {
@@ -46,69 +54,34 @@ it('Should parameterize all lookup or function call nodes', async () => {
           }),
         }),
       },
-    },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe(`$1\n$11\n$2\n$2!\n$3`);
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
-  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe(
-    'functionResult'
-  );
-  expect(executor.createBuilder.firstCall.args[1].get('$3')).toBe(
-    'complexResult'
+    }
   );
 });
 
 it('Should reuse the parameter with same values', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `{{ context.params.id }}{{ context.params.name }}{{ context.params.id }}`
+  await queryTest(
+    `{{ context.params.id }}{{ context.params.name }}{{ context.params.id }}`,
+    [`$1$2$1`],
+    [[1, 'freda']]
   );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { id: 1, name: 'freda' } },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe(`$1$2$1`);
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
-  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe('freda');
 });
 
 it('Should reset the index with new request', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `
-{% req user %}
+  await queryTest(
+    `{% req user %}
 select * from users where name = {{ context.params.name }}
 {% endreq %}
-select * from groups where userId = {{ user.value()[0].id }}
-`
+select * from groups where userId = {{ user.value()[0].id }}`,
+    [
+      `select * from users where name = $1`,
+      `select * from groups where userId = $1`,
+    ],
+    [['freda'], [1]]
   );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { name: 'freda' } },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe(
-    `select * from users where name = $1`
-  );
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe('freda');
-  expect(executor.createBuilder.secondCall.args[0]).toBe(
-    `select * from groups where userId = $1`
-  );
-  expect(executor.createBuilder.secondCall.args[1].get('$1')).toBe(1);
 });
 
 it('Should use raw value to handle application logic', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
+  await queryTest(
     `{% if context.params.id == 1 %}This should be rendered - {{ context.params.id }}{% endif %}
 {% set someVar = context.params.id + 1 %}
 {% if someVar == 2 %}This should be rendered - {{ someVar }}{% endif %}
@@ -116,115 +89,57 @@ it('Should use raw value to handle application logic', async () => {
 {% for val in someArray %}
 {{ val }}
 {% endfor %}
-`
-  );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { id: 1 } },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe(
-    `This should be rendered - $1
+  `,
+    [
+      `This should be rendered - $1
 This should be rendered - $2
 $3
 $4
-$5`
+$5`,
+    ],
+    [[1, 2, 5, 6, 7]]
   );
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe(1);
-  expect(executor.createBuilder.firstCall.args[1].get('$2')).toBe(2);
-  expect(executor.createBuilder.firstCall.args[1].get('$3')).toBe(5);
-  expect(executor.createBuilder.firstCall.args[1].get('$4')).toBe(6);
-  expect(executor.createBuilder.firstCall.args[1].get('$5')).toBe(7);
 });
 
-it('The binding keys should be in order which they are used', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `{{ context.params.name }}{{ context.params.id }}`
+it('The binding values should be in order which they are used', async () => {
+  await queryTest(
+    `{{ context.params.name }}{{ context.params.id }}`,
+    [`$1$2`],
+    [['freda', 1]]
   );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { id: 1, name: 'freda' } },
-  });
-  // Assert
-  expect(Array.from(executor.createBuilder.firstCall.args[1].keys())).toEqual([
-    '$1',
-    '$2',
-  ]);
 });
 
 it('Should render raw value when using raw filter', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `{{ context.params.id | raw }}{{ context.params.name | upper | raw }}`
+  await queryTest(
+    `{{ context.params.id | raw }}{{ context.params.name | upper | raw }}`,
+    [`1FREDA`],
+    []
   );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { id: 1, name: 'freda' } },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe('1FREDA');
 });
 
 it('Raw value should be wrapped again when accessing its children', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `{{ (context.params.data | raw).name }}`
+  await queryTest(
+    `{{ (context.params.data | raw).name }}`,
+    [`$1`],
+    [['freda']],
+    { params: { data: { id: 1, name: 'freda' } } }
   );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { data: { id: 1, name: 'freda' } } },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe('$1');
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe('freda');
 });
 
 it('Raw value should be wrapped again when raw filter is chaining again', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
-    `{{ context.params.name | raw | upper }}`
+  await queryTest(
+    `{{ context.params.name | raw | upper }}`,
+    [`$1`],
+    [['FREDA']]
   );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { name: 'freda' } },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe('$1');
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe('FREDA');
 });
 
 it('Raw value should be wrapped again when it is assigned to variables and is rendered', async () => {
-  // Arrange
-  const { compiler, loader, builder, executor } = await createTestCompiler();
-  const { compiledData } = await compiler.compile(
+  await queryTest(
     `{% set someVar = (context.params.name | upper | raw) %}
 {% if someVar == "FREDA" %}This should be rendered{% endif %}
-{{ someVar }}`
+{{ someVar }}`,
+    [`This should be rendered\n$1`],
+    [['FREDA']]
   );
-  builder.value.onFirstCall().resolves([{ id: 1, name: 'freda' }]);
-  // Action
-  loader.setSource('test', compiledData);
-  await compiler.execute('test', {
-    context: { params: { name: 'freda' } },
-  });
-  // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe(
-    'This should be rendered\n$1'
-  );
-  expect(executor.createBuilder.firstCall.args[1].get('$1')).toBe('FREDA');
 });

--- a/packages/core/test/template-engine/built-in-extensions/sql-helper/unique.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/sql-helper/unique.spec.ts
@@ -15,7 +15,10 @@ it('Extension should return correct values without unique by argument', async ()
   loader.setSource('test', compiledData);
   await compiler.execute('test', {});
   // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe('1\n2\n3\n4');
+  expect(executor.createBuilder.firstCall.args[0]).toBe('$1\n$2\n$3\n$4');
+  expect(Array.from(executor.createBuilder.firstCall.args[1].values())).toEqual(
+    [1, 2, 3, 4]
+  );
 });
 
 it('Extension should return correct values with unique by keyword argument', async () => {
@@ -33,7 +36,10 @@ it('Extension should return correct values with unique by keyword argument', asy
   loader.setSource('test', compiledData);
   await compiler.execute('test', {});
   // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe('Tom\nJoy');
+  expect(executor.createBuilder.firstCall.args[0]).toBe('$1\n$2');
+  expect(Array.from(executor.createBuilder.firstCall.args[1].values())).toEqual(
+    ['Tom', 'Joy']
+  );
 });
 
 it('Extension should return correct values with unique by argument', async () => {
@@ -51,5 +57,8 @@ it('Extension should return correct values with unique by argument', async () =>
   loader.setSource('test', compiledData);
   await compiler.execute('test', {});
   // Assert
-  expect(executor.createBuilder.firstCall.args[0]).toBe('Tom\nJoy');
+  expect(executor.createBuilder.firstCall.args[0]).toBe('$1\n$2');
+  expect(Array.from(executor.createBuilder.firstCall.args[1].values())).toEqual(
+    ['Tom', 'Joy']
+  );
 });

--- a/packages/core/test/template-engine/built-in-extensions/validator/filters.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/validator/filters.spec.ts
@@ -13,7 +13,9 @@ it('If we try to use loaded filter, extension should return the correct list', a
   // Arrange
   const { compiler } = await createTestCompiler();
   // Act
-  const { metadata } = await compiler.compile(`{{ 123 | unique }}`);
+  const { metadata } = await compiler.compile(
+    `{% set someVar = 123 | unique %}`
+  );
   // Act, Assert
   expect(metadata['filter.vulcan.com'].length).toBe(1);
 });
@@ -22,7 +24,7 @@ it('If we try to use a built-in filter, extension should return the correct list
   // Arrange
   const { compiler } = await createTestCompiler();
   // Act
-  const { metadata } = await compiler.compile(`{{ 123 | abs }}`);
+  const { metadata } = await compiler.compile(`{% set someVar = 123 | abs %}`);
   // Act, Assert
   expect(metadata['filter.vulcan.com'].length).toBe(1);
 });

--- a/packages/core/test/template-engine/externalExtension.spec.ts
+++ b/packages/core/test/template-engine/externalExtension.spec.ts
@@ -3,20 +3,23 @@ import * as path from 'path';
 
 it('The activate function should be called before executing', async () => {
   // Arrange
-  const { compiler, loader, getCreatedQueries } = await createTestCompiler({
-    options: {
-      extensions: {
-        test: path.resolve(__dirname, 'testExtension.ts'),
+  const { compiler, loader, getCreatedQueries, getCreatedBinding } =
+    await createTestCompiler({
+      options: {
+        extensions: {
+          test: path.resolve(__dirname, 'testExtension.ts'),
+        },
       },
-    },
-  });
+    });
   const { compiledData } = await compiler.compile('Hello {{ 123 | test }}!');
 
   // Action
   loader.setSource('test', compiledData);
   await compiler.execute('test', {});
   const queries = await getCreatedQueries();
+  const binding = await getCreatedBinding();
 
   // Assert
-  expect(queries[0]).toBe('Hello 123-true!');
+  expect(queries[0]).toBe('Hello $1!');
+  expect(Array.from(binding[0].values())).toEqual(['123-true']);
 });

--- a/packages/core/test/template-engine/nunjuckCompiler.spec.ts
+++ b/packages/core/test/template-engine/nunjuckCompiler.spec.ts
@@ -13,16 +13,19 @@ it('Nunjucks compiler should compile template without error.', async () => {
 
 it('Nunjucks compiler should load compiled code and execute rendered template with it', async () => {
   // Arrange
-  const { compiler, loader, getCreatedQueries } = await createTestCompiler();
+  const { compiler, loader, getCreatedQueries, getCreatedBinding } =
+    await createTestCompiler();
   const { compiledData } = await compiler.compile('Hello {{ name }}!');
 
   // Action
   loader.setSource('test', compiledData);
   await compiler.execute('test', { name: 'World' });
   const queries = await getCreatedQueries();
+  const binding = await getCreatedBinding();
 
   // Assert
-  expect(queries[0]).toBe('Hello World!');
+  expect(queries[0]).toBe('Hello $1!');
+  expect(binding[0].get('$1')).toBe('World');
 });
 
 it('Nunjucks compiler should reject the extension which has no valid super class', async () => {

--- a/packages/core/test/template-engine/templateEngine.spec.ts
+++ b/packages/core/test/template-engine/templateEngine.spec.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
       errors: [],
     },
   });
-  stubCompiler.execute.resolves('sql-result');
+  stubCompiler.execute.resolves('sql-result' as any);
 
   const generator = async function* () {
     yield {
@@ -86,7 +86,7 @@ it('Template engine render function should forward correct data to compiler', as
   };
 
   // Act
-  const result = await templateEngine.execute('template-name', context);
+  const result = await templateEngine.execute('template-name', { context });
 
   // Assert
   expect(stubCompiler.execute.firstCall.args[1]).toEqual(expected);

--- a/packages/core/test/template-engine/templateEngine.spec.ts
+++ b/packages/core/test/template-engine/templateEngine.spec.ts
@@ -80,10 +80,8 @@ it('Template engine render function should forward correct data to compiler', as
     name: 'name',
   };
   const expected = {
-    _paramBinds: {},
     context: {
       ...context,
-      params: {},
     },
   };
 
@@ -91,7 +89,7 @@ it('Template engine render function should forward correct data to compiler', as
   const result = await templateEngine.execute('template-name', context);
 
   // Assert
-  expect(stubCompiler.execute.getCalls()[0].args[1]).toEqual(expected);
+  expect(stubCompiler.execute.firstCall.args[1]).toEqual(expected);
   expect(result).toBe('sql-result');
 });
 

--- a/packages/core/test/template-engine/testCompiler.ts
+++ b/packages/core/test/template-engine/testCompiler.ts
@@ -65,5 +65,9 @@ export const createTestCompiler = async ({
       const calls = stubExecutor.createBuilder.getCalls();
       return calls.map((call) => call.args[0]);
     },
+    getCreatedBinding: async () => {
+      const calls = stubExecutor.createBuilder.getCalls();
+      return calls.map((call) => call.args[1]);
+    },
   };
 };

--- a/packages/core/test/template-engine/testCompiler.ts
+++ b/packages/core/test/template-engine/testCompiler.ts
@@ -8,7 +8,7 @@ import * as sinon from 'ts-sinon';
 import * as nunjucks from 'nunjucks';
 import { IDataQueryBuilder, IExecutor } from '@vulcan-sql/core/data-query';
 import { extensionModule } from '../../src/containers/modules';
-import { ICoreOptions } from '@vulcan-sql/core';
+import { DataSource, ICoreOptions } from '@vulcan-sql/core';
 import { DeepPartial } from 'ts-essentials';
 
 export const createTestCompiler = async ({
@@ -21,6 +21,11 @@ export const createTestCompiler = async ({
   stubQueryBuilder.count.returns(stubQueryBuilder);
   const stubExecutor = sinon.stubInterface<IExecutor>();
   stubExecutor.createBuilder.resolves(stubQueryBuilder);
+  const stubDataSource = sinon.stubInterface<DataSource>();
+  stubDataSource.prepare.callsFake(
+    async ({ parameterIndex }) => `$${parameterIndex}`
+  );
+  stubExecutor.getDataSource.resolves(stubDataSource);
 
   container
     .bind(TYPES.CompilerLoader)

--- a/packages/core/test/template-engine/testCompiler.ts
+++ b/packages/core/test/template-engine/testCompiler.ts
@@ -8,7 +8,7 @@ import * as sinon from 'ts-sinon';
 import * as nunjucks from 'nunjucks';
 import { IDataQueryBuilder, IExecutor } from '@vulcan-sql/core/data-query';
 import { extensionModule } from '../../src/containers/modules';
-import { DataSource, ICoreOptions } from '@vulcan-sql/core';
+import { ICoreOptions } from '@vulcan-sql/core';
 import { DeepPartial } from 'ts-essentials';
 
 export const createTestCompiler = async ({
@@ -21,11 +21,9 @@ export const createTestCompiler = async ({
   stubQueryBuilder.count.returns(stubQueryBuilder);
   const stubExecutor = sinon.stubInterface<IExecutor>();
   stubExecutor.createBuilder.resolves(stubQueryBuilder);
-  const stubDataSource = sinon.stubInterface<DataSource>();
-  stubDataSource.prepare.callsFake(
+  stubExecutor.prepare.callsFake(
     async ({ parameterIndex }) => `$${parameterIndex}`
   );
-  stubExecutor.getDataSource.resolves(stubDataSource);
 
   container
     .bind(TYPES.CompilerLoader)

--- a/packages/extension-debug-tools/test/astPrinter.spec.ts
+++ b/packages/extension-debug-tools/test/astPrinter.spec.ts
@@ -61,19 +61,27 @@ it('Printer should generate mermaid for each AST tree', async () => {
     13[Filter]
     13 --name--> 14
     14[Symbol]
-    15{{"string"}}
+    15{{"sanitize"}}
     14 --value--> 15
     13 --args--> 16
     16[NodeList]
     16 --"children[0]"--> 17
-    17[Symbol]
-    18{{"c"}}
-    17 --value--> 18
-    8 --"children[2]"--> 19
-    19[Output]
-    19 --"children[0]"--> 20
-    20[TemplateData]
-    21{{"d"}}
-    20 --value--> 21
+    17[Filter]
+    17 --name--> 18
+    18[Symbol]
+    19{{"string"}}
+    18 --value--> 19
+    17 --args--> 20
+    20[NodeList]
+    20 --"children[0]"--> 21
+    21[Symbol]
+    22{{"c"}}
+    21 --value--> 22
+    8 --"children[2]"--> 23
+    23[Output]
+    23 --"children[0]"--> 24
+    24[TemplateData]
+    25{{"d"}}
+    24 --value--> 25
 `);
 });

--- a/packages/integration-testing/src/example1/buildAndServe.spec.ts
+++ b/packages/integration-testing/src/example1/buildAndServe.spec.ts
@@ -54,7 +54,7 @@ const projectConfig: ServeConfig & IBuildOptions = {
 let server: VulcanServer;
 
 afterEach(async () => {
-  await server.close();
+  await server?.close();
 });
 
 it('Example1: Build and serve should work', async () => {

--- a/packages/integration-testing/src/mockExtensions/mockDb.ts
+++ b/packages/integration-testing/src/mockExtensions/mockDb.ts
@@ -1,10 +1,8 @@
 import {
-  IdentifierParameters,
-  BindParameters,
   DataResult,
   DataSource,
   ExecuteOptions,
-  RequestParameters,
+  RequestParameter,
   VulcanExtensionId,
 } from '@vulcan-sql/core';
 import { newDb } from 'pg-mem';
@@ -21,11 +19,11 @@ export class MockDataSource extends DataSource {
     const { statement, bindParams } = options;
     // handle parameterized query statement
     let query = statement;
-    for (const identifier of Object.keys(bindParams)) {
+    for (const identifier of bindParams.keys()) {
       query = query.replace(
         // escape special char '$'
         new RegExp(identifier.replace('$', '\\$'), 'g'),
-        bindParams[identifier]
+        bindParams.get(identifier)!
       );
     }
 
@@ -46,19 +44,7 @@ export class MockDataSource extends DataSource {
       },
     };
   }
-  public async prepare(params: RequestParameters) {
-    const identifiers = {} as IdentifierParameters;
-    const binds = {} as BindParameters;
-    let index = 1;
-    for (const key of Object.keys(params)) {
-      const identifier = `$${index}`;
-      identifiers[key] = identifier;
-      binds[identifier] = params[key];
-      index += 1;
-    }
-    return {
-      identifiers,
-      binds,
-    };
+  public async prepare({ parameterIndex }: RequestParameter) {
+    return `$${parameterIndex}`;
   }
 }

--- a/packages/serve/src/lib/route/route-component/baseRoute.ts
+++ b/packages/serve/src/lib/route/route-component/baseRoute.ts
@@ -19,7 +19,6 @@ export interface RouteOptions {
   reqTransformer: IRequestTransformer;
   reqValidator: IRequestValidator;
   paginationTransformer: IPaginationTransformer;
-  dataSource: DataSource;
   templateEngine: TemplateEngine;
 }
 
@@ -32,21 +31,19 @@ export abstract class BaseRoute implements IRoute {
   protected readonly reqTransformer: IRequestTransformer;
   protected readonly reqValidator: IRequestValidator;
   protected readonly templateEngine: TemplateEngine;
-  protected readonly dataSource: DataSource;
   protected readonly paginationTransformer: IPaginationTransformer;
+
   constructor({
     apiSchema,
     reqTransformer,
     reqValidator,
     paginationTransformer,
-    dataSource,
     templateEngine,
   }: RouteOptions) {
     this.apiSchema = apiSchema;
     this.reqTransformer = reqTransformer;
     this.reqValidator = reqValidator;
     this.paginationTransformer = paginationTransformer;
-    this.dataSource = dataSource;
     this.templateEngine = templateEngine;
   }
 
@@ -58,12 +55,9 @@ export abstract class BaseRoute implements IRoute {
     const { reqParams } = transformed;
     // could template name or template path, use for template engine
     const { templateSource } = this.apiSchema;
-    // prepare query params for providing data source to prevent sql injection when query
-    const prepared = await this.dataSource.prepare(reqParams);
 
     const result = await this.templateEngine.execute(templateSource, {
-      ['user']: user,
-      ['_prepared']: prepared,
+      context: { params: reqParams, user },
     });
     return result;
   }

--- a/packages/serve/src/lib/route/route-component/baseRoute.ts
+++ b/packages/serve/src/lib/route/route-component/baseRoute.ts
@@ -1,10 +1,5 @@
 import { AuthUserInfo, KoaContext } from '@vulcan-sql/serve/models';
-import {
-  APISchema,
-  TemplateEngine,
-  Pagination,
-  DataSource,
-} from '@vulcan-sql/core';
+import { APISchema, TemplateEngine, Pagination } from '@vulcan-sql/core';
 import { IRequestValidator } from './requestValidator';
 import { IRequestTransformer, RequestParameters } from './requestTransformer';
 import { IPaginationTransformer } from './paginationTransformer';

--- a/packages/serve/src/lib/route/routeGenerator.ts
+++ b/packages/serve/src/lib/route/routeGenerator.ts
@@ -27,7 +27,6 @@ export class RouteGenerator {
   private reqTransformer: IRequestTransformer;
   private paginationTransformer: IPaginationTransformer;
   private templateEngine: TemplateEngine;
-  private dataSource: DataSource;
   private apiOptions: APIRouteBuilderOption = {
     [APIProviderType.RESTFUL]: RestfulRoute,
     [APIProviderType.GRAPHQL]: GraphQLRoute,
@@ -38,13 +37,11 @@ export class RouteGenerator {
     @inject(TYPES.RequestValidator) reqValidator: IRequestValidator,
     @inject(TYPES.PaginationTransformer)
     paginationTransformer: IPaginationTransformer,
-    @inject(CORE_TYPES.DataSource) dataSource: DataSource,
     @inject(CORE_TYPES.TemplateEngine) templateEngine: TemplateEngine
   ) {
     this.reqValidator = reqValidator;
     this.reqTransformer = reqTransformer;
     this.paginationTransformer = paginationTransformer;
-    this.dataSource = dataSource;
     this.templateEngine = templateEngine;
   }
 
@@ -57,7 +54,6 @@ export class RouteGenerator {
       reqTransformer: this.reqTransformer,
       reqValidator: this.reqValidator,
       paginationTransformer: this.paginationTransformer,
-      dataSource: this.dataSource,
       templateEngine: this.templateEngine,
     });
   }

--- a/packages/serve/src/lib/route/routeGenerator.ts
+++ b/packages/serve/src/lib/route/routeGenerator.ts
@@ -1,5 +1,5 @@
 import { IPaginationTransformer } from '@vulcan-sql/serve/route';
-import { APISchema, DataSource, TemplateEngine } from '@vulcan-sql/core';
+import { APISchema, TemplateEngine } from '@vulcan-sql/core';
 import {
   RestfulRoute,
   GraphQLRoute,

--- a/packages/serve/test/app.spec.ts
+++ b/packages/serve/test/app.spec.ts
@@ -348,7 +348,7 @@ describe('Test vulcan server for calling restful APIs', () => {
       });
 
       stubTemplateEngine.execute.resolves({
-        getData: () => expected,
+        getData: () => expected as any,
         getColumns: () => [],
       });
       // Act

--- a/packages/serve/test/route/routeGenerator.spec.ts
+++ b/packages/serve/test/route/routeGenerator.spec.ts
@@ -71,7 +71,6 @@ describe('Test route generator ', () => {
         paginationTransformer: container.get<IPaginationTransformer>(
           TYPES.PaginationTransformer
         ),
-        dataSource: container.get<DataSource>(CORE_TYPES.DataSource),
         templateEngine: container.get<TemplateEngine>(
           CORE_TYPES.TemplateEngine
         ),
@@ -107,7 +106,6 @@ describe('Test route generator ', () => {
         paginationTransformer: container.get<IPaginationTransformer>(
           TYPES.PaginationTransformer
         ),
-        dataSource: container.get<DataSource>(CORE_TYPES.DataSource),
         templateEngine: container.get<TemplateEngine>(
           CORE_TYPES.TemplateEngine
         ),

--- a/types/nunjucks.d.ts
+++ b/types/nunjucks.d.ts
@@ -51,6 +51,25 @@ declare module 'nunjucks' {
     ): string;
   }
 
+  export interface Context {
+    init(ctx: Context, blocks: any, env: Environment): void;
+    lookup<T = any>(name: string): T | undefined;
+    setVariable<T = any>(name: string, val: T): void;
+    getVariables(): Record<string, any>;
+    addBlock(name: string, block: any): this;
+    getBlock(name: string): any;
+    getSuper(
+      env: Environment,
+      name: string,
+      block: any,
+      frame: any,
+      runtime: any,
+      cb: any
+    ): void;
+    addExport(name: string): void;
+    getExported(): Record<string, any>;
+  }
+
   export class Template {
     constructor(
       src: string,


### PR DESCRIPTION
## What's fixed
1. After https://github.com/Canner/vulcan/pull/23, we replace the input parameters with parameterized values like $1, $2 ...etc. But we need the raw value with template logic, for example:

    ```sql
    select * from user
    {% if context.params.age %} where age > {{ context.params.age }} {% endif %}
    ```
    
    The above template will always render the where query because `context.params.age` is "$1". This PR fixed this issue, it replaces values only when needed.

2. We sent useless binding with sub-queries. For example:

    ```sql
     {% req user %}
        select id from users where userName = {{ context.params.name }}
    {% endreq %}
    select * from groups where groupName = {{ context.params.groupName }}
    ```
    
    We sent `select id from users where userName = $1` with binding ['someUserName', 'someGroupName'] at the first query, which might cause driver failure (binding length is not equal to query usage). This PR sends binding with only required parameters.
 


### Enhancement
1. Parameterize all the values including sub queries' values, user attributes... 

    ```sql
    {% req user %}
    select id from users where userName = {{ context.params.name }}
    {% endreq %}
    select * from groups where userId = {{ user.value()[0].id }}; --- this value will be parameterized too.
    ```

2. Provide a filter `raw` to force us to render the raw values.

    ```sql
    {{ context.params.name }} --- $1
    {{ context.params.name | raw }} --- someName
    ```