### PR TITLE
Fix: Missing start square bracket for empty data and get incorrect response format when request indicated

### DIFF
--- a/packages/integration-testing/src/example1/buildAndServe.spec.ts
+++ b/packages/integration-testing/src/example1/buildAndServe.spec.ts
@@ -57,18 +57,28 @@ afterEach(async () => {
   await server?.close();
 });
 
-it('Example1: Build and serve should work', async () => {
-  const builder = new VulcanBuilder(projectConfig);
-  await builder.build();
-  server = new VulcanServer(projectConfig);
-  const httpServer = (await server.start())['http'];
+it.each([
+  [
+    '436193eb-f686-4105-ad7b-b5945276c14a',
+    [
+      {
+        id: '436193eb-f686-4105-ad7b-b5945276c14a',
+        name: 'ivan',
+      },
+    ],
+  ],
+  ['2dc839e0-0f65-4dba-ac38-4eaf023d0008', []],
+])(
+  'Example1: Build and serve should work',
+  async (userId, expected) => {
+    const builder = new VulcanBuilder(projectConfig);
+    await builder.build();
+    server = new VulcanServer(projectConfig);
+    const httpServer = (await server.start())['http'];
 
-  const agent = supertest(httpServer);
-  const result = await agent.get(
-    '/api/user/436193eb-f686-4105-ad7b-b5945276c14a'
-  );
-  expect(result.body).toContainEqual({
-    id: '436193eb-f686-4105-ad7b-b5945276c14a',
-    name: 'ivan',
-  });
-}, 10000);
+    const agent = supertest(httpServer);
+    const result = await agent.get(`/api/user/${userId}`);
+    expect(JSON.stringify(result.body)).toEqual(JSON.stringify(expected));
+  },
+  10000
+);

--- a/packages/serve/src/lib/middleware/response-format/helpers.ts
+++ b/packages/serve/src/lib/middleware/response-format/helpers.ts
@@ -6,21 +6,6 @@ export type ResponseFormatterMap = {
 };
 
 /**
- * start to formatting if path is end with the format or "Accept" in the header contains the format
- * @param context koa context
- * @param format the formate name
- * @returns boolean, is received
- */
-export const isReceivedFormatRequest = (
-  context: KoaContext,
-  format: string
-) => {
-  if (context.request.path.endsWith(`.${format}`)) return true;
-  if (context.request.accepts(format)) return true;
-  return false;
-};
-
-/**
  *
  * @param context koa context
  * @param formatters the formatters which built-in and loaded extensions.
@@ -28,23 +13,37 @@ export const isReceivedFormatRequest = (
  */
 export const checkUsableFormat = ({
   context,
-  formatters,
   supportedFormats,
   defaultFormat,
 }: {
   context: KoaContext;
-  formatters: ResponseFormatterMap;
   supportedFormats: string[];
   defaultFormat: string;
 }) => {
-  for (const format of supportedFormats) {
-    if (!(format in formatters)) continue;
-    if (!isReceivedFormatRequest(context, format)) continue;
-    return format;
-  }
-  // if not found, use default format
-  if (!(defaultFormat in formatters))
-    throw new Error(`Not find implemented formatters named ${defaultFormat}`);
+  // find last matched value be format
+  const pathFormat = context.path.split('.')[1];
 
-  return defaultFormat;
+  // match result for searching in Accept header.
+  const acceptFormat = context.accepts(supportedFormats);
+
+  // if path ending has no format
+  if (!pathFormat) {
+    // get default when "Accept" header also not matched or "Accept" header not in request (shows by */*)
+    if (!acceptFormat || acceptFormat == '*/*') return defaultFormat;
+    // if accept format existed, use "Accept" first matched format by support format order
+    return acceptFormat;
+  }
+
+  // if path ending has format but not matched
+  if (!supportedFormats.includes(pathFormat)) {
+    // throw error if "Accept" header also not matched or "Accept" header not in request (shows by */*)
+    if (!acceptFormat || acceptFormat == '*/*')
+      throw new Error(
+        `Url ending format and "Accept" header both not matched in "formats" options`
+      );
+    // if accept format existed, use "Accept" first matched format by support format order
+    return acceptFormat;
+  }
+  // if path ending has format and matched, no matter Accept matched or not, use path ending format
+  return pathFormat;
 };

--- a/packages/serve/src/lib/middleware/response-format/helpers.ts
+++ b/packages/serve/src/lib/middleware/response-format/helpers.ts
@@ -36,13 +36,8 @@ export const checkUsableFormat = ({
 
   // if path ending has format but not matched
   if (!supportedFormats.includes(pathFormat)) {
-    // throw error if "Accept" header also not matched or "Accept" header not in request (shows by */*)
-    if (!acceptFormat || acceptFormat == '*/*')
-      throw new Error(
-        `Url ending format and "Accept" header both not matched in "formats" options`
-      );
-    // if accept format existed, use "Accept" first matched format by support format order
-    return acceptFormat;
+    // 415 ERROR, Throw error if user request with url ending format, but not matched.
+    throw new Error(`Url ending format not matched in "formats" options`);
   }
   // if path ending has format and matched, no matter Accept matched or not, use path ending format
   return pathFormat;

--- a/packages/serve/src/lib/middleware/response-format/middleware.ts
+++ b/packages/serve/src/lib/middleware/response-format/middleware.ts
@@ -36,10 +36,25 @@ export class ResponseFormatMiddleware extends BuiltInMiddleware<ResponseFormatOp
       },
       {}
     );
-
     this.supportedFormats = formats.map((format) => format.toLowerCase());
     this.defaultFormat = !options.default ? 'json' : options.default;
   }
+
+  public override async onActivate() {
+    if (this.enabled) {
+      if (!Object.keys(this.formatters).includes(this.defaultFormat))
+        throw new Error(
+          `The type "${this.defaultFormat}" in "default" not implement extension`
+        );
+      this.supportedFormats.map((format) => {
+        if (!Object.keys(this.formatters).includes(format))
+          throw new Error(
+            `The type "${format}" in "formats" not implement extension`
+          );
+      });
+    }
+  }
+
   public async handle(context: KoaContext, next: Next) {
     // return to skip the middleware, if disabled
     if (!this.enabled) return next();
@@ -47,7 +62,6 @@ export class ResponseFormatMiddleware extends BuiltInMiddleware<ResponseFormatOp
     // get supported and request format to use.
     const format = checkUsableFormat({
       context,
-      formatters: this.formatters,
       supportedFormats: this.supportedFormats,
       defaultFormat: this.defaultFormat,
     });

--- a/packages/serve/src/lib/response-formatter/jsonFormatter.ts
+++ b/packages/serve/src/lib/response-formatter/jsonFormatter.ts
@@ -48,6 +48,8 @@ class JsonStringTransformer extends Stream.Transform {
     callback(null);
   }
   override _final(callback: (error?: Error | null) => void) {
+    // if first is still true, means no data.
+    if (this.first) this.push(toBuffer('['));
     this.push(toBuffer(']'));
     callback(null);
   }

--- a/packages/serve/test/middlewares/built-in-middlewares/response-format/formatResponseMiddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/response-format/formatResponseMiddleware.spec.ts
@@ -1,6 +1,7 @@
 import * as sinon from 'ts-sinon';
 import { ResponseFormatMiddleware } from '@vulcan-sql/serve/middleware';
-import { KoaContext } from '@vulcan-sql/serve/models';
+import { BaseResponseFormatter } from '@vulcan-sql/serve';
+
 describe('Test format response middleware', () => {
   afterEach(() => {
     sinon.default.restore();
@@ -8,10 +9,6 @@ describe('Test format response middleware', () => {
 
   it('Test to get default json format and empty supported format when not set any config for response formatter', async () => {
     // Arrange
-    const ctx: KoaContext = {
-      ...sinon.stubInterface<KoaContext>(),
-    };
-    // Act
     const middleware = new ResponseFormatMiddleware(
       {
         enabled: false,
@@ -19,42 +16,42 @@ describe('Test format response middleware', () => {
       '',
       []
     );
-
-    await middleware.handle(ctx, async () => Promise.resolve());
-
+    // Act
+    await middleware.activate();
+    // Assert
     expect(middleware.supportedFormats).toEqual([]);
     expect(middleware.defaultFormat).toEqual('json');
   });
 
-  it('Test to get default "csv" format and empty supported format when set "default" is "csv', async () => {
-    // Arrange
-    const ctx: KoaContext = {
-      ...sinon.stubInterface<KoaContext>(),
-    };
-    // Act
-    const middleware = new ResponseFormatMiddleware(
-      {
-        enabled: false,
-        options: {
-          default: 'csv',
+  it.each([
+    ['json', 'json'],
+    ['csv', 'csv'],
+    ['hyper', 'hyper'],
+  ])(
+    'Test to get default %p format and empty supported format when set "default" is %p',
+    async (defaultVal, expected) => {
+      // Arrange
+      const middleware = new ResponseFormatMiddleware(
+        {
+          enabled: false,
+          options: {
+            default: defaultVal,
+          },
         },
-      },
-      '',
-      []
-    );
+        '',
+        []
+      );
 
-    await middleware.handle(ctx, async () => Promise.resolve());
+      // Act
+      await middleware.activate();
 
-    expect(middleware.supportedFormats).toEqual([]);
-    expect(middleware.defaultFormat).toEqual('csv');
-  });
+      expect(middleware.supportedFormats).toEqual([]);
+      expect(middleware.defaultFormat).toEqual(expected);
+    }
+  );
 
   it('Test to get ["hyper", "csv"] formats when set "formats" to ["hyper", "csv"]', async () => {
     // Arrange
-    const ctx: KoaContext = {
-      ...sinon.stubInterface<KoaContext>(),
-    };
-    // Act
     const middleware = new ResponseFormatMiddleware(
       {
         enabled: false,
@@ -66,10 +63,158 @@ describe('Test format response middleware', () => {
       []
     );
 
-    await middleware.handle(ctx, async () => Promise.resolve());
+    // Act
+    await middleware.activate();
 
     expect(middleware.supportedFormats).toEqual(['hyper', 'csv']);
     expect(middleware.defaultFormat).toEqual('json');
+  });
+
+  it('Test to throw error when default is "json" but not given default json formatter extension', async () => {
+    // Arrange
+    const expected = new Error(
+      `The type "json" in "default" not implement extension`
+    );
+
+    const middleware = new ResponseFormatMiddleware({}, '', []);
+
+    // Act
+    const activateFunc = async () => await middleware.activate();
+
+    // Assert
+    expect(activateFunc).rejects.toThrow(expected);
+  });
+
+  it.each([['json'], ['csv'], ['hyper']])(
+    'Test to throw error when default is %p but not given default %p formatter extension',
+    async (defaultVal) => {
+      // Arrange
+      const expected = new Error(
+        `The type "${defaultVal}" in "default" not implement extension`
+      );
+
+      const middleware = new ResponseFormatMiddleware(
+        {
+          options: {
+            default: defaultVal,
+          },
+        },
+        '',
+        []
+      );
+
+      // Act
+      const activateFunc = async () => await middleware.activate();
+
+      // Assert
+      expect(activateFunc).rejects.toThrow(expected);
+    }
+  );
+
+  it.each([
+    ['json', sinon.stubInterface<BaseResponseFormatter>()],
+    ['csv', sinon.stubInterface<BaseResponseFormatter>()],
+    ['hyper', sinon.stubInterface<BaseResponseFormatter>()],
+  ])(
+    'Test to success when default is %p but not given %p formatter extension',
+    async (defaultVal, formatter) => {
+      // Arrange
+      formatter.getExtensionId.returns(defaultVal);
+
+      const middleware = new ResponseFormatMiddleware(
+        {
+          options: {
+            default: defaultVal,
+          },
+        },
+        '',
+        [formatter]
+      );
+
+      // Act
+      const activateFunc = async () => await middleware.activate();
+
+      // Assert
+      expect(activateFunc).not.toThrow();
+    }
+  );
+
+  it.each([[['csv', 'hyper']], [['hyper', 'csv']]])(
+    'Test to throw error when formats are %p but not given %p formatter extension',
+    async (formatValues) => {
+      // Arrange
+      const stubJsonFormatter = sinon.stubInterface<BaseResponseFormatter>();
+      stubJsonFormatter.getExtensionId.returns('json');
+
+      const expected = new Error(
+        `The type "${formatValues[0]}" in "formats" not implement extension`
+      );
+
+      const middleware = new ResponseFormatMiddleware(
+        {
+          options: {
+            formats: formatValues,
+          },
+        },
+        '',
+        [stubJsonFormatter]
+      );
+
+      // Act
+      const activateFunc = async () => await middleware.activate();
+
+      // Assert
+      expect(activateFunc).rejects.toThrow(expected);
+    }
+  );
+  it('Test to success when formats are "[json, csv]" but not given formatter extension', async () => {
+    // Arrange
+    const stubJsonFormatter = sinon.stubInterface<BaseResponseFormatter>();
+    stubJsonFormatter.getExtensionId.returns('json');
+    const stubCsvFormatter = sinon.stubInterface<BaseResponseFormatter>();
+    stubCsvFormatter.getExtensionId.returns('csv');
+
+    const middleware = new ResponseFormatMiddleware(
+      {
+        options: {
+          formats: ['json', 'csv'],
+        },
+      },
+      '',
+      [stubJsonFormatter, stubCsvFormatter]
+    );
+
+    // Act
+    const activateFunc = async () => await middleware.activate();
+
+    // Assert
+    expect(activateFunc).not.toThrow();
+  });
+
+  it('Test to success when formats are "[csv, hyper]" but not given formatter extension', async () => {
+    // Arrange
+    const stubJsonFormatter = sinon.stubInterface<BaseResponseFormatter>();
+    stubJsonFormatter.getExtensionId.returns('json');
+    const stubCsvFormatter = sinon.stubInterface<BaseResponseFormatter>();
+    stubCsvFormatter.getExtensionId.returns('csv');
+    const stubHyperFormatter = sinon.stubInterface<BaseResponseFormatter>();
+    stubHyperFormatter.getExtensionId.returns('hyper');
+
+    const middleware = new ResponseFormatMiddleware(
+      {
+        options: {
+          formats: ['csv', 'hyper'],
+        },
+      },
+      '',
+      [stubJsonFormatter, stubCsvFormatter, stubHyperFormatter]
+    );
+
+    // Act
+    const activateFunc = async () => await middleware.activate();
+
+    // Assert
+    expect(activateFunc).not.toThrow();
   });
 
   // TODO: test handle to get context response

--- a/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
@@ -1,109 +1,28 @@
-import { Request } from 'koa';
 import * as sinon from 'ts-sinon';
-import faker from '@faker-js/faker';
-import * as responseHelpers from '@vulcan-sql/serve/middleware/response-format/helpers';
-import { BaseResponseFormatter } from '@vulcan-sql/serve';
-import {
-  checkUsableFormat,
-  isReceivedFormatRequest,
-  ResponseFormatterMap,
-} from '@vulcan-sql/serve/middleware';
-import {
-  CsvFormatter,
-  JsonFormatter,
-} from '@vulcan-sql/serve/response-formatter';
+import { checkUsableFormat } from '@vulcan-sql/serve/middleware';
 import { KoaContext } from '@vulcan-sql/serve/models';
-
-class HyperFormatter extends BaseResponseFormatter {
-  public format(): any {
-    return;
-  }
-
-  public toResponse() {
-    return;
-  }
-}
-
-it.each([
-  {
-    request: {
-      path: `${faker.internet.url()}.json`,
-      accepts: jest.fn().mockReturnValue(false),
-    },
-    format: 'json',
-    expected: true,
-  },
-  {
-    request: {
-      path: faker.internet.url(),
-      accepts: jest.fn().mockReturnValue('application/json'),
-    },
-    format: 'json',
-    expected: true,
-  },
-  {
-    request: {
-      path: `${faker.internet.url()}.json`,
-      accepts: jest.fn().mockReturnValue(false),
-    },
-    format: 'csv',
-    expected: false,
-  },
-])(
-  'Test to get $expected when call received format request with $request, format "$format"',
-  ({ request, format, expected }) => {
-    // Arrange
-    const context = {
-      ...sinon.stubInterface<KoaContext>(),
-      request: {
-        ...sinon.stubInterface<Request>(),
-        path: request.path,
-        accepts: request.accepts,
-      } as Request,
-    };
-    // Act
-    const result = isReceivedFormatRequest(context, format);
-    // Assert
-    expect(result).toEqual(expected);
-  }
-);
 
 describe('Test to call check usable format function', () => {
   afterEach(() => {
     sinon.default.restore();
   });
-  it.each([
-    {
-      defaultFormat: 'json',
-      expected: 'json',
-    },
-    {
-      defaultFormat: 'csv',
-      expected: 'csv',
-    },
-    {
-      defaultFormat: 'hyper',
-      expected: 'hyper',
-    },
-  ])(
-    'Test to get default format "$expected" when check usable format with empty support formats',
-    ({ defaultFormat, expected }) => {
+
+  it.each([['json'], ['csv'], ['hyper']])(
+    'Test to get default format %p when context path no ending format and "Accept" header not matched.',
+    (format) => {
       // Arrange
-      const input = {
-        formatters: {
-          csv: new CsvFormatter({}, 'csv'),
-          json: new JsonFormatter({}, 'json'),
-          hyper: new HyperFormatter({}, ''),
-        } as ResponseFormatterMap,
-        supportedFormats: [],
+      const expected = format;
+      const context = {
+        ...sinon.stubInterface<KoaContext>(),
+        path: '/orders',
+        accepts: jest.fn().mockReturnValue(false),
       };
 
       // Act
       const result = checkUsableFormat({
-        context: sinon.stubInterface<KoaContext>(),
-        formatters: input.formatters,
-        supportedFormats: input.supportedFormats,
-        defaultFormat,
+        context,
+        supportedFormats: [],
+        defaultFormat: format,
       });
 
       // Assert
@@ -112,66 +31,87 @@ describe('Test to call check usable format function', () => {
   );
 
   it.each([
-    {
-      defaultFormat: 'hyper',
-    },
-    {
-      defaultFormat: 'json',
-    },
+    ['json', [], 'json'],
+    ['csv', [], 'csv'],
+    ['hyper', [], 'hyper'],
   ])(
-    'Test to throw error when check usable format with empty support formats, but default format "$defaultFormat" not existed in formatters',
-    ({ defaultFormat }) => {
+    'Test to get "Accept" format %p when context path no ending format but "Accept" header matched.',
+    (format, supportedFormats, acceptFormat) => {
       // Arrange
-      const expected = new Error(
-        `Not find implemented formatters named ${defaultFormat}`
-      );
+      const expected = acceptFormat;
+      const context = {
+        ...sinon.stubInterface<KoaContext>(),
+        path: '/orders',
+        accepts: jest.fn().mockReturnValue(acceptFormat),
+      };
 
       // Act
-      const checkUsableFormatAction = () =>
+      const result = checkUsableFormat({
+        context,
+        supportedFormats,
+        defaultFormat: 'json',
+      });
+
+      // Assert
+      expect(result).toEqual(expected);
+    }
+  );
+
+  it.each([
+    ['json', [], false],
+    ['json', [], '*/*'],
+    ['json', ['csv', 'hyper'], false],
+    ['json', ['csv', 'hyper'], '*/*'],
+    ['csv', ['hyper', 'json'], false],
+    ['csv', ['hyper', 'json'], '*/*'],
+    ['hyper', ['csv', 'json'], false],
+    ['hyper', ['csv', 'json'], '*/*'],
+  ])(
+    'Test to throw error when context path ending format %p not matched and "Accept" header %p also not matched.',
+    (format, supportedFormats, acceptFormat) => {
+      // Arrange
+      const expected = new Error(
+        `Url ending format and "Accept" header both not matched in "formats" options`
+      );
+      const context = {
+        ...sinon.stubInterface<KoaContext>(),
+        path: `/orders.${format}`,
+        accepts: jest.fn().mockReturnValue(acceptFormat),
+      };
+
+      // Act
+      const checkFunc = () =>
         checkUsableFormat({
-          context: sinon.stubInterface<KoaContext>(),
-          formatters: {},
-          supportedFormats: [],
-          defaultFormat,
+          context,
+          supportedFormats,
+          defaultFormat: 'json',
         });
 
       // Assert
-      expect(checkUsableFormatAction).toThrowError(expected);
+      expect(checkFunc).toThrowError(expected);
     }
   );
 
   it.each([
-    {
-      formatters: {
-        hyper: new HyperFormatter({}, ''),
-      } as ResponseFormatterMap,
-      supportedFormats: ['csv', 'json'],
-      defaultFormat: 'hyper',
-      expected: 'hyper',
-    },
-    {
-      formatters: {
-        json: new JsonFormatter({}, 'json'),
-      } as ResponseFormatterMap,
-      supportedFormats: ['csv', 'hyper'],
-      defaultFormat: 'json',
-      expected: 'json',
-    },
+    ['json', ['csv', 'hyper'], 'csv'],
+    ['csv', ['hyper', 'json'], 'hyper'],
+    ['hyper', ['csv', 'xml'], 'xml'],
   ])(
-    'Test to get default format "$expected" when check usable format with supported formats "$supportedFormats" but formatters not matched',
-    ({ formatters, supportedFormats, defaultFormat, expected }) => {
+    'Test to get "Accept" format when context path ending format %p not matched but "Accept" header matched.',
+    (format, supportedFormats, acceptFormat) => {
       // Arrange
-
-      sinon.default
-        .stub(responseHelpers, 'isReceivedFormatRequest')
-        .returns(true);
+      const expected = acceptFormat;
+      const context = {
+        ...sinon.stubInterface<KoaContext>(),
+        path: `/orders.${format}`,
+        accepts: jest.fn().mockReturnValue(acceptFormat),
+      };
 
       // Act
       const result = checkUsableFormat({
-        context: sinon.stubInterface<KoaContext>(),
-        formatters,
+        context,
         supportedFormats,
-        defaultFormat,
+        defaultFormat: 'json',
       });
 
       // Assert
@@ -180,79 +120,54 @@ describe('Test to call check usable format function', () => {
   );
 
   it.each([
-    {
-      formatters: {
-        json: new JsonFormatter({}, 'json'),
-        hyper: new HyperFormatter({}, ''),
-      } as ResponseFormatterMap,
-      supportedFormats: ['csv', 'hyper'],
-      defaultFormat: 'json',
-      expected: 'json',
-    },
-    {
-      formatters: {
-        json: new JsonFormatter({}, 'json'),
-        hyper: new HyperFormatter({}, ''),
-      } as ResponseFormatterMap,
-      supportedFormats: ['csv', 'json'],
-      defaultFormat: 'hyper',
-      expected: 'hyper',
-    },
+    ['json', ['json', 'hyper'], false],
+    ['json', ['json', 'hyper'], '*/*'],
+    ['csv', ['json', 'csv'], false],
+    ['csv', ['json', 'csv'], '*/*'],
+    ['hyper', ['csv', 'hyper'], false],
+    ['hyper', ['csv', 'hyper'], '*/*'],
   ])(
-    'Test to get default format "$expected" when check usable format with matched formatter in supported formats "$supportedFormats" but not received format request',
-    ({ formatters, supportedFormats, defaultFormat, expected }) => {
+    'Test to get url ending format when context path ending format matched but "Accept" header not matched.',
+    (format, supportedFormats, acceptFormat) => {
       // Arrange
-
-      sinon.default
-        .stub(responseHelpers, 'isReceivedFormatRequest')
-        .returns(false);
+      const expected = format;
+      const context = {
+        ...sinon.stubInterface<KoaContext>(),
+        path: `/orders.${format}`,
+        accepts: jest.fn().mockReturnValue(acceptFormat),
+      };
 
       // Act
       const result = checkUsableFormat({
-        context: sinon.stubInterface<KoaContext>(),
-        formatters,
+        context,
         supportedFormats,
-        defaultFormat,
+        defaultFormat: 'json',
       });
 
       // Assert
       expect(result).toEqual(expected);
     }
   );
-
   it.each([
-    {
-      formatters: {
-        json: new JsonFormatter({}, ''),
-        hyper: new HyperFormatter({}, ''),
-      } as ResponseFormatterMap,
-      supportedFormats: ['csv', 'json', 'hyper'],
-      defaultFormat: 'hyper',
-      expected: 'json',
-    },
-    {
-      formatters: {
-        json: new JsonFormatter({}, ''),
-        hyper: new HyperFormatter({}, ''),
-      } as ResponseFormatterMap,
-      supportedFormats: ['csv', 'hyper', 'json'],
-      defaultFormat: 'json',
-      expected: 'hyper',
-    },
+    ['json', ['json', 'hyper'], 'hyper'],
+    ['csv', ['json', 'csv'], 'json'],
+    ['hyper', ['csv', 'hyper'], 'csv'],
   ])(
-    'Test to get format "$expected" when check usable format with matched formatter in supported formats "$supportedFormats" and received format request',
-    ({ formatters, supportedFormats, defaultFormat, expected }) => {
+    'Test to get url ending format when context path ending format matched and "Accept" header also matched.',
+    (format, supportedFormats, acceptFormat) => {
       // Arrange
-      sinon.default
-        .stub(responseHelpers, 'isReceivedFormatRequest')
-        .returns(true);
+      const expected = format;
+      const context = {
+        ...sinon.stubInterface<KoaContext>(),
+        path: `/orders.${format}`,
+        accepts: jest.fn().mockReturnValue(acceptFormat),
+      };
 
       // Act
       const result = checkUsableFormat({
-        context: sinon.stubInterface<KoaContext>(),
-        formatters,
+        context,
         supportedFormats,
-        defaultFormat,
+        defaultFormat: 'json',
       });
 
       // Assert

--- a/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
@@ -62,16 +62,19 @@ describe('Test to call check usable format function', () => {
     ['json', [], '*/*'],
     ['json', ['csv', 'hyper'], false],
     ['json', ['csv', 'hyper'], '*/*'],
+    ['json', ['csv', 'hyper'], 'csv'],
     ['csv', ['hyper', 'json'], false],
     ['csv', ['hyper', 'json'], '*/*'],
+    ['csv', ['hyper', 'json'], 'hyper'],
     ['hyper', ['csv', 'json'], false],
     ['hyper', ['csv', 'json'], '*/*'],
+    ['hyper', ['csv', 'json'], 'csv'],
   ])(
-    'Test to throw error when context path ending format %p not matched and "Accept" header %p also not matched.',
+    'Test to throw error when context path ending format %p not matched (No matter "Accept" header %p match or not).',
     (format, supportedFormats, acceptFormat) => {
       // Arrange
       const expected = new Error(
-        `Url ending format and "Accept" header both not matched in "formats" options`
+        `Url ending format not matched in "formats" options`
       );
       const context = {
         ...sinon.stubInterface<KoaContext>(),
@@ -93,67 +96,17 @@ describe('Test to call check usable format function', () => {
   );
 
   it.each([
-    ['json', ['csv', 'hyper'], 'csv'],
-    ['csv', ['hyper', 'json'], 'hyper'],
-    ['hyper', ['csv', 'xml'], 'xml'],
-  ])(
-    'Test to get "Accept" format when context path ending format %p not matched but "Accept" header matched.',
-    (format, supportedFormats, acceptFormat) => {
-      // Arrange
-      const expected = acceptFormat;
-      const context = {
-        ...sinon.stubInterface<KoaContext>(),
-        path: `/orders.${format}`,
-        accepts: jest.fn().mockReturnValue(acceptFormat),
-      };
-
-      // Act
-      const result = checkUsableFormat({
-        context,
-        supportedFormats,
-        defaultFormat: 'json',
-      });
-
-      // Assert
-      expect(result).toEqual(expected);
-    }
-  );
-
-  it.each([
     ['json', ['json', 'hyper'], false],
     ['json', ['json', 'hyper'], '*/*'],
+    ['json', ['json', 'hyper'], 'hyper'],
     ['csv', ['json', 'csv'], false],
     ['csv', ['json', 'csv'], '*/*'],
+    ['csv', ['json', 'csv'], 'json'],
     ['hyper', ['csv', 'hyper'], false],
     ['hyper', ['csv', 'hyper'], '*/*'],
-  ])(
-    'Test to get url ending format when context path ending format matched but "Accept" header not matched.',
-    (format, supportedFormats, acceptFormat) => {
-      // Arrange
-      const expected = format;
-      const context = {
-        ...sinon.stubInterface<KoaContext>(),
-        path: `/orders.${format}`,
-        accepts: jest.fn().mockReturnValue(acceptFormat),
-      };
-
-      // Act
-      const result = checkUsableFormat({
-        context,
-        supportedFormats,
-        defaultFormat: 'json',
-      });
-
-      // Assert
-      expect(result).toEqual(expected);
-    }
-  );
-  it.each([
-    ['json', ['json', 'hyper'], 'hyper'],
-    ['csv', ['json', 'csv'], 'json'],
     ['hyper', ['csv', 'hyper'], 'csv'],
   ])(
-    'Test to get url ending format when context path ending format matched and "Accept" header also matched.',
+    'Test to get url ending format when context path ending format match (No matter "Accept" header %p match or not).',
     (format, supportedFormats, acceptFormat) => {
       // Arrange
       const expected = format;

--- a/packages/serve/test/response-formatter/csv.spec.ts
+++ b/packages/serve/test/response-formatter/csv.spec.ts
@@ -49,6 +49,17 @@ describe('Test to respond to csv', () => {
   it.each([
     {
       input: {
+        data: arrayToStream([]),
+        columns: [
+          { name: 'name', type: 'varchar' },
+          { name: 'age', type: 'integer' },
+          { name: 'hobby', type: 'array' },
+        ],
+      },
+      expected: `\ufeffname,age,hobby\n`,
+    },
+    {
+      input: {
         data: arrayToStream([
           {
             column1: '5ccbe099-3647-47f6-b16a-847184dc8349',

--- a/packages/serve/test/response-formatter/json.spec.ts
+++ b/packages/serve/test/response-formatter/json.spec.ts
@@ -28,6 +28,13 @@ describe('Test to respond to json', () => {
   it.each([
     {
       input: {
+        data: arrayToStream([]),
+        columns: [],
+      },
+      expected: [],
+    },
+    {
+      input: {
         data: arrayToStream([
           {
             column1: '5ccbe099-3647-47f6-b16a-847184dc8349',


### PR DESCRIPTION
# Descriprtion
- Fix the missing start square bracket `[` for request no existing data and return empty data.
- Fix getting incorrect response format when request indicated.

## New logic for returning request format
1.  If the path ending has no format 
   - Get default when `Accept` header is also not matched or `Accept` header is not in request (shows by `*/*`)
   - If accept format existed, use `Accept` first matched format by support format order
2. If the path ending has format but is not matched
  - Throw an error not matter `Accept` match or not ( Because user indicated the format in the end of URL )
4. If the path ending has the format and match, no matter `Accept` is matched or not, use the path ending format


# Issue ticket number
closes #45 and #46

# Commit Message
* 01d0a9d - fix(serve): missing start square bracket when data is empty
     - Fix to add `[` when no data in `_final` method of `JsonStringTransformer`.
    - add empty data case in json and csv format test case.
    - add response empty data case in integration testing.
* 99b6711 - fix(serve): fix the logic for request indicated response format.
     - add to check the format in options which formatter extension loaded.
    - fix and change the check indicated format logic.
    - update test cases of `checkUsableFormat` and `ResponseFormatMiddleware`.
* ef593c5 - fix(serve): upgrade logic when url path ending format not match in response format options