### PR TITLE
Fix: Remove serve package from dependencies list

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/build",
   "description": "VulcanSQL package for building projects",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"
@@ -22,6 +22,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@vulcan-sql/core": "~0.2.0-0"
+    "@vulcan-sql/core": "~0.2.1-0"
   }
 }

--- a/packages/build/project.json
+++ b/packages/build/project.json
@@ -64,5 +64,6 @@
       ]
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!serve"]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/cli",
   "description": "CLI tools for VulcanSQL",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "bin": {
     "vulcan": "./src/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/core",
   "description": "Core package of VulcanSQL",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"

--- a/packages/extension-dbt/package.json
+++ b/packages/extension-dbt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/extension-dbt",
   "description": "Using dbt models form VulcanSQL projects",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@vulcan-sql/core": "~0.2.0-0"
+    "@vulcan-sql/core": "~0.2.1-0"
   }
 }

--- a/packages/extension-debug-tools/package.json
+++ b/packages/extension-debug-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/extension-debug-tools",
   "description": "A collection of Vulcan extension debug tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@vulcan-sql/core": "~0.2.0-0"
+    "@vulcan-sql/core": "~0.2.1-0"
   },
   "devDependencies": {
     "@vulcan-sql/test-utility": "0.1.0-alpha.1"

--- a/packages/extension-driver-duckdb/package.json
+++ b/packages/extension-driver-duckdb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/extension-driver-duckdb",
   "description": "duckdb driver for Vulcan SQL",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@vulcan-sql/core": "~0.2.0-0"
+    "@vulcan-sql/core": "~0.2.1-0"
   }
 }

--- a/packages/extension-driver-pg/package.json
+++ b/packages/extension-driver-pg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/extension-driver-pg",
   "description": "PG driver for Vulcan SQL",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"
@@ -24,6 +24,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@vulcan-sql/core": "~0.2.0-0"
+    "@vulcan-sql/core": "~0.2.1-0"
   }
 }

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/serve",
   "description": "VulcanSQL package for serving projects",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@vulcan-sql/core": "~0.2.0-0"
+    "@vulcan-sql/core": "~0.2.1-0"
   },
   "dependencies": {
     "redoc": "2.0.0-rc.76"

--- a/packages/test-utility/package.json
+++ b/packages/test-utility/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vulcan-sql/test-utility",
   "description": "Vulcan package for extension testing",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "publishConfig": {
     "access": "public"
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@vulcan-sql/core": "~0.2.0-0"
+    "@vulcan-sql/core": "~0.2.1-0"
   }
 }


### PR DESCRIPTION
## Description

NX detects dependencies from our template js file, so we need to remove it manually.

https://github.com/Canner/vulcan-sql/blob/923605a390b71c81e7871040778362081728c0fa/packages/build/src/models/extensions/packager/assets/entry.js#L1

## Issue ticket number

N/A

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
