### PR TITLE
Fix: default value of rate-limit and unnecessary content of access logs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "@koa/cors": "^3.3.0",
+    "bytes": "^3.1.2",
     "class-validator": "^0.13.2",
     "commander": "^9.4.0",
     "dayjs": "^1.11.2",
@@ -42,6 +43,7 @@
     "@nrwl/linter": "14.0.3",
     "@nrwl/workspace": "14.0.3",
     "@types/bcryptjs": "^2.4.2",
+    "@types/bytes": "^3.1.1",
     "@types/from2": "^2.3.1",
     "@types/glob": "^7.2.0",
     "@types/inquirer": "^8.0.0",

--- a/packages/core/src/lib/utils/logger.ts
+++ b/packages/core/src/lib/utils/logger.ts
@@ -21,9 +21,13 @@ export enum LoggingLevel {
   FATAL = 'fatal',
 }
 
+type DisplayFilePathTypes = 'hidden' | 'displayAll' | 'hideNodeModulesOnly';
+
 export interface LoggerOptions {
   level?: LoggingLevel;
   displayRequestId?: boolean;
+  displayFunctionName?: boolean;
+  displayFilePath?: DisplayFilePathTypes;
 }
 
 type LoggerMapConfig = {
@@ -34,18 +38,26 @@ const defaultMapConfig: LoggerMapConfig = {
   [LoggingScope.CORE]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
+    displayFilePath: 'hideNodeModulesOnly',
+    displayFunctionName: true,
   },
   [LoggingScope.BUILD]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
+    displayFilePath: 'hideNodeModulesOnly',
+    displayFunctionName: true,
   },
   [LoggingScope.SERVE]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
+    displayFilePath: 'hideNodeModulesOnly',
+    displayFunctionName: true,
   },
   [LoggingScope.AUDIT]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
+    displayFilePath: 'hidden',
+    displayFunctionName: false,
   },
 };
 
@@ -95,6 +107,9 @@ class LoggerFactory {
       minLevel: options.level || prevSettings.minLevel,
       displayRequestId:
         options.displayRequestId || prevSettings.displayRequestId,
+      displayFunctionName:
+        options.displayFunctionName || prevSettings.displayFunctionName,
+      displayFilePath: options.displayFilePath || prevSettings.displayFilePath,
     });
   }
 
@@ -106,6 +121,11 @@ class LoggerFactory {
       requestId: () => this.asyncReqIdStorage.getStore()?.requestId as string,
       displayRequestId:
         options?.displayRequestId || defaultMapConfig[name].displayRequestId,
+      displayFunctionName:
+        options?.displayFunctionName ||
+        defaultMapConfig[name].displayFunctionName,
+      displayFilePath:
+        options?.displayFilePath || defaultMapConfig[name].displayFilePath,
     });
   }
 }

--- a/packages/core/src/lib/utils/logger.ts
+++ b/packages/core/src/lib/utils/logger.ts
@@ -38,20 +38,20 @@ const defaultMapConfig: LoggerMapConfig = {
   [LoggingScope.CORE]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
-    displayFilePath: 'hideNodeModulesOnly',
-    displayFunctionName: true,
+    displayFilePath: 'hidden',
+    displayFunctionName: false,
   },
   [LoggingScope.BUILD]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
-    displayFilePath: 'hideNodeModulesOnly',
-    displayFunctionName: true,
+    displayFilePath: 'hidden',
+    displayFunctionName: false,
   },
   [LoggingScope.SERVE]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
-    displayFilePath: 'hideNodeModulesOnly',
-    displayFunctionName: true,
+    displayFilePath: 'hidden',
+    displayFunctionName: false,
   },
   [LoggingScope.ACCESS_LOG]: {
     level: LoggingLevel.DEBUG,

--- a/packages/core/src/lib/utils/logger.ts
+++ b/packages/core/src/lib/utils/logger.ts
@@ -6,7 +6,7 @@ export enum LoggingScope {
   CORE = 'CORE',
   BUILD = 'BUILD',
   SERVE = 'SERVE',
-  AUDIT = 'AUDIT',
+  ACCESS_LOG = 'ACCESS_LOG',
 }
 
 type LoggingScopeTypes = keyof typeof LoggingScope;
@@ -53,7 +53,7 @@ const defaultMapConfig: LoggerMapConfig = {
     displayFilePath: 'hideNodeModulesOnly',
     displayFunctionName: true,
   },
-  [LoggingScope.AUDIT]: {
+  [LoggingScope.ACCESS_LOG]: {
     level: LoggingLevel.DEBUG,
     displayRequestId: false,
     displayFilePath: 'hidden',

--- a/packages/serve/src/lib/middleware/accessLogMiddleware.ts
+++ b/packages/serve/src/lib/middleware/accessLogMiddleware.ts
@@ -6,10 +6,10 @@ import {
 import * as bytes from 'bytes';
 import { BuiltInMiddleware, KoaContext, Next } from '@vulcan-sql/serve/models';
 
-@VulcanInternalExtension('audit-log')
-export class AuditLoggingMiddleware extends BuiltInMiddleware<LoggerOptions> {
+@VulcanInternalExtension('access-log')
+export class AccessLogMiddleware extends BuiltInMiddleware<LoggerOptions> {
   private logger = getLogger({
-    scopeName: 'AUDIT',
+    scopeName: 'ACCESS_LOG',
     options: this.getOptions(),
   });
 

--- a/packages/serve/src/lib/middleware/accessLogMiddleware.ts
+++ b/packages/serve/src/lib/middleware/accessLogMiddleware.ts
@@ -20,10 +20,6 @@ export class AccessLogMiddleware extends BuiltInMiddleware<LoggerOptions> {
 
     const reqSize = req.length ? bytes(req.length).toLowerCase() : 'none';
     const respSize = resp.length ? bytes(resp.length).toLowerCase() : 'none';
-    /**
-     * TODO: The response body of our API server might be huge.
-     * We can let users to set what data they want to record in config in the future.
-     */
     this.logger.info(
       `--> ${req.ip} -- "${req.method} ${req.path}" -- size: ${reqSize}`
     );

--- a/packages/serve/src/lib/middleware/index.ts
+++ b/packages/serve/src/lib/middleware/index.ts
@@ -19,10 +19,10 @@ import { DocRouterMiddleware } from './docRouterMiddleware';
 
 // The order is the middleware running order
 export const BuiltInRouteMiddlewares: ClassType<ExtensionBase>[] = [
+  AccessLogMiddleware,
   CorsMiddleware,
   EnforceHttpsMiddleware,
   RequestIdMiddleware,
-  AccessLogMiddleware,
   RateLimitMiddleware,
   AuthMiddleware,
   ResponseFormatMiddleware,

--- a/packages/serve/src/lib/middleware/index.ts
+++ b/packages/serve/src/lib/middleware/index.ts
@@ -1,6 +1,6 @@
 export * from './corsMiddleware';
 export * from './requestIdMiddleware';
-export * from './auditLogMiddleware';
+export * from './accessLogMiddleware';
 export * from './rateLimitMiddleware';
 export * from './authMiddleware';
 export * from './response-format';
@@ -11,7 +11,7 @@ import { CorsMiddleware } from './corsMiddleware';
 import { AuthMiddleware } from './authMiddleware';
 import { RateLimitMiddleware } from './rateLimitMiddleware';
 import { RequestIdMiddleware } from './requestIdMiddleware';
-import { AuditLoggingMiddleware } from './auditLogMiddleware';
+import { AccessLogMiddleware } from './accessLogMiddleware';
 import { ResponseFormatMiddleware } from './response-format';
 import { EnforceHttpsMiddleware } from './enforceHttpsMiddleware';
 import { ClassType, ExtensionBase } from '@vulcan-sql/core';
@@ -22,7 +22,7 @@ export const BuiltInRouteMiddlewares: ClassType<ExtensionBase>[] = [
   CorsMiddleware,
   EnforceHttpsMiddleware,
   RequestIdMiddleware,
-  AuditLoggingMiddleware,
+  AccessLogMiddleware,
   RateLimitMiddleware,
   AuthMiddleware,
   ResponseFormatMiddleware,

--- a/packages/serve/src/lib/middleware/rateLimitMiddleware.ts
+++ b/packages/serve/src/lib/middleware/rateLimitMiddleware.ts
@@ -1,15 +1,26 @@
 import { RateLimit, RateLimitOptions } from 'koa2-ratelimit';
 import { BuiltInMiddleware, KoaContext, Next } from '@vulcan-sql/serve/models';
-import { VulcanInternalExtension } from '@vulcan-sql/core';
+import { VulcanInternalExtension, TYPES as CORE_TYPES } from '@vulcan-sql/core';
+import { inject } from 'inversify';
 
 export { RateLimitOptions };
 
 @VulcanInternalExtension('rate-limit')
 export class RateLimitMiddleware extends BuiltInMiddleware<RateLimitOptions> {
-  private koaRateLimit = RateLimit.middleware(this.getOptions());
+  private options: RateLimitOptions;
+  private koaRateLimitFunc;
+  constructor(
+    @inject(CORE_TYPES.ExtensionConfig) config: any,
+    @inject(CORE_TYPES.ExtensionName) name: string
+  ) {
+    super(config, name);
+    this.options = (this.getOptions() as RateLimitOptions) || { max: 60 };
+    if (!this.options['max']) this.options['max'] = 60;
+    this.koaRateLimitFunc = RateLimit.middleware(this.options);
+  }
 
   public async handle(context: KoaContext, next: Next) {
     if (!this.enabled) return next();
-    return this.koaRateLimit(context, next);
+    return this.koaRateLimitFunc(context, next);
   }
 }

--- a/packages/serve/test/app.spec.ts
+++ b/packages/serve/test/app.spec.ts
@@ -369,6 +369,7 @@ describe('Test vulcan server for calling restful APIs', () => {
 
       // Assert
       expect(response.body.data).toEqual(expected);
-    }
+    },
+    10000
   );
 });

--- a/packages/serve/test/middlewares/built-in-middlewares/accessLogMiddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/accessLogMiddleware.spec.ts
@@ -7,12 +7,12 @@ import { KoaContext } from '@vulcan-sql/serve/models';
 import * as core from '@vulcan-sql/core';
 import * as uuid from 'uuid';
 import {
-  AuditLoggingMiddleware,
+  AccessLogMiddleware,
   RequestIdMiddleware,
 } from '@vulcan-sql/serve/middleware';
 import bytes = require('bytes');
 
-describe('Test audit logging middlewares', () => {
+describe('Test access log middlewares', () => {
   afterEach(() => {
     sinon.default.restore();
   });
@@ -63,9 +63,9 @@ describe('Test audit logging middlewares', () => {
       ` <- header: ${JSON.stringify(resp.header)}`,
     ];
     // Act
-    const middleware = new AuditLoggingMiddleware({}, '');
-    // Use spy to trace the logger from getLogger( scopeName: 'AUDIT' }) to know in logger.info(...)
-    const spy = sinon.default.spy(core.getLogger({ scopeName: 'AUDIT' }));
+    const middleware = new AccessLogMiddleware({}, '');
+    // Use spy to trace the logger from getLogger( scopeName: 'ACCESS_LOG' }) to know in logger.info(...)
+    const spy = sinon.default.spy(core.getLogger({ scopeName: 'ACCESS_LOG' }));
     await middleware.handle(ctx, async () => Promise.resolve());
 
     // Assert
@@ -129,7 +129,7 @@ describe('Test audit logging middlewares', () => {
 
     // setup request-id middleware run first.
     const stubReqIdMiddleware = new RequestIdMiddleware({}, '');
-    const middleware = new AuditLoggingMiddleware(
+    const middleware = new AccessLogMiddleware(
       {
         options: {
           displayRequestId: true,
@@ -137,11 +137,11 @@ describe('Test audit logging middlewares', () => {
       },
       ''
     );
-    // Use spy to trace the logger from getLogger( scopeName: 'AUDIT' }) to know in logger.info(...)
-    // it will get the setting of logger from above new audit logging middleware
+    // Use spy to trace the logger from getLogger( scopeName: 'ACCESS_LOG' }) to know in logger.info(...)
+    // it will get the setting of logger from above new ACCESS_LOG logging middleware
     const spy = sinon.default.spy(
       core.getLogger({
-        scopeName: 'AUDIT',
+        scopeName: 'ACCESS_LOG',
       })
     );
     // Act

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/bytes@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/bytes/-/bytes-3.1.1.tgz#67a876422e660dc4c10a27f3e5bcfbd5455f01d0"
+  integrity sha512-lOGyCnw+2JVPKU3wIV0srU0NyALwTBJlVSx5DfMQOFuuohA8y9S8orImpuIQikZ0uIQ8gehrRjxgQC1rLRi11w==
+
 "@types/chai@*":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
@@ -1954,7 +1959,7 @@ buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-bytes@3.1.2:
+bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==


### PR DESCRIPTION
## Description
Fix the default value of sending 5 times requests in 1 minute to 60 times in 1 minute for the rate limit and refactor the access log message.
We rename the `AuditLoggingMiddleware` to `AccessLogMiddleware`, and change the module name from `audit-log` to `access-log`.

The access log message become to below format:
```bash
2022-09-12 10:15:26.997  INFO  [ACCESS_LOG:b995f7d9-9147-4456-b59c-e07b4d16d7a3] --> 227.173.195.209 -- "PUT http://ripe-celebration.org" -- size: 15.93kb 
2022-09-12 10:15:26.998  INFO  [ACCESS_LOG:b995f7d9-9147-4456-b59c-e07b4d16d7a3]  -> header: {"X-Agent":"test-school-client"} 
2022-09-12 10:15:27.000  INFO  [ACCESS_LOG:b995f7d9-9147-4456-b59c-e07b4d16d7a3]  -> query: {"sortby":"score"} 
2022-09-12 10:15:27.001  INFO  [ACCESS_LOG:b995f7d9-9147-4456-b59c-e07b4d16d7a3]  -> params: {"uuid":"9d086934-3156-4e22-8faa-10f52ce1eefa"} 
2022-09-12 10:15:27.002  INFO  [ACCESS_LOG:b995f7d9-9147-4456-b59c-e07b4d16d7a3] <-- status: 200 -- size: 85.2kb 
2022-09-12 10:15:27.002  INFO  [ACCESS_LOG:b995f7d9-9147-4456-b59c-e07b4d16d7a3]  <- header: undefined 
```



## Commit Message
* 977e858 fix(serve): default value of rate limit and unnecessary content of audit logs
    - set default max to 60 in rate-limit middleware.
    - change audit-log middleware message format.
    - update test cases.
* 916da3e - chore(serve): rename `audit-log` to `access-log`
    - rename `AuditLoggingMiddleware` to `AccessLogMiddleware`.
    - rename option name from `audit-log` to `access-log`.
    - rename `AUDIT` to `ACCESS_LOG` in `getLogger` function.
* 5099cb4 0 fix(serve): make other scope logger also hidden the file path and function name.
* 18a90d7 - fix(serve): move the `AccessLogMiddleware` log after other middleware ran `next()`
* 9efb93e - chore(core): refactor logger to make all defined and non-defined logging scope both hide the function name and file path

