### PR TITLE
Fix: Fix format error when url is not found

### DIFF
--- a/packages/serve/src/lib/middleware/response-format/middleware.ts
+++ b/packages/serve/src/lib/middleware/response-format/middleware.ts
@@ -58,6 +58,9 @@ export class ResponseFormatMiddleware extends BuiltInMiddleware<ResponseFormatOp
   public async handle(context: KoaContext, next: Next) {
     // return to skip the middleware, if disabled
     if (!this.enabled) return next();
+    // TODO: replace the hardcoded api with configurable prefix
+    // Only handle the path for Vulcan API
+    if (!context.request.path.startsWith('/api')) return next();
 
     // get supported and request format to use.
     const format = checkUsableFormat({

--- a/packages/serve/test/middlewares/built-in-middlewares/response-format/formatResponseMiddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/response-format/formatResponseMiddleware.spec.ts
@@ -1,6 +1,6 @@
 import * as sinon from 'ts-sinon';
 import { ResponseFormatMiddleware } from '@vulcan-sql/serve/middleware';
-import { BaseResponseFormatter } from '@vulcan-sql/serve';
+import { BaseResponseFormatter, KoaContext } from '@vulcan-sql/serve';
 
 describe('Test format response middleware', () => {
   afterEach(() => {
@@ -218,4 +218,17 @@ describe('Test format response middleware', () => {
   });
 
   // TODO: test handle to get context response
+
+  it('Test to do nothing with paths which are not start in /api', async () => {
+    // Arrange
+    const middleware = new ResponseFormatMiddleware({}, '', []);
+    const mockContext = sinon.stubInterface<KoaContext>();
+    mockContext.request.path = '/favicon.ico';
+    mockContext.response.body = '123';
+    // Act
+    await middleware.handle(mockContext, async () => null);
+
+    // Assert
+    expect(mockContext.response.body).toBe('123');
+  });
 });


### PR DESCRIPTION
## Description
Format middleware now only handles Vulcan APIs.

## Issue ticket number

closes #84

## Additional Context
- Hardcoding API in middleware is a temporary solution, we should use a configurable path instead.

