### PR TITLE
Feature: Throw errors with proper http code

### DIFF
--- a/packages/build/src/containers/container.ts
+++ b/packages/build/src/containers/container.ts
@@ -1,5 +1,5 @@
 import { Container as InversifyContainer } from 'inversify';
-import { Container as CoreContainer } from '@vulcan-sql/core';
+import { Container as CoreContainer, InternalError } from '@vulcan-sql/core';
 import { IBuildOptions } from '@vulcan-sql/build/models';
 import {
   documentGeneratorModule,
@@ -15,7 +15,7 @@ export class Container {
   public get<T>(type: symbol) {
     const instance = this.inversifyContainer?.get<T>(type);
     if (!instance)
-      throw new Error(`Cannot resolve ${type.toString()} in container`);
+      throw new InternalError(`Cannot resolve ${type.toString()} in container`);
     return instance;
   }
 

--- a/packages/build/src/lib/document-generator/spec-generator/oas3/oas3SpecGenerator.ts
+++ b/packages/build/src/lib/document-generator/spec-generator/oas3/oas3SpecGenerator.ts
@@ -17,6 +17,7 @@ import {
   VulcanExtensionId,
   VulcanInternalExtension,
   DocumentSpec,
+  ConfigurationError,
 } from '@vulcan-sql/core';
 import { isEmpty } from 'lodash';
 
@@ -104,7 +105,9 @@ export class OAS3SpecGenerator extends SpecGenerator<oas3.OpenAPIObject> {
       case FieldInType.QUERY:
         return 'query';
       default:
-        throw new Error(`FieldInType ${fieldInType} is not supported`);
+        throw new ConfigurationError(
+          `FieldInType ${fieldInType} is not supported`
+        );
     }
   }
 
@@ -145,7 +148,9 @@ export class OAS3SpecGenerator extends SpecGenerator<oas3.OpenAPIObject> {
       case FieldDataType.STRING:
         return 'string';
       default:
-        throw new Error(`FieldDataType ${fieldDataType} is not supported`);
+        throw new ConfigurationError(
+          `FieldDataType ${fieldDataType} is not supported`
+        );
     }
   }
 

--- a/packages/build/src/lib/schema-parser/middleware/checkProfile.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkProfile.ts
@@ -1,5 +1,10 @@
 import { RawAPISchema, SchemaParserMiddleware } from './middleware';
-import { APISchema, DataSource, TYPES as CORE_TYPES } from '@vulcan-sql/core';
+import {
+  APISchema,
+  ConfigurationError,
+  DataSource,
+  TYPES as CORE_TYPES,
+} from '@vulcan-sql/core';
 import { inject, interfaces } from 'inversify';
 
 export class CheckProfile extends SchemaParserMiddleware {
@@ -21,7 +26,7 @@ export class CheckProfile extends SchemaParserMiddleware {
     await next();
     const transformedSchemas = schemas as APISchema;
     if (!transformedSchemas.profiles)
-      throw new Error(
+      throw new ConfigurationError(
         `The profile of schema ${transformedSchemas.urlPath} is not defined`
       );
 
@@ -29,7 +34,7 @@ export class CheckProfile extends SchemaParserMiddleware {
       try {
         this.dataSourceFactory(profile);
       } catch (e: any) {
-        throw new Error(
+        throw new ConfigurationError(
           `The profile ${profile} of schema ${transformedSchemas.urlPath} is invalid: ${e?.message}`
         );
       }

--- a/packages/build/src/lib/schema-parser/middleware/checkValidator.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkValidator.ts
@@ -2,6 +2,7 @@ import { RawAPISchema, SchemaParserMiddleware } from './middleware';
 import { chain } from 'lodash';
 import {
   APISchema,
+  ConfigurationError,
   IValidatorLoader,
   TYPES as CORE_TYPES,
 } from '@vulcan-sql/core';
@@ -26,7 +27,7 @@ export class CheckValidator extends SchemaParserMiddleware {
 
     for (const validatorRequest of validators) {
       if (!validatorRequest.name) {
-        throw new Error('Validator name is required');
+        throw new ConfigurationError('Validator name is required');
       }
 
       const validator = this.validatorLoader.getValidator(

--- a/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
+++ b/packages/build/src/lib/schema-parser/middleware/responseSampler.ts
@@ -2,6 +2,7 @@ import { inject } from 'inversify';
 import { RawAPISchema, SchemaParserMiddleware } from './middleware';
 import {
   APISchema,
+  ConfigurationError,
   FieldDataType,
   ResponseProperty,
   TemplateEngine,
@@ -27,7 +28,7 @@ export class ResponseSampler extends SchemaParserMiddleware {
     const schema = rawSchema as APISchema;
     if (!schema.sample) return;
     if (!schema.sample.profile) {
-      throw new Error(
+      throw new ConfigurationError(
         `Schema ${schema.urlPath} misses the required property: sample.profile`
       );
     }

--- a/packages/build/src/lib/schema-parser/schema-reader/fileSchemaReader.ts
+++ b/packages/build/src/lib/schema-parser/schema-reader/fileSchemaReader.ts
@@ -12,6 +12,7 @@ import {
   VulcanExtensionId,
   VulcanInternalExtension,
   TYPES as CORE_TYPES,
+  ConfigurationError,
 } from '@vulcan-sql/core';
 import { inject } from 'inversify';
 import { TYPES } from '@vulcan-sql/build/containers';
@@ -36,7 +37,9 @@ export class FileSchemaReader extends SchemaReader {
 
   public async *readSchema(): AsyncGenerator<SchemaData> {
     if (!this.options?.folderPath)
-      throw new Error(`Config schema-parser.folderPath must be defined`);
+      throw new ConfigurationError(
+        `Config schema-parser.folderPath must be defined`
+      );
     const files = await this.getSchemaFilePaths();
 
     for (const file of files) {

--- a/packages/build/src/lib/schema-parser/schemaParser.ts
+++ b/packages/build/src/lib/schema-parser/schemaParser.ts
@@ -1,4 +1,8 @@
-import { APISchema, AllTemplateMetadata } from '@vulcan-sql/core';
+import {
+  APISchema,
+  AllTemplateMetadata,
+  InternalError,
+} from '@vulcan-sql/core';
 import {
   SchemaData,
   SchemaFormat,
@@ -61,7 +65,7 @@ export class SchemaParser {
           ...(yaml.load(schemaData.content) as object),
         } as RawAPISchema;
       default:
-        throw new Error(`Unsupported schema type: ${schemaData.type}`);
+        throw new InternalError(`Unsupported schema type: ${schemaData.type}`);
     }
   }
 }

--- a/packages/build/src/options/schemaParser.ts
+++ b/packages/build/src/options/schemaParser.ts
@@ -5,6 +5,7 @@ import {
   SchemaReaderType,
 } from '@vulcan-sql/build/models';
 import { IsOptional, IsString, validateSync } from 'class-validator';
+import { ConfigurationError } from '@vulcan-sql/core';
 
 @injectable()
 export class SchemaParserOptions implements ISchemaParserOptions {
@@ -23,7 +24,9 @@ export class SchemaParserOptions implements ISchemaParserOptions {
     Object.assign(this, options);
     const errors = validateSync(this);
     if (errors.length > 0) {
-      throw new Error('Invalid schema parser options: ' + errors.join(', '));
+      throw new ConfigurationError(
+        'Invalid schema parser options: ' + errors.join(', ')
+      );
     }
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,7 @@ import { program } from './cli';
   } catch (e: any) {
     // Ignore error with exit code = 0, e.g. commander.helpDisplayed error
     if (e?.exitCode === 0) return;
-    logger.prettyError(e, true, false, false);
+    logger.prettyError(e, true, false, true);
     process.exit(e?.exitCode ?? 1);
   }
 })();

--- a/packages/core/src/containers/modules/executor.ts
+++ b/packages/core/src/containers/modules/executor.ts
@@ -9,6 +9,7 @@ import {
 import { Profile } from '../../models/profile';
 import 'reflect-metadata';
 import { ClassType } from '../../lib/utils/module';
+import { ConfigurationError } from '@vulcan-sql/core/utils';
 
 export const executorModule = (profiles: Map<string, Profile>) =>
   new AsyncContainerModule(async (bind) => {
@@ -23,7 +24,8 @@ export const executorModule = (profiles: Map<string, Profile>) =>
       TYPES.Factory_DataSource
     ).toFactory((context) => (profileName: string) => {
       const profile = profiles.get(profileName);
-      if (!profile) throw new Error(`Profile ${profileName} not found`);
+      if (!profile)
+        throw new ConfigurationError(`Profile ${profileName} not found`);
       return context.container.getNamed(
         TYPES.Extension_DataSource,
         profile.type

--- a/packages/core/src/lib/artifact-builder/vulcanArtifactBuilder.ts
+++ b/packages/core/src/lib/artifact-builder/vulcanArtifactBuilder.ts
@@ -3,6 +3,7 @@ import { PersistentStore } from '@vulcan-sql/core/models';
 import { Serializer } from '@vulcan-sql/core/models';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
+import { InternalError } from '../utils';
 
 @injectable()
 export class VulcanArtifactBuilder implements ArtifactBuilder {
@@ -32,7 +33,7 @@ export class VulcanArtifactBuilder implements ArtifactBuilder {
 
   public getArtifact<T = any>(key: string): T {
     const target = this.artifact[key];
-    if (!target) throw new Error(`Artifact ${key} not found`);
+    if (!target) throw new InternalError(`Artifact ${key} not found`);
     return target as T;
   }
 

--- a/packages/core/src/lib/data-query/builder/dataQueryBuilder.ts
+++ b/packages/core/src/lib/data-query/builder/dataQueryBuilder.ts
@@ -21,6 +21,7 @@ import {
   JoinOnClause,
   JoinOnClauseOperation,
 } from './joinOnClause';
+import { TemplateError } from '../../utils/errors';
 
 export enum SelectCommandType {
   SELECT = 'SELECT',
@@ -612,7 +613,7 @@ export class DataQueryBuilder implements IDataQueryBuilder {
     value: string | number | boolean | IDataQueryBuilder
   ) {
     if (!isOfComparisonOperator(operator))
-      throw new Error(`'There is no ${operator}  operator.`);
+      throw new TemplateError(`'There is no ${operator}  operator.`);
 
     this.recordWhere({
       command: null,
@@ -860,7 +861,7 @@ export class DataQueryBuilder implements IDataQueryBuilder {
   ) {
     const normalized = typeof column === 'string' ? { name: column } : column;
     if (!isOfComparisonOperator(operator))
-      throw new Error(`'There is no ${operator}  operator.`);
+      throw new TemplateError(`'There is no ${operator}  operator.`);
 
     this.recordHaving({
       command: null,

--- a/packages/core/src/lib/data-query/builder/joinOnClause.ts
+++ b/packages/core/src/lib/data-query/builder/joinOnClause.ts
@@ -1,3 +1,4 @@
+import { TemplateError } from '../../utils/errors';
 import {
   ComparisonPredicate,
   ComparisonOperator,
@@ -68,7 +69,7 @@ export class JoinOnClause implements IJoinOnClause {
 
   public on(leftColumn: string, operator: string, rightColumn: string) {
     if (!isOfComparisonOperator(operator))
-      throw new Error(`'There is no ${operator} operator.`);
+      throw new TemplateError(`'There is no ${operator} operator.`);
 
     this.recordOn({
       command: null,
@@ -79,7 +80,9 @@ export class JoinOnClause implements IJoinOnClause {
 
   public onBetween(column: string, min: number, max: number) {
     if (min > max)
-      throw new Error(`min value ${min} not smaller than max value ${max}.`);
+      throw new TemplateError(
+        `min value ${min} not smaller than max value ${max}.`
+      );
 
     this.recordOn({
       command: ComparisonPredicate.BETWEEN,

--- a/packages/core/src/lib/data-query/profile/profile-readers/localFile.ts
+++ b/packages/core/src/lib/data-query/profile/profile-readers/localFile.ts
@@ -8,6 +8,7 @@ import {
 import * as path from 'path';
 import * as fs from 'fs';
 import * as jsYAML from 'js-yaml';
+import { ConfigurationError } from '@vulcan-sql/core/utils';
 
 export interface LocalFileProfileReaderOptions {
   path: string;
@@ -18,7 +19,9 @@ export interface LocalFileProfileReaderOptions {
 export class LocalFileProfileReader extends ProfileReader {
   public async read(options: LocalFileProfileReaderOptions) {
     if (!options.path)
-      throw new Error('LocalFile profile reader needs options.path property');
+      throw new ConfigurationError(
+        'LocalFile profile reader needs options.path property'
+      );
 
     const profilePath = path.resolve(process.cwd(), options.path);
     if (!fs.existsSync(profilePath)) return [];
@@ -30,7 +33,7 @@ export class LocalFileProfileReader extends ProfileReader {
     // validate profiles
     for (const profile of profiles) {
       if (!profile.name || !profile.type)
-        throw new Error(
+        throw new ConfigurationError(
           `Invalid profile in ${profilePath}. Profile name and type are required.`
         );
     }

--- a/packages/core/src/lib/extension-loader/extensionLoader.ts
+++ b/packages/core/src/lib/extension-loader/extensionLoader.ts
@@ -1,6 +1,6 @@
 import { ExtensionBase, ICoreOptions } from '@vulcan-sql/core/models';
 import { interfaces } from 'inversify';
-import { ClassType, defaultImport } from '../utils';
+import { ClassType, defaultImport, InternalError } from '../utils';
 import {
   EXTENSION_ENFORCED_ID_METADATA_KEY,
   EXTENSION_IDENTIFIER_METADATA_KEY,
@@ -30,7 +30,7 @@ export class ExtensionLoader {
   /** Load external extensions (should be called by core package) */
   public async loadExternalExtensionModules() {
     if (this.bound)
-      throw new Error(
+      throw new InternalError(
         `We must load all extensions before call bindExtension function`
       );
 
@@ -61,7 +61,7 @@ export class ExtensionLoader {
 
   public loadInternalExtensionModule(moduleEntry: ExtensionModuleEntry) {
     if (this.bound)
-      throw new Error(
+      throw new InternalError(
         `We must load all extensions before call bindExtension function`
       );
 
@@ -70,7 +70,7 @@ export class ExtensionLoader {
     for (const extension of extensions) {
       const name = Reflect.getMetadata(EXTENSION_NAME_METADATA_KEY, extension);
       if (name === undefined)
-        throw new Error(
+        throw new InternalError(
           `Internal extension must have @VulcanInternalExtension decorator`
         );
       this.loadExtension(name, extension);
@@ -113,7 +113,7 @@ export class ExtensionLoader {
       extension
     );
     if (enforcedId && !extensionId)
-      throw new Error(
+      throw new InternalError(
         `Extension ${extension.name} needed an extension id but was not found, please use the decorator @VulcanExtensionId to set the id.`
       );
 
@@ -128,7 +128,7 @@ export class ExtensionLoader {
       extension
     );
     if (!extensionType)
-      throw new Error(
+      throw new InternalError(
         `Extension must have @VulcanExtension decorator, have you use extend the correct super class?`
       );
     if (!this.extensionRegistry.has(extensionType))

--- a/packages/core/src/lib/template-engine/built-in-extensions/custom-error/errorTagBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/custom-error/errorTagBuilder.ts
@@ -2,6 +2,7 @@ import * as nunjucks from 'nunjucks';
 import { chain } from 'lodash';
 import { METADATA_NAME } from './constants';
 import { TagBuilder, VulcanInternalExtension } from '@vulcan-sql/core/models';
+import { TemplateError } from '../../../utils/errors';
 
 interface ErrorCode {
   code: string;
@@ -39,7 +40,9 @@ export class ErrorTagBuilder extends TagBuilder {
 
       const errorCodeNode = node.args.children[0];
       if (!(errorCodeNode instanceof nunjucks.nodes.Literal))
-        throw new Error(`Expected literal, got ${errorCodeNode.typename}`);
+        throw new TemplateError(
+          `Expected literal, got ${errorCodeNode.typename}`
+        );
 
       this.errorCodes.push({
         code: errorCodeNode.value,

--- a/packages/core/src/lib/template-engine/built-in-extensions/custom-error/errorTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/custom-error/errorTagRunner.ts
@@ -3,6 +3,7 @@ import {
   TagRunnerOptions,
   VulcanInternalExtension,
 } from '@vulcan-sql/core/models';
+import { UserError } from '../../../utils/errors';
 
 @VulcanInternalExtension()
 export class ErrorTagRunner extends TagRunner {
@@ -12,6 +13,8 @@ export class ErrorTagRunner extends TagRunner {
     const message = args[0];
     const lineno = args[1];
     const colno = args[2];
-    throw new Error(`${message} at ${lineno}:${colno}`);
+    throw new UserError(String(message), {
+      description: `Error throw from template at ${lineno}:${colno}.`,
+    });
   }
 }

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/parameterizer.ts
@@ -1,4 +1,5 @@
 import { RequestParameter } from '@vulcan-sql/core/models';
+import { InternalError } from '../../../utils/errors';
 
 type PrepareParameterFuncWithoutProfile = {
   (param: Omit<RequestParameter, 'profileName'>): Promise<string>;
@@ -20,7 +21,7 @@ export class Parameterizer {
 
   public async generateIdentifier(value: any): Promise<string> {
     if (this.sealed)
-      throw new Error(
+      throw new InternalError(
         `This parameterizer has been sealed, we might use the parameterizer from a wrong request scope.`
       );
     if (this.valueToIdMapping.has(value))

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagBuilder.ts
@@ -1,6 +1,7 @@
 import * as nunjucks from 'nunjucks';
 import { FINIAL_BUILDER_NAME, METADATA_NAME } from './constants';
 import { TagBuilder, VulcanInternalExtension } from '@vulcan-sql/core/models';
+import { TemplateError } from '../../../utils/errors';
 
 interface DeclarationLocation {
   lineNo: number;
@@ -113,7 +114,7 @@ export class ReqTagBuilder extends TagBuilder {
     const variable = node.args.children[0] as nunjucks.nodes.Literal;
     if (this.variableList.has(variable.value)) {
       const previousDeclaration = this.variableList.get(variable.value);
-      throw new Error(
+      throw new TemplateError(
         `We can't declare multiple builder with same name. Duplicated name: ${variable.value} (declared at ${previousDeclaration?.lineNo}:${previousDeclaration?.colNo} and ${variable.lineno}:${variable.colno})`
       );
     }
@@ -130,14 +131,14 @@ export class ReqTagBuilder extends TagBuilder {
     if (!isMainBuilder) return;
 
     if (this.hasMainBuilder) {
-      throw new Error(`Only one main builder is allowed.`);
+      throw new TemplateError(`Only one main builder is allowed.`);
     }
     this.hasMainBuilder = true;
   }
 
   private wrapOutputWithBuilder() {
     if (!this.root) {
-      throw new Error('No root node found.');
+      throw new TemplateError('No root node found.');
     }
     const originalChildren = this.root.children;
     const args = new nunjucks.nodes.NodeList(0, 0);

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
@@ -8,6 +8,7 @@ import {
 } from '@vulcan-sql/core/models';
 import { FINIAL_BUILDER_NAME, PARAMETERIZER_VAR_NAME } from './constants';
 import { Parameterizer } from './parameterizer';
+import { InternalError } from '../../../utils/errors';
 
 @VulcanInternalExtension()
 export class ReqTagRunner extends TagRunner {
@@ -26,7 +27,7 @@ export class ReqTagRunner extends TagRunner {
   public async run({ context, args, contentArgs, metadata }: TagRunnerOptions) {
     const name = String(args[0]);
     const profileName = metadata.getProfileName();
-    if (!profileName) throw new Error(`No profile name found`);
+    if (!profileName) throw new InternalError(`No profile name found`);
 
     const parameterizer = new Parameterizer((param) =>
       this.executor.prepare({ ...param, profileName })

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/sanitizerRunner.ts
@@ -3,6 +3,7 @@ import {
   FilterRunnerTransformOptions,
   VulcanInternalExtension,
 } from '@vulcan-sql/core/models';
+import { InternalError } from '../../../utils/errors';
 import { PARAMETERIZER_VAR_NAME, SANITIZER_NAME } from './constants';
 import { Parameterizer } from './parameterizer';
 import { TemplateInput } from './templateInput';
@@ -23,7 +24,7 @@ export class SanitizerRunner extends FilterRunner {
     }
     // Parameterizer should be set by req tag runner
     const parameterizer = context.lookup<Parameterizer>(PARAMETERIZER_VAR_NAME);
-    if (!parameterizer) throw new Error(`No parameterizer found`);
+    if (!parameterizer) throw new InternalError(`No parameterizer found`);
     return await input.parameterize(parameterizer);
   }
 }

--- a/packages/core/src/lib/template-engine/built-in-extensions/validator/parametersChecker.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/validator/parametersChecker.ts
@@ -4,6 +4,7 @@ import {
 } from '@vulcan-sql/core/models';
 import { chain } from 'lodash';
 import * as nunjucks from 'nunjucks';
+import { InternalError } from '@vulcan-sql/core/utils';
 import {
   LOOK_UP_PARAMETER,
   PARAMETER_METADATA_NAME,
@@ -29,7 +30,7 @@ export class ParametersChecker extends CompileTimeExtension {
       while (parent) {
         depth++;
         if (depth > REFERENCE_SEARCH_MAX_DEPTH) {
-          throw new Error('Max depth reached');
+          throw new InternalError('Max depth reached');
         }
         if (parent instanceof nunjucks.nodes.LookupVal) {
           name = parent.val.value + '.' + name;

--- a/packages/core/src/lib/template-engine/nunjucksCompiler.ts
+++ b/packages/core/src/lib/template-engine/nunjucksCompiler.ts
@@ -24,6 +24,7 @@ import {
   DataResult,
 } from '@vulcan-sql/core/models';
 import { NunjucksExecutionMetadata } from './nunjucksExecutionMetadata';
+import { InternalError } from '../utils';
 
 @injectable()
 export class NunjucksCompiler implements Compiler {
@@ -97,7 +98,7 @@ export class NunjucksCompiler implements Compiler {
     } else if (extension instanceof CompileTimeExtension) {
       this.loadCompileTimeExtensions(extension);
     } else {
-      throw new Error(
+      throw new InternalError(
         `Extension must be of type RuntimeExtension or CompileTimeExtension`
       );
     }

--- a/packages/core/src/lib/template-engine/template-providers/fileTemplateProvider.ts
+++ b/packages/core/src/lib/template-engine/template-providers/fileTemplateProvider.ts
@@ -14,6 +14,7 @@ import {
 import { inject } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
 import { TemplateEngineOptions } from '@vulcan-sql/core/options';
+import { ConfigurationError } from '../../utils/errors';
 
 @VulcanInternalExtension()
 @VulcanExtensionId(TemplateProviderType.LocalFile)
@@ -31,7 +32,7 @@ export class FileTemplateProvider extends TemplateProvider {
 
   public async *getTemplates(): AsyncGenerator<Template> {
     if (!this.options?.folderPath)
-      throw new Error(`Config template.folderPath is required`);
+      throw new ConfigurationError(`Config template.folderPath is required`);
 
     const files = await this.getTemplateFilePaths();
 

--- a/packages/core/src/lib/template-engine/templateEngine.ts
+++ b/packages/core/src/lib/template-engine/templateEngine.ts
@@ -7,6 +7,7 @@ import {
   Pagination,
   TemplateProvider,
 } from '@vulcan-sql/core/models';
+import { InternalError } from '../utils';
 
 export type AllTemplateMetadata = Record<string, TemplateMetadata>;
 
@@ -37,7 +38,7 @@ export class TemplateEngine {
 
   public async compile(): Promise<Required<PreCompiledResult>> {
     if (!this.templateProvider)
-      throw new Error('Template provider has not been initialized.');
+      throw new InternalError('Template provider has not been initialized.');
 
     await this.templateProvider!.activate?.();
 

--- a/packages/core/src/lib/utils/errors.ts
+++ b/packages/core/src/lib/utils/errors.ts
@@ -1,0 +1,73 @@
+import { asyncReqIdStorage } from './logger';
+
+export interface VulcanErrorOptions {
+  code?: string;
+  nestedError?: Error;
+  httpCode?: number;
+  exitCode?: number;
+  description?: string;
+}
+
+export class VulcanError extends Error {
+  public readonly code?: string;
+  public readonly nestedError?: Error;
+  public readonly httpCode?: number;
+  public readonly exitCode?: number;
+  public readonly description?: string;
+  public readonly requestId?: string;
+
+  constructor(message?: string, options?: VulcanErrorOptions) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = options?.code;
+    this.nestedError = options?.nestedError;
+    this.httpCode = options?.httpCode;
+    this.exitCode = options?.exitCode;
+    this.description = options?.description;
+    this.requestId = asyncReqIdStorage.getStore()?.requestId;
+  }
+}
+
+/** Expected errors, which is caused by users */
+export class UserError extends VulcanError {
+  constructor(message?: string, options?: VulcanErrorOptions) {
+    super(message, {
+      ...options,
+      httpCode: options?.httpCode || 400,
+      code: options?.code || 'vulcan.userError',
+      exitCode: options?.exitCode || 2,
+    });
+  }
+}
+
+/** Unexpected errors, which is caused by internal issues */
+export class InternalError extends VulcanError {
+  constructor(message?: string, options?: VulcanErrorOptions) {
+    super(message, {
+      ...options,
+      httpCode: options?.httpCode || 500,
+      code: options?.code || 'vulcan.internalError',
+      exitCode: options?.exitCode || 3,
+    });
+  }
+}
+
+/** The configurations e.g. vulcan.yaml, user.yaml ... are incorrect */
+export class ConfigurationError extends InternalError {
+  constructor(message?: string, options?: VulcanErrorOptions) {
+    super(message, {
+      ...options,
+      code: options?.code || 'vulcan.configError',
+    });
+  }
+}
+
+/** Error from template syntax */
+export class TemplateError extends InternalError {
+  constructor(message?: string, options?: VulcanErrorOptions) {
+    super(message, {
+      ...options,
+      code: options?.code || 'vulcan.templateError',
+    });
+  }
+}

--- a/packages/core/src/lib/utils/index.ts
+++ b/packages/core/src/lib/utils/index.ts
@@ -2,3 +2,4 @@ export * from './normalizedStringValue';
 export * from './logger';
 export * from './module';
 export * from './streams';
+export * from './errors';

--- a/packages/core/src/lib/utils/logger.ts
+++ b/packages/core/src/lib/utils/logger.ts
@@ -1,5 +1,6 @@
 import { Logger } from 'tslog';
 import { AsyncLocalStorage } from 'async_hooks';
+import { InternalError } from './errors';
 export { Logger as ILogger };
 // The category according to package name
 export enum LoggingScope {
@@ -63,7 +64,7 @@ class LoggerFactory {
     options?: LoggerOptions;
   }) {
     if (!(scopeName in LoggingScope))
-      throw new Error(
+      throw new InternalError(
         `The ${scopeName} does not belong to ${Object.keys(LoggingScope)}`
       );
     // if scope name exist in mapper and not update config

--- a/packages/core/src/lib/utils/normalizedStringValue.ts
+++ b/packages/core/src/lib/utils/normalizedStringValue.ts
@@ -1,3 +1,5 @@
+import { UserError } from './errors';
+
 export const canBeNormalized = (type: string) => {
   return (
     ['number', 'boolean', 'string', 'date'].indexOf(type.toLowerCase()) !== -1
@@ -12,11 +14,11 @@ export const normalizeStringValue = (
   switch (dataType.toLowerCase()) {
     case 'number': {
       if (value === '') {
-        throw new Error(`${dataName} must be number`);
+        throw new UserError(`${dataName} must be number`);
       }
       const valueNumber = +value;
       if (isNaN(valueNumber)) {
-        throw new Error(`${dataName} must be number`);
+        throw new UserError(`${dataName} must be number`);
       }
       return valueNumber;
     }
@@ -27,14 +29,14 @@ export const normalizeStringValue = (
       } else if (value === 'false' || value === '0') {
         return false;
       } else {
-        throw new Error(`${dataName} must be boolean`);
+        throw new UserError(`${dataName} must be boolean`);
       }
     }
 
     case 'date': {
       const parsedDate = new Date(value);
       if (Number.isNaN(parsedDate.getTime())) {
-        throw new Error(`${dataName} must be date`);
+        throw new UserError(`${dataName} must be date`);
       }
       return parsedDate;
     }

--- a/packages/core/src/lib/validators/built-in-validators/dateTypeValidator.ts
+++ b/packages/core/src/lib/validators/built-in-validators/dateTypeValidator.ts
@@ -7,6 +7,7 @@ import {
   VulcanExtensionId,
   VulcanInternalExtension,
 } from '@vulcan-sql/core/models';
+import { ConfigurationError, UserError } from '../../utils/errors';
 
 // Support custom date format -> dayjs.format(...)
 dayjs.extend(customParseFormat);
@@ -30,7 +31,7 @@ export class DateTypeValidator extends InputValidator {
       // validate arguments schema
       Joi.assert(args, this.argsValidator);
     } catch {
-      throw new Error(
+      throw new ConfigurationError(
         'The arguments schema for "date" type validator is incorrect'
       );
     }
@@ -44,6 +45,8 @@ export class DateTypeValidator extends InputValidator {
       valid = args.format ? dayjs(value, args.format, true).isValid() : valid;
     }
     if (!valid)
-      throw new Error('The input parameter is invalid, it should be date type');
+      throw new UserError(
+        'The input parameter is invalid, it should be date type'
+      );
   }
 }

--- a/packages/core/src/lib/validators/built-in-validators/integerTypeValidator.ts
+++ b/packages/core/src/lib/validators/built-in-validators/integerTypeValidator.ts
@@ -5,6 +5,7 @@ import {
 } from '@vulcan-sql/core/models';
 import * as Joi from 'joi';
 import { isUndefined } from 'lodash';
+import { ConfigurationError, UserError } from '../../utils/errors';
 
 export interface IntInputArgs {
   // The integer minimum value
@@ -33,7 +34,7 @@ export class IntegerTypeValidator extends InputValidator {
       // validate arguments schema
       Joi.assert(args, this.argsValidator);
     } catch {
-      throw new Error(
+      throw new ConfigurationError(
         'The arguments schema for "integer" type validator is incorrect'
       );
     }
@@ -56,7 +57,7 @@ export class IntegerTypeValidator extends InputValidator {
     try {
       Joi.assert(value, schema);
     } catch {
-      throw new Error(
+      throw new UserError(
         'The input parameter is invalid, it should be integer type'
       );
     }

--- a/packages/core/src/lib/validators/built-in-validators/requiredValidator.ts
+++ b/packages/core/src/lib/validators/built-in-validators/requiredValidator.ts
@@ -4,6 +4,7 @@ import {
   VulcanInternalExtension,
 } from '@vulcan-sql/core/models';
 import * as Joi from 'joi';
+import { ConfigurationError, UserError } from '../../utils/errors';
 
 export interface RequiredInputArgs {
   /**
@@ -27,7 +28,7 @@ export class RequiredValidator extends InputValidator {
       // validate arguments schema
       Joi.assert(args, this.argsValidator);
     } catch {
-      throw new Error(
+      throw new ConfigurationError(
         'The arguments schema for "required" type validator is incorrect'
       );
     }
@@ -46,7 +47,9 @@ export class RequiredValidator extends InputValidator {
       }
       Joi.assert(value, schema);
     } catch {
-      throw new Error('The input parameter is invalid, it should be required');
+      throw new UserError(
+        'The input parameter is invalid, it should be required'
+      );
     }
   }
 }

--- a/packages/core/src/lib/validators/built-in-validators/stringTypeValidator.ts
+++ b/packages/core/src/lib/validators/built-in-validators/stringTypeValidator.ts
@@ -5,6 +5,7 @@ import {
 } from '@vulcan-sql/core/models';
 import * as Joi from 'joi';
 import { isUndefined } from 'lodash';
+import { ConfigurationError, UserError } from '../../utils/errors';
 export interface StringInputArgs {
   // The string regex format pattern
   format?: string;
@@ -32,7 +33,7 @@ export class StringTypeValidator extends InputValidator {
       // validate arguments schema
       Joi.assert(args, this.argsValidator);
     } catch {
-      throw new Error(
+      throw new ConfigurationError(
         'The arguments schema for "string" type validator is incorrect'
       );
     }
@@ -55,7 +56,7 @@ export class StringTypeValidator extends InputValidator {
       // validate data value
       Joi.assert(value, schema);
     } catch {
-      throw new Error(
+      throw new UserError(
         'The input parameter is invalid, it should be string type'
       );
     }

--- a/packages/core/src/lib/validators/built-in-validators/uuidTypeValidator.ts
+++ b/packages/core/src/lib/validators/built-in-validators/uuidTypeValidator.ts
@@ -6,6 +6,7 @@ import {
 import * as Joi from 'joi';
 import { GuidVersions } from 'joi';
 import { isUndefined } from 'lodash';
+import { ConfigurationError, UserError } from '../../utils/errors';
 
 type UUIDVersion = 'uuid_v1' | 'uuid_v4' | 'uuid_v5';
 
@@ -27,7 +28,7 @@ export class UUIDTypeValidator extends InputValidator {
       // validate arguments schema
       Joi.assert(args, this.argsValidator);
     } catch {
-      throw new Error(
+      throw new ConfigurationError(
         'The arguments schema for "uuid" type validator is incorrect'
       );
     }
@@ -51,7 +52,9 @@ export class UUIDTypeValidator extends InputValidator {
       // validate data value
       Joi.assert(value, schema);
     } catch {
-      throw new Error('The input parameter is invalid, it should be uuid type');
+      throw new UserError(
+        'The input parameter is invalid, it should be uuid type'
+      );
     }
   }
 }

--- a/packages/core/src/lib/validators/constraints.ts
+++ b/packages/core/src/lib/validators/constraints.ts
@@ -1,4 +1,5 @@
 import { intersection } from 'lodash';
+import { InternalError } from '../utils';
 
 export abstract class Constraint {
   static Required() {
@@ -113,7 +114,9 @@ export class RegexConstraint extends Constraint {
   }
 
   public compose(): RegexConstraint {
-    throw new Error(`Can use multiple RegexConstraint at the same time.`);
+    throw new InternalError(
+      `Can use multiple RegexConstraint at the same time.`
+    );
   }
 }
 

--- a/packages/core/src/lib/validators/validatorLoader.ts
+++ b/packages/core/src/lib/validators/validatorLoader.ts
@@ -1,6 +1,7 @@
 import { injectable, multiInject, optional } from 'inversify';
 import { TYPES } from '../../containers/types';
 import { InputValidator } from '@vulcan-sql/core/models';
+import { ConfigurationError } from '../utils';
 
 export interface IValidatorLoader {
   getValidator(validatorName: string): InputValidator;
@@ -21,7 +22,7 @@ export class ValidatorLoader implements IValidatorLoader {
   public getValidator(validatorName: string) {
     if (!this.extensions.has(validatorName))
       // throw error if not found
-      throw new Error(
+      throw new ConfigurationError(
         `The identifier name "${validatorName}" of validator is not defined in built-in validators or extensions configuration`
       );
 
@@ -32,7 +33,7 @@ export class ValidatorLoader implements IValidatorLoader {
     for (const validator of validators) {
       const validatorName = validator.getExtensionId()!;
       if (this.extensions.has(validatorName)) {
-        throw new Error(
+        throw new ConfigurationError(
           `The identifier name "${validatorName}" of validator has been defined in other extensions`
         );
       }

--- a/packages/core/src/models/extensions/dataSource.ts
+++ b/packages/core/src/models/extensions/dataSource.ts
@@ -3,6 +3,7 @@ import { Pagination, Profile } from '@vulcan-sql/core/models';
 import { TYPES } from '@vulcan-sql/core/types';
 import { inject, multiInject, optional } from 'inversify';
 import { Readable } from 'stream';
+import { InternalError } from '../../lib/utils/errors';
 import { ExtensionBase } from './base';
 import { VulcanExtension } from './decorators';
 
@@ -68,7 +69,7 @@ export abstract class DataSource<
   protected getProfile(name: string): Profile {
     const profile = this.profiles.get(name);
     if (!profile)
-      throw new Error(
+      throw new InternalError(
         `Profile name ${name} not found in data source ${this.getExtensionId()}`
       );
     return profile;

--- a/packages/core/src/options/artifactBuilder.ts
+++ b/packages/core/src/options/artifactBuilder.ts
@@ -6,6 +6,7 @@ import {
   IArtifactBuilderOptions,
 } from '@vulcan-sql/core/models';
 import { IsString, validateSync, IsOptional } from 'class-validator';
+import { ConfigurationError } from '../lib/utils/errors';
 
 @injectable()
 export class ArtifactBuilderOptions implements IArtifactBuilderOptions {
@@ -27,7 +28,9 @@ export class ArtifactBuilderOptions implements IArtifactBuilderOptions {
     Object.assign(this, options);
     const errors = validateSync(this);
     if (errors.length > 0) {
-      throw new Error('Invalid artifact builder options: ' + errors.join(', '));
+      throw new ConfigurationError(
+        'Invalid artifact builder options: ' + errors.join(', ')
+      );
     }
   }
 }

--- a/packages/core/src/options/document.ts
+++ b/packages/core/src/options/document.ts
@@ -2,6 +2,7 @@ import { injectable, inject, optional } from 'inversify';
 import { IsOptional, IsArray, validateSync } from 'class-validator';
 import { DocumentRouterType, DocumentSpec, IDocumentOptions } from '../models';
 import { TYPES } from '@vulcan-sql/core/types';
+import { ConfigurationError } from '../lib/utils/errors';
 
 @injectable()
 export class DocumentOptions implements IDocumentOptions {
@@ -20,7 +21,7 @@ export class DocumentOptions implements IDocumentOptions {
     Object.assign(this, options);
     const errors = validateSync(this);
     if (errors.length > 0) {
-      throw new Error(
+      throw new ConfigurationError(
         'Invalid document generator options: ' + errors.join(', ')
       );
     }

--- a/packages/core/src/options/profilesLookup.ts
+++ b/packages/core/src/options/profilesLookup.ts
@@ -8,6 +8,7 @@ import {
 import * as os from 'os';
 import * as path from 'path';
 import { chain } from 'lodash';
+import { ConfigurationError } from '../lib/utils/errors';
 
 @injectable()
 export class ProfilesLookupOptions {
@@ -40,7 +41,7 @@ export class ProfilesLookupOptions {
       .uniqBy(JSON.stringify)
       .forEach((profile) => {
         if (!profile.type)
-          throw new Error(
+          throw new ConfigurationError(
             `Profile config is invalid: ${JSON.stringify(
               profile
             )}, "type" is required`

--- a/packages/core/src/options/project.ts
+++ b/packages/core/src/options/project.ts
@@ -1,6 +1,7 @@
 import { IsOptional, IsString, validateSync } from 'class-validator';
 import { inject, injectable, optional } from 'inversify';
 import { TYPES } from '../containers';
+import { ConfigurationError } from '../lib/utils/errors';
 import { ICoreOptions } from '../models';
 
 /** Root level options */
@@ -26,7 +27,9 @@ export class ProjectOptions implements Partial<ICoreOptions> {
     Object.assign(this, options);
     const errors = validateSync(this);
     if (errors.length > 0) {
-      throw new Error('Invalid root options: ' + errors.join(', '));
+      throw new ConfigurationError(
+        'Invalid root options: ' + errors.join(', ')
+      );
     }
   }
 }

--- a/packages/core/src/options/templateEngine.ts
+++ b/packages/core/src/options/templateEngine.ts
@@ -2,6 +2,7 @@ import { injectable, inject, optional } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
 import { ITemplateEngineOptions } from '@vulcan-sql/core/models';
 import { IsOptional, IsString, validateSync } from 'class-validator';
+import { ConfigurationError } from '../lib/utils/errors';
 
 @injectable()
 export class TemplateEngineOptions implements ITemplateEngineOptions {
@@ -25,7 +26,9 @@ export class TemplateEngineOptions implements ITemplateEngineOptions {
     Object.assign(this, options);
     const errors = validateSync(this);
     if (errors.length > 0) {
-      throw new Error('Invalid template engine options: ' + errors.join(', '));
+      throw new ConfigurationError(
+        'Invalid template engine options: ' + errors.join(', ')
+      );
     }
   }
 }

--- a/packages/core/test/template-engine/built-in-extensions/custom-error/custom-error.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/custom-error/custom-error.spec.ts
@@ -12,7 +12,7 @@ it('Extension should throw custom error with error code and the position while e
     executeTemplate('test', {
       name: 'World',
     })
-  ).rejects.toThrowError('This is an error at 1:3');
+  ).rejects.toThrowError('This is an error');
 });
 
 it('Extension should provide a correct error list', async () => {

--- a/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
+++ b/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
@@ -4,6 +4,7 @@ import {
   DataResult,
   DataSource,
   ExecuteOptions,
+  InternalError,
   RequestParameter,
   VulcanExtensionId,
 } from '@vulcan-sql/core';
@@ -68,7 +69,7 @@ export class DuckDBDataSource extends DataSource<any, DuckDBOptions> {
     profileName,
   }: ExecuteOptions): Promise<DataResult> {
     if (!this.dbMapping.has(profileName)) {
-      throw new Error(`Profile instance ${profileName} not found`);
+      throw new InternalError(`Profile instance ${profileName} not found`);
     }
     const { db, ...options } = this.dbMapping.get(profileName)!;
     const statement = db.prepare(sql);

--- a/packages/extension-driver-pg/src/lib/pgDataSource.ts
+++ b/packages/extension-driver-pg/src/lib/pgDataSource.ts
@@ -2,6 +2,7 @@ import {
   DataResult,
   DataSource,
   ExecuteOptions,
+  InternalError,
   RequestParameter,
   VulcanExtensionId,
 } from '@vulcan-sql/core';
@@ -48,7 +49,7 @@ export class PGDataSource extends DataSource<any, PGOptions> {
     profileName,
   }: ExecuteOptions): Promise<DataResult> {
     if (!this.poolMapping.has(profileName)) {
-      throw new Error(`Profile instance ${profileName} not found`);
+      throw new InternalError(`Profile instance ${profileName} not found`);
     }
     const { pool, options } = this.poolMapping.get(profileName)!;
     this.logger.debug(`Acquiring connection from ${profileName}`);

--- a/packages/serve/src/containers/container.ts
+++ b/packages/serve/src/containers/container.ts
@@ -1,5 +1,5 @@
 import { Container as InversifyContainer } from 'inversify';
-import { Container as CoreContainer } from '@vulcan-sql/core';
+import { Container as CoreContainer, InternalError } from '@vulcan-sql/core';
 import {
   applicationModule,
   documentRouterModule,
@@ -16,7 +16,7 @@ export class Container {
   public get<T>(type: symbol) {
     const instance = this.inversifyContainer?.get<T>(type);
     if (!instance)
-      throw new Error(`Cannot resolve ${type.toString()} in container`);
+      throw new InternalError(`Cannot resolve ${type.toString()} in container`);
     return instance;
   }
 

--- a/packages/serve/src/lib/auth/httpBasicAuthenticator.ts
+++ b/packages/serve/src/lib/auth/httpBasicAuthenticator.ts
@@ -7,7 +7,11 @@ import {
   AuthStatus,
   AuthResult,
 } from '@vulcan-sql/serve/models';
-import { VulcanExtensionId, VulcanInternalExtension } from '@vulcan-sql/core';
+import {
+  UserError,
+  VulcanExtensionId,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core';
 import { isEmpty } from 'lodash';
 import 'koa-bodyparser';
 
@@ -92,7 +96,7 @@ export class BasicAuthenticator extends BaseAuthenticator<BasicOptions> {
     const username = ctx.request.body!['username'] as string;
     const password = ctx.request.body!['password'] as string;
     if (!username || !password)
-      throw new Error('please provide "username" and "password".');
+      throw new UserError('please provide "username" and "password".');
 
     const token = Buffer.from(`${username}:${password}`).toString('base64');
 
@@ -141,7 +145,7 @@ export class BasicAuthenticator extends BaseAuthenticator<BasicOptions> {
       !(username in this.usersCredentials) ||
       !(md5(password) === this.usersCredentials[username].md5Password)
     )
-      throw new Error(
+      throw new UserError(
         `authenticate user by "${this.getExtensionId()}" type failed.`
       );
 

--- a/packages/serve/src/lib/auth/passwordFileAuthenticator.ts
+++ b/packages/serve/src/lib/auth/passwordFileAuthenticator.ts
@@ -7,7 +7,12 @@ import {
   AuthStatus,
   AuthResult,
 } from '@vulcan-sql/serve/models';
-import { VulcanExtensionId, VulcanInternalExtension } from '@vulcan-sql/core';
+import {
+  ConfigurationError,
+  UserError,
+  VulcanExtensionId,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core';
 import { isEmpty } from 'lodash';
 import 'koa-bodyparser';
 export interface PasswordFileUserOptions {
@@ -56,7 +61,9 @@ export class PasswordFileAuthenticator extends BaseAuthenticator<PasswordFileOpt
       const name = line.split(':')[0] || '';
       const bcryptPassword = line.split(':')[1] || '';
       if (!isEmpty(bcryptPassword) && !bcryptPassword.startsWith('$2y$'))
-        throw new Error(`"${this.getExtensionId()}" type must bcrypt in file.`);
+        throw new ConfigurationError(
+          `"${this.getExtensionId()}" type must bcrypt in file.`
+        );
 
       // if users exist the same name, add attr to here, or as empty
       this.usersCredentials[name] = {
@@ -70,7 +77,7 @@ export class PasswordFileAuthenticator extends BaseAuthenticator<PasswordFileOpt
     const username = ctx.request.body!['username'] as string;
     const password = ctx.request.body!['password'] as string;
     if (!username || !password)
-      throw new Error('please provide "username" and "password".');
+      throw new UserError('please provide "username" and "password".');
 
     const token = Buffer.from(`${username}:${password}`).toString('base64');
 
@@ -119,7 +126,7 @@ export class PasswordFileAuthenticator extends BaseAuthenticator<PasswordFileOpt
         this.usersCredentials[username].bcryptPassword
       )
     )
-      throw new Error(
+      throw new UserError(
         `authenticate user by "${this.getExtensionId()}" type failed.`
       );
 

--- a/packages/serve/src/lib/auth/simpleTokenAuthenticator.ts
+++ b/packages/serve/src/lib/auth/simpleTokenAuthenticator.ts
@@ -4,7 +4,11 @@ import {
   AuthResult,
   AuthStatus,
 } from '@vulcan-sql/serve/models';
-import { VulcanExtensionId, VulcanInternalExtension } from '@vulcan-sql/core';
+import {
+  UserError,
+  VulcanExtensionId,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core';
 import { isEmpty } from 'lodash';
 import 'koa-bodyparser';
 
@@ -46,7 +50,7 @@ export class SimpleTokenAuthenticator extends BaseAuthenticator<SimpleTokenOptio
 
   public async getTokenInfo(ctx: KoaContext) {
     const token = ctx.request.body!['token'] as string;
-    if (!token) throw new Error('please provide "token".');
+    if (!token) throw new UserError('please provide "token".');
 
     return {
       token: token,
@@ -82,7 +86,7 @@ export class SimpleTokenAuthenticator extends BaseAuthenticator<SimpleTokenOptio
   private async validate(token: string) {
     // if authenticated
     if (!(token in this.usersCredentials))
-      throw new Error(
+      throw new UserError(
         `authenticate user by "${this.getExtensionId()}" type failed.`
       );
 

--- a/packages/serve/src/lib/evaluator/evaluator.ts
+++ b/packages/serve/src/lib/evaluator/evaluator.ts
@@ -1,5 +1,6 @@
 import {
   getLogger,
+  InternalError,
   Profile,
   ProfileAllowConstraints,
   TYPES as CORE_TYPES,
@@ -63,7 +64,7 @@ export class Evaluator {
     for (const candidate of candidates) {
       const orConstraints = this.profiles.get(candidate);
       if (!orConstraints)
-        throw new Error(
+        throw new InternalError(
           `Profile candidate ${candidate} doesn't have any rule.`
         );
       const isQualified = this.evaluateOrConstraints(user, orConstraints);

--- a/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
@@ -1,4 +1,4 @@
-import { VulcanInternalExtension } from '@vulcan-sql/core';
+import { UserError, VulcanInternalExtension } from '@vulcan-sql/core';
 import { Next, KoaContext, AuthStatus } from '@vulcan-sql/serve/models';
 import { BaseAuthMiddleware } from './authMiddleware';
 
@@ -41,6 +41,9 @@ export class AuthCredentialsMiddleware extends BaseAuthMiddleware {
       return;
     }
 
-    throw new Error('all types of authenticator failed.');
+    throw new UserError('All types of authenticator failed.', {
+      httpCode: 401,
+      code: 'vulcan.unauthorized',
+    });
   }
 }

--- a/packages/serve/src/lib/middleware/auth/authMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authMiddleware.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash';
 import { inject, multiInject } from 'inversify';
-import { TYPES as CORE_TYPES } from '@vulcan-sql/core';
+import { ConfigurationError, TYPES as CORE_TYPES } from '@vulcan-sql/core';
 import {
   BuiltInMiddleware,
   BaseAuthenticator,
@@ -35,14 +35,14 @@ export abstract class BaseAuthMiddleware extends BuiltInMiddleware<AuthOptions> 
   public async initialize() {
     const names = Object.keys(this.authenticators);
     if (this.enabled && isEmpty(this.options)) {
-      throw new Error(
+      throw new ConfigurationError(
         `please set at least one auth type and user credential when you enable the "auth" options, currently support types: "${names}".`
       );
     }
     // check setup auth type in options also valid in authenticators
     Object.keys(this.options).map((type) => {
       if (!names.includes(type))
-        throw new Error(
+        throw new ConfigurationError(
           `The auth type "${type}" in options not supported, authenticator only supported ${names}.`
         );
     });

--- a/packages/serve/src/lib/middleware/auth/authSourceNormalizerMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authSourceNormalizerMiddleware.ts
@@ -1,4 +1,8 @@
-import { getLogger, VulcanInternalExtension } from '@vulcan-sql/core';
+import {
+  ConfigurationError,
+  getLogger,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core';
 import {
   AuthSourceOptions,
   AuthSourceTypes,
@@ -24,7 +28,7 @@ export class AuthSourceNormalizerMiddleware extends BuiltInMiddleware<AuthSource
       this.options.in = this.options.in || AuthSourceTypes.QUERY;
 
       if (!Object.keys(AuthSourceTypes).includes(this.options.in.toUpperCase()))
-        throw new Error(
+        throw new ConfigurationError(
           `The "${this.options.in}" not support, only supported: ${Object.keys(
             AuthSourceTypes
           )}`

--- a/packages/serve/src/lib/middleware/enforceHttpsMiddleware.ts
+++ b/packages/serve/src/lib/middleware/enforceHttpsMiddleware.ts
@@ -1,6 +1,6 @@
 import { isUndefined, omit } from 'lodash';
 import { inject } from 'inversify';
-import { TYPES as CORE_TYPES } from '@vulcan-sql/core';
+import { ConfigurationError, TYPES as CORE_TYPES } from '@vulcan-sql/core';
 import { VulcanInternalExtension } from '@vulcan-sql/core';
 import { BuiltInMiddleware } from '@vulcan-sql/serve/models';
 import { KoaContext, Next } from '@vulcan-sql/serve/models';
@@ -92,7 +92,7 @@ export class EnforceHttpsMiddleware extends BuiltInMiddleware<EnforceHttpsOption
     // if type is CUSTOM
     if (type === ResolverType.CUSTOM) {
       if (!rawOptions.proto)
-        throw new Error(
+        throw new ConfigurationError(
           'The "CUSTOM" type need also provide "proto" in options.'
         );
 
@@ -111,7 +111,7 @@ export class EnforceHttpsMiddleware extends BuiltInMiddleware<EnforceHttpsOption
   private checkResolverType(type: string) {
     // check incorrect type
     if (!(type.toUpperCase() in ResolverType))
-      throw new Error(
+      throw new ConfigurationError(
         `The type is incorrect, only support type in ${JSON.stringify(
           Object.keys(ResolverType)
         )}.`

--- a/packages/serve/src/lib/middleware/errorHandlerMIddleware.ts
+++ b/packages/serve/src/lib/middleware/errorHandlerMIddleware.ts
@@ -1,0 +1,40 @@
+import { BuiltInMiddleware, KoaContext, Next } from '@vulcan-sql/serve/models';
+import {
+  getLogger,
+  UserError,
+  VulcanError,
+  VulcanInternalExtension,
+  asyncReqIdStorage,
+} from '@vulcan-sql/core';
+
+@VulcanInternalExtension('error-handler')
+export class ErrorHandlerMiddleware extends BuiltInMiddleware {
+  private logger = getLogger({ scopeName: 'SERVE' });
+
+  public async handle(context: KoaContext, next: Next) {
+    if (!this.enabled) return next();
+    try {
+      await next();
+    } catch (e) {
+      this.logger.warn(e);
+      const { requestId } = asyncReqIdStorage.getStore() || {};
+      // Set status code
+      if (e instanceof VulcanError) {
+        context.response.status = e.httpCode || 500;
+      }
+      // Only set error message when this is an user error
+      if (e instanceof UserError) {
+        context.response.body = {
+          code: e.code,
+          message: e.message,
+          requestId,
+        };
+      } else {
+        context.response.body = {
+          message: 'An internal error occurred',
+          requestId,
+        };
+      }
+    }
+  }
+}

--- a/packages/serve/src/lib/middleware/index.ts
+++ b/packages/serve/src/lib/middleware/index.ts
@@ -6,6 +6,7 @@ export * from './auth';
 export * from './response-format';
 export * from './enforceHttpsMiddleware';
 export * from './docRouterMiddleware';
+export * from './errorHandlerMIddleware';
 
 import { CorsMiddleware } from './corsMiddleware';
 import {
@@ -20,13 +21,15 @@ import { ResponseFormatMiddleware } from './response-format';
 import { EnforceHttpsMiddleware } from './enforceHttpsMiddleware';
 import { ClassType, ExtensionBase } from '@vulcan-sql/core';
 import { DocRouterMiddleware } from './docRouterMiddleware';
+import { ErrorHandlerMiddleware } from './errorHandlerMIddleware';
 
 // The array is the middleware running order
 export const BuiltInRouteMiddlewares: ClassType<ExtensionBase>[] = [
+  RequestIdMiddleware,
+  ErrorHandlerMiddleware,
   AccessLogMiddleware,
   CorsMiddleware,
   EnforceHttpsMiddleware,
-  RequestIdMiddleware,
   RateLimitMiddleware,
   AuthSourceNormalizerMiddleware,
   AuthCredentialsMiddleware,

--- a/packages/serve/src/lib/middleware/response-format/helpers.ts
+++ b/packages/serve/src/lib/middleware/response-format/helpers.ts
@@ -1,3 +1,4 @@
+import { UserError } from '@vulcan-sql/core';
 import { KoaContext } from '@vulcan-sql/serve/models';
 import { BaseResponseFormatter } from '@vulcan-sql/serve/models';
 
@@ -36,8 +37,10 @@ export const checkUsableFormat = ({
 
   // if path ending has format but not matched
   if (!supportedFormats.includes(pathFormat)) {
-    // 415 ERROR, Throw error if user request with url ending format, but not matched.
-    throw new Error(`Url ending format not matched in "formats" options`);
+    // Throw error if user request with url ending format, but not matched.
+    throw new UserError(`Url ending format not matched in "formats" options`, {
+      httpCode: 415,
+    });
   }
   // if path ending has format and matched, no matter Accept matched or not, use path ending format
   return pathFormat;

--- a/packages/serve/src/lib/middleware/response-format/middleware.ts
+++ b/packages/serve/src/lib/middleware/response-format/middleware.ts
@@ -4,7 +4,7 @@ import {
   BuiltInMiddleware,
 } from '@vulcan-sql/serve/models';
 import { checkUsableFormat, ResponseFormatterMap } from './helpers';
-import { VulcanInternalExtension } from '@vulcan-sql/core';
+import { InternalError, VulcanInternalExtension } from '@vulcan-sql/core';
 import { TYPES as CORE_TYPES } from '@vulcan-sql/core';
 import { inject, multiInject } from 'inversify';
 import { TYPES } from '@vulcan-sql/serve/containers';
@@ -43,12 +43,12 @@ export class ResponseFormatMiddleware extends BuiltInMiddleware<ResponseFormatOp
   public override async onActivate() {
     if (this.enabled) {
       if (!Object.keys(this.formatters).includes(this.defaultFormat))
-        throw new Error(
+        throw new InternalError(
           `The type "${this.defaultFormat}" in "default" not implement extension`
         );
       this.supportedFormats.map((format) => {
         if (!Object.keys(this.formatters).includes(format))
-          throw new Error(
+          throw new InternalError(
             `The type "${format}" in "formats" not implement extension`
           );
       });

--- a/packages/serve/src/lib/pagination/strategy/cursorBasedStrategy.ts
+++ b/packages/serve/src/lib/pagination/strategy/cursorBasedStrategy.ts
@@ -3,6 +3,7 @@ import {
   normalizeStringValue,
   PaginationMode,
   CursorPagination,
+  UserError,
 } from '@vulcan-sql/core';
 import { PaginationStrategy } from './strategy';
 
@@ -12,7 +13,7 @@ export class CursorBasedStrategy extends PaginationStrategy<CursorPagination> {
       Object.keys(ctx.request.query).includes(field)
     );
     if (!checkFelidInQueryString)
-      throw new Error(
+      throw new UserError(
         `The ${PaginationMode.CURSOR} must provide limit and cursor in query string.`
       );
     const limitVal = ctx.request.query['limit'] as string;

--- a/packages/serve/src/lib/pagination/strategy/keysetBasedStrategy.ts
+++ b/packages/serve/src/lib/pagination/strategy/keysetBasedStrategy.ts
@@ -2,6 +2,7 @@ import {
   normalizeStringValue,
   PaginationMode,
   KeysetPagination,
+  UserError,
 } from '@vulcan-sql/core';
 import { KoaContext } from '@vulcan-sql/serve/models';
 import { PaginationStrategy } from './strategy';
@@ -14,14 +15,14 @@ export class KeysetBasedStrategy extends PaginationStrategy<KeysetPagination> {
   }
   public async transform(ctx: KoaContext) {
     if (!this.keyName)
-      throw new Error(
+      throw new UserError(
         `The keyset pagination need to set "keyName" in schema for indicate what key need to do filter.`
       );
     const checkFelidInQueryString = ['limit', this.keyName].every((field) =>
       Object.keys(ctx.request.query).includes(field)
     );
     if (!checkFelidInQueryString)
-      throw new Error(
+      throw new UserError(
         `The ${PaginationMode.KEYSET} must provide limit and key name in query string.`
       );
     const limitVal = ctx.request.query['limit'] as string;

--- a/packages/serve/src/lib/pagination/strategy/offsetBasedStrategy.ts
+++ b/packages/serve/src/lib/pagination/strategy/offsetBasedStrategy.ts
@@ -3,6 +3,7 @@ import {
   normalizeStringValue,
   PaginationMode,
   OffsetPagination,
+  UserError,
 } from '@vulcan-sql/core';
 import { PaginationStrategy } from './strategy';
 
@@ -12,7 +13,7 @@ export class OffsetBasedStrategy extends PaginationStrategy<OffsetPagination> {
       Object.keys(ctx.request.query).includes(field)
     );
     if (!checkFelidInQueryString)
-      throw new Error(
+      throw new UserError(
         `The ${PaginationMode.OFFSET} must provide limit and offset in query string.`
       );
     const limitVal = ctx.request.query['limit'] as string;

--- a/packages/serve/src/lib/response-formatter/csvFormatter.ts
+++ b/packages/serve/src/lib/response-formatter/csvFormatter.ts
@@ -2,6 +2,7 @@ import * as Stream from 'stream';
 import {
   DataColumn,
   getLogger,
+  InternalError,
   VulcanExtensionId,
   VulcanInternalExtension,
 } from '@vulcan-sql/core';
@@ -86,7 +87,7 @@ class CsvTransformer extends Stream.Transform {
 @VulcanExtensionId('csv')
 export class CsvFormatter extends BaseResponseFormatter {
   public format(data: Stream.Readable, columns?: DataColumn[]) {
-    if (!columns) throw new Error('must provide columns');
+    if (!columns) throw new InternalError('must provide columns');
     // create csv transform stream and define transform to csv way.
     const csvStream = new CsvTransformer({
       columns: columns.map((column) => column.name),
@@ -96,7 +97,7 @@ export class CsvFormatter extends BaseResponseFormatter {
       .pipe(csvStream)
       .on('error', (err) => {
         logger.warn(`read stream failed, detail error ${err}`);
-        throw new Error(
+        throw new InternalError(
           `read data in the stream for formatting to csv failed.`
         );
       })

--- a/packages/serve/src/lib/response-formatter/jsonFormatter.ts
+++ b/packages/serve/src/lib/response-formatter/jsonFormatter.ts
@@ -1,6 +1,7 @@
 import * as Stream from 'stream';
 import {
   getLogger,
+  InternalError,
   VulcanExtensionId,
   VulcanInternalExtension,
 } from '@vulcan-sql/core';
@@ -65,7 +66,7 @@ export class JsonFormatter extends BaseResponseFormatter {
       .pipe(jsonStream)
       .on('error', (err: Error) => {
         logger.warn(`read stream failed, detail error ${err}`);
-        throw new Error(
+        throw new InternalError(
           `read data in the stream for formatting to json failed.`
         );
       })

--- a/packages/serve/src/lib/route/route-component/baseRoute.ts
+++ b/packages/serve/src/lib/route/route-component/baseRoute.ts
@@ -1,5 +1,10 @@
 import { AuthUserInfo, KoaContext } from '@vulcan-sql/serve/models';
-import { APISchema, TemplateEngine, Pagination } from '@vulcan-sql/core';
+import {
+  APISchema,
+  TemplateEngine,
+  Pagination,
+  UserError,
+} from '@vulcan-sql/core';
 import { IRequestValidator } from './requestValidator';
 import { IRequestTransformer, RequestParameters } from './requestTransformer';
 import { IPaginationTransformer } from './paginationTransformer';
@@ -59,8 +64,10 @@ export abstract class BaseRoute implements IRoute {
 
     const profile = this.evaluator.evaluateProfile(user, profiles);
     if (!profile)
-      // Should be 403
-      throw new Error(`Forbidden`);
+      throw new UserError(`No profile found`, {
+        httpCode: 403,
+        code: 'vulcan.forbidden',
+      });
 
     const result = await this.templateEngine.execute(templateSource, {
       parameters: reqParams,

--- a/packages/serve/src/lib/route/route-component/paginationTransformer.ts
+++ b/packages/serve/src/lib/route/route-component/paginationTransformer.ts
@@ -1,5 +1,10 @@
 import { KoaContext } from '@vulcan-sql/serve/models';
-import { APISchema, PaginationMode, Pagination } from '@vulcan-sql/core';
+import {
+  APISchema,
+  PaginationMode,
+  Pagination,
+  ConfigurationError,
+} from '@vulcan-sql/core';
 import {
   CursorBasedStrategy,
   OffsetBasedStrategy,
@@ -21,7 +26,7 @@ export class PaginationTransformer {
 
     if (pagination) {
       if (!Object.values(PaginationMode).includes(pagination.mode))
-        throw new Error(
+        throw new ConfigurationError(
           `The pagination only support ${Object.keys(PaginationMode)}`
         );
 

--- a/packages/serve/src/lib/route/route-component/requestTransformer.ts
+++ b/packages/serve/src/lib/route/route-component/requestTransformer.ts
@@ -1,5 +1,6 @@
 import {
   APISchema,
+  ConfigurationError,
   FieldDataType,
   FieldInType,
   normalizeStringValue,
@@ -74,7 +75,9 @@ export class RequestTransformer implements IRequestTransformer {
     type: FieldDataType
   ) {
     if (!Object.values(FieldDataType).includes(type))
-      throw new Error(`The ${type} type not been implemented now.`);
+      throw new ConfigurationError(
+        `The ${type} type not been implemented now.`
+      );
 
     return RequestTransformer.convertTypeMapper[type](value, name);
   }

--- a/packages/serve/src/lib/route/routeGenerator.ts
+++ b/packages/serve/src/lib/route/routeGenerator.ts
@@ -1,5 +1,9 @@
 import { IPaginationTransformer } from '@vulcan-sql/serve/route';
-import { APISchema, TemplateEngine } from '@vulcan-sql/core';
+import {
+  APISchema,
+  ConfigurationError,
+  TemplateEngine,
+} from '@vulcan-sql/core';
 import {
   RestfulRoute,
   GraphQLRoute,
@@ -51,7 +55,9 @@ export class RouteGenerator {
 
   public async generate(apiSchema: APISchema, optionType: APIProviderType) {
     if (!(optionType in this.apiOptions))
-      throw new Error(`The API type: ${optionType} currently not provided now`);
+      throw new ConfigurationError(
+        `The API type: ${optionType} currently not provided now`
+      );
 
     return new this.apiOptions[optionType]({
       apiSchema,

--- a/packages/serve/src/lib/server.ts
+++ b/packages/serve/src/lib/server.ts
@@ -10,6 +10,8 @@ import {
   BuiltInArtifactKeys,
   APISchema,
   ArtifactBuilder,
+  InternalError,
+  ConfigurationError,
 } from '@vulcan-sql/core';
 import { Container, TYPES } from '../containers';
 import { ServeConfig, sslFileOptions } from '../models';
@@ -42,7 +44,7 @@ export class VulcanServer {
    */
   public async start() {
     if (!isEmpty(this.servers))
-      throw new Error('Server has created, please close it first.');
+      throw new InternalError('Server has created, please close it first.');
 
     // Load container
     await this.container.load(this.config);
@@ -125,7 +127,7 @@ export class VulcanServer {
   ) {
     // check ssl file
     if (!fs.existsSync(ssl.key) || !fs.existsSync(ssl.cert))
-      throw new Error(
+      throw new ConfigurationError(
         'Must need key and cert file at least when open https server.'
       );
 

--- a/packages/serve/test/middlewares/built-in-middlewares/authCredentialMiddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/authCredentialMiddleware.spec.ts
@@ -153,7 +153,7 @@ describe('Test auth credential middleware', () => {
     'Should auth successful when request match  authorization',
     async (type, authenticator) => {
       // Arrange
-      const expected = new Error('all types of authenticator failed.');
+      const expected = new Error('All types of authenticator failed.');
 
       const options = {};
 

--- a/packages/serve/test/middlewares/built-in-middlewares/errorHandlerMIddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/errorHandlerMIddleware.spec.ts
@@ -1,0 +1,63 @@
+import { InternalError, UserError } from '@vulcan-sql/core';
+import { KoaContext } from '@vulcan-sql/serve';
+import { ErrorHandlerMiddleware } from '@vulcan-sql/serve/middleware';
+import * as sinon from 'ts-sinon';
+
+describe('Test error handler middlewares', () => {
+  it('it should do nothing when disabled', async () => {
+    // Arrange
+    const middleware = new ErrorHandlerMiddleware({ enabled: false }, '');
+    const context = sinon.stubInterface<KoaContext>();
+    // Act, Assert
+    await expect(
+      middleware.handle(context, async () => {
+        throw new Error();
+      })
+    ).rejects.toThrow();
+  });
+
+  it('it should catch UserError and show error code and error message', async () => {
+    // Arrange
+    const middleware = new ErrorHandlerMiddleware({}, '');
+    const context = sinon.stubInterface<KoaContext>();
+    // Act
+    await middleware.handle(context, async () => {
+      throw new UserError('rrr', { code: 'vulcan.mock' });
+    });
+    // Assert
+    expect(context.response.body).toMatchObject({
+      code: 'vulcan.mock',
+      message: 'rrr',
+    });
+  });
+
+  it('it should catch InternalError and show error message without any further information', async () => {
+    // Arrange
+    const middleware = new ErrorHandlerMiddleware({}, '');
+    const context = sinon.stubInterface<KoaContext>();
+    // Act
+    await middleware.handle(context, async () => {
+      throw new InternalError('rrr', { code: 'vulcan.mock' });
+    });
+    // Assert
+    expect(context.response.body).toMatchObject({
+      message: 'An internal error occurred',
+    });
+    expect((context.response.body as any).code).toBeUndefined();
+  });
+
+  it('it should catch Error and show error message without any further information', async () => {
+    // Arrange
+    const middleware = new ErrorHandlerMiddleware({}, '');
+    const context = sinon.stubInterface<KoaContext>();
+    // Act
+    await middleware.handle(context, async () => {
+      throw new Error('rrr');
+    });
+    // Assert
+    expect(context.response.body).toMatchObject({
+      message: 'An internal error occurred',
+    });
+    expect((context.response.body as any).code).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description
1. Custom errors
    I've created 4 errors for us:
    ```ts
    /** Expected errors, which is caused by users */
    export class UserError extends VulcanError {
      constructor(message?: string, options?: VulcanErrorOptions) {
        super(message, {
          ...options,
          httpCode: options?.httpCode || 400,
          code: options?.code || 'vulcan.userError',
          exitCode: options?.exitCode || 2,
        });
      }
    }
    
    /** Unexpected errors, which is caused by internal issues */
    export class InternalError extends VulcanError {
      constructor(message?: string, options?: VulcanErrorOptions) {
        super(message, {
          ...options,
          httpCode: options?.httpCode || 500,
          code: options?.code || 'vulcan.internalError',
          exitCode: options?.exitCode || 3,
        });
      }
    }
    
    /** The configurations e.g. vulcan.yaml, user.yaml ... are incorrect */
    export class ConfigurationError extends InternalError {
      constructor(message?: string, options?: VulcanErrorOptions) {
        super(message, {
          ...options,
          code: options?.code || 'vulcan.configError',
        });
      }
    }
    
    /** Error from template syntax */
    export class TemplateError extends InternalError {
      constructor(message?: string, options?: VulcanErrorOptions) {
        super(message, {
          ...options,
          code: options?.code || 'vulcan.templateError',
        });
      }
    }
    ```
2. Catch errors and set proper HTTP code and body.
3. Corrected the order of middlewares.

## Issue ticket number

closes #61

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
