### PR TITLE
Fix: Fix auth source middleware error handle issue

### DIFF
--- a/packages/serve/src/lib/middleware/auth/authSourceNormalizerMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authSourceNormalizerMiddleware.ts
@@ -64,14 +64,12 @@ export class AuthSourceNormalizerMiddleware extends BuiltInMiddleware<AuthSource
         if (found && !context.request.headers['authorization'])
           context.request.headers.authorization = credentials['Authorization'];
       }
-      await next();
-      return;
     } catch (error) {
       logger.debug(
         'normalize auth payload source failed, reason =>',
         (error as Error).message
       );
-      return next();
     }
+    await next();
   }
 }


### PR DESCRIPTION
## Description
We called the next() function twice while catching errors.
```
2022-09-22 06:21:11.094  DEBUG [SERVE] normalize auth payload source failed, reason => Url ending format not matched in "formats" options

  Error: next() called multiple times
      at dispatch (/home/goofy/projects/vulcan/node_modules/koa-compose/index.js:36:45)
      at AuthSourceNormalizerMiddleware.<anonymous> (/home/goofy/projects/vulcan/labs/playground1/node_modules/@vulcan-sql/serve/src/lib/middleware/auth/authSourceNormalizerMiddleware.js:64:24)
      at Generator.throw (<anonymous>)
      at rejected (/home/goofy/projects/vulcan/node_modules/tslib/tslib.js:116:69)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## Issue ticket number
N/A quick fix

## Additional Context
Related to #47
