### PR TITLE
Feature: Implement start --watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "@koa/cors": "^3.3.0",
+    "chokidar": "^3.5.3",
     "bcryptjs": "^2.4.3",
     "bytes": "^3.1.2",
     "class-validator": "^0.13.2",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -56,6 +56,7 @@ program
     './vulcan.yaml'
   )
   .option('-p --port <port>', 'server port', '3000')
+  .option('-w --watch', 'watch file changes', false)
   .action(async (options) => {
     await handleStart(options);
   });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -12,6 +12,15 @@ const defaultOptions: BuildCommandOptions = {
   config: './vulcan.yaml',
 };
 
+export const mergeBuildDefaultOption = (
+  options: Partial<BuildCommandOptions>
+) => {
+  return {
+    ...defaultOptions,
+    ...options,
+  } as BuildCommandOptions;
+};
+
 export const buildVulcan = async (options: BuildCommandOptions) => {
   const configPath = path.resolve(process.cwd(), options.config);
   const config: any = jsYAML.load(await fs.readFile(configPath, 'utf-8'));
@@ -36,9 +45,5 @@ export const buildVulcan = async (options: BuildCommandOptions) => {
 export const handleBuild = async (
   options: Partial<BuildCommandOptions>
 ): Promise<void> => {
-  options = {
-    ...defaultOptions,
-    ...options,
-  };
-  await buildVulcan(options as BuildCommandOptions);
+  await buildVulcan(mergeBuildDefaultOption(options));
 };

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,9 +1,119 @@
-import { BuildCommandOptions, handleBuild } from './build';
-import { handleServe, ServeCommandOptions } from './serve';
+import {
+  BuildCommandOptions,
+  buildVulcan,
+  mergeBuildDefaultOption,
+} from './build';
+import {
+  mergeServeDefaultOption,
+  ServeCommandOptions,
+  serveVulcan,
+} from './serve';
+import * as chokidar from 'chokidar';
+import * as jsYAML from 'js-yaml';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { logger } from '../utils';
+
+const callAfterFulfilled = (func: () => Promise<void>) => {
+  let busy = false;
+  let waitQueue: (() => void)[] = [];
+  const runJob = () => {
+    const currentPromises = waitQueue;
+    waitQueue = [];
+    busy = true;
+    func().finally(() => {
+      currentPromises.forEach((resolve) => resolve());
+      busy = false;
+      if (waitQueue.length > 0) runJob();
+    });
+  };
+  const callback = () =>
+    new Promise<void>((resolve) => {
+      waitQueue.push(resolve);
+      if (!busy) runJob();
+    });
+  return callback;
+};
+
+export interface StartCommandOptions {
+  watch: boolean;
+  config: string;
+}
+
+const defaultOptions: StartCommandOptions = {
+  config: './vulcan.yaml',
+  watch: false,
+};
+
+export const mergeStartDefaultOption = (
+  options: Partial<StartCommandOptions>
+) => {
+  return {
+    ...defaultOptions,
+    ...options,
+  } as StartCommandOptions;
+};
 
 export const handleStart = async (
-  options: Partial<BuildCommandOptions & ServeCommandOptions>
+  options: Partial<
+    StartCommandOptions & BuildCommandOptions & ServeCommandOptions
+  >
 ): Promise<void> => {
-  await handleBuild(options);
-  await handleServe(options);
+  const buildOptions = mergeBuildDefaultOption(options);
+  const serveOptions = mergeServeDefaultOption(options);
+  const startOptions = mergeStartDefaultOption(options);
+
+  const configPath = path.resolve(process.cwd(), startOptions.config);
+  const config: any = jsYAML.load(await fs.readFile(configPath, 'utf-8'));
+
+  let stopServer: (() => Promise<any>) | undefined;
+
+  const restartServer = async () => {
+    if (stopServer) await stopServer();
+    await buildVulcan(buildOptions);
+    stopServer = (await serveVulcan(serveOptions)).stopServer;
+  };
+
+  await restartServer();
+
+  if (startOptions.watch) {
+    const pathsToWatch: string[] = [];
+
+    // YAML files
+    const schemaReader = config['schema-parser']?.['reader'];
+    if (schemaReader === 'LocalFile') {
+      pathsToWatch.push(
+        `${path
+          .resolve(config['schema-parser']?.['folderPath'])
+          .split(path.sep)
+          .join('/')}/**/*.yaml`
+      );
+    } else {
+      logger.warn(
+        `We can't watch with schema parser reader: ${schemaReader}, ignore it.`
+      );
+    }
+
+    // SQL files
+    const templateProvider = config['template']?.['provider'];
+    if (templateProvider === 'LocalFile') {
+      pathsToWatch.push(
+        `${path
+          .resolve(config['template']?.['folderPath'])
+          .split(path.sep)
+          .join('/')}/**/*.sql`
+      );
+    } else {
+      logger.warn(
+        `We can't watch with template provider: ${templateProvider}, ignore it.`
+      );
+    }
+
+    const restartWhenFulfilled = callAfterFulfilled(restartServer);
+    chokidar
+      .watch(pathsToWatch, { ignoreInitial: true })
+      .on('all', () => restartWhenFulfilled());
+
+    logger.info(`Start watching changes...`);
+  }
 };

--- a/packages/cli/src/utils/shutdown.ts
+++ b/packages/cli/src/utils/shutdown.ts
@@ -8,6 +8,11 @@ export const addShutdownJob = (job: JobBeforeShutdown) => {
   shutdownJobs.push(job);
 };
 
+export const removeShutdownJob = (job: JobBeforeShutdown) => {
+  const index = shutdownJobs.indexOf(job);
+  if (index >= 0) shutdownJobs.splice(index, 1);
+};
+
 export const runShutdownJobs = async () => {
   logger.info('Ctrl-C signal caught, stopping services...');
   await Promise.all(shutdownJobs.map((job) => job()));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,7 +2157,7 @@ charenc@0.0.2:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
 
-chokidar@^3.5.1:
+chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==


### PR DESCRIPTION
## Description

Provide a flag --watch, -w for start command, which lets the server watch SQL and schemas changes, and restart the server when needed.

## Issue ticket number

closes #60 

## Additional Context
- Watch flag doesn't work in docker CLI, we might need another solution (e.g. polling) for it.
