### PR TITLE
Fix: Fix dependencies issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "@koa/cors": "^3.3.0",
+    "bcryptjs": "^2.4.3",
     "bytes": "^3.1.2",
     "class-validator": "^0.13.2",
     "commander": "^9.4.0",
@@ -66,7 +67,6 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "~5.18.0",
     "@typescript-eslint/parser": "~5.18.0",
-    "bcryptjs": "^2.4.3",
     "commitizen": "^4.2.5",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "~8.12.0",

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -23,5 +23,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@vulcan-sql/core": "~0.2.0-0"
+  },
+  "dependencies": {
+    "redoc": "2.0.0-rc.76"
   }
 }


### PR DESCRIPTION
## Description
The package.json of serve package missed two packages:
- redoc: because we imported it at run time only. I won't import it because we only use the bundle result, but not the source.
- bcryptjs: because we set it to dev dependencies

This PR fix these issues.

## Issue ticket number
N/A quick fix

## Additional Context
Related to #38 #26 
