### PR TITLE
fix(serve, cli): fix the checking "format" field logistic in "response-formats" options

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -76,7 +76,7 @@ export const createProject = async (
     installSpinner.succeed('Initial done.');
 
     logger.info(
-      `Project has been initialized. Run "cd ${projectPath} && vulcan start" to start the server.`
+      `Project has been initialized. Set the profiles and run "cd ${projectPath} && vulcan start" to start the server.`
     );
   } catch (e) {
     installSpinner.fail();

--- a/packages/serve/src/lib/middleware/response-format/helpers.ts
+++ b/packages/serve/src/lib/middleware/response-format/helpers.ts
@@ -29,8 +29,8 @@ export const checkUsableFormat = ({
 
   // if path ending has no format
   if (!pathFormat) {
-    // Use the default when "acceptFormat" us array type, because array type only happened when "supportedFormats" is [] and "Accept" header has multiple
-    if (Array.isArray(acceptFormat)) return defaultFormat;
+    // Use the default format when "supportedFormats" is [].
+    if (supportedFormats.length === 0) return defaultFormat;
     // get default when "Accept" header also not matched or "Accept" header not in request (shows by */*)
     if (!acceptFormat || acceptFormat == '*/*') return defaultFormat;
     // if accept format existed, use "Accept" first matched format by support format order

--- a/packages/serve/src/lib/middleware/response-format/helpers.ts
+++ b/packages/serve/src/lib/middleware/response-format/helpers.ts
@@ -29,6 +29,8 @@ export const checkUsableFormat = ({
 
   // if path ending has no format
   if (!pathFormat) {
+    // Use the default when "acceptFormat" us array type, because array type only happened when "supportedFormats" is [] and "Accept" header has multiple
+    if (Array.isArray(acceptFormat)) return defaultFormat;
     // get default when "Accept" header also not matched or "Accept" header not in request (shows by */*)
     if (!acceptFormat || acceptFormat == '*/*') return defaultFormat;
     // if accept format existed, use "Accept" first matched format by support format order

--- a/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
@@ -7,15 +7,31 @@ describe('Test to call check usable format function', () => {
     sinon.default.restore();
   });
 
-  it.each([['json'], ['csv'], ['hyper']])(
+  it.each([
+    ['json', false],
+    ['csv', false],
+    ['hyper', false],
+    ['json', '*/*'],
+    ['csv', '*/*'],
+    ['hyper', '*/*'],
+    ['json', []],
+    ['csv', []],
+    ['hyper', []],
+    ['json', ['*/*']],
+    ['csv', ['*/*']],
+    ['hyper', ['*/*']],
+    ['json', ['text/html', 'application/json']],
+    ['csv', ['text/html', 'application/json']],
+    ['hyper', ['text/html', 'application/json']],
+  ])(
     'Test to get default format %p when context path no ending format and "Accept" header not matched.',
-    (format) => {
+    (format, acceptsResult) => {
       // Arrange
       const expected = format;
       const context = {
         ...sinon.stubInterface<KoaContext>(),
         path: '/orders',
-        accepts: jest.fn().mockReturnValue(false),
+        accepts: jest.fn().mockReturnValue(acceptsResult),
       };
 
       // Act
@@ -60,14 +76,18 @@ describe('Test to call check usable format function', () => {
   it.each([
     ['json', [], false],
     ['json', [], '*/*'],
+    ['json', [], ['text/html', 'application/json']],
     ['json', ['csv', 'hyper'], false],
     ['json', ['csv', 'hyper'], '*/*'],
+    ['json', ['csv', 'hyper'], ['text/html', 'application/json']],
     ['json', ['csv', 'hyper'], 'csv'],
     ['csv', ['hyper', 'json'], false],
     ['csv', ['hyper', 'json'], '*/*'],
+    ['csv', ['hyper', 'json'], ['text/html', 'application/json']],
     ['csv', ['hyper', 'json'], 'hyper'],
     ['hyper', ['csv', 'json'], false],
     ['hyper', ['csv', 'json'], '*/*'],
+    ['hyper', ['csv', 'json'], ['text/html', 'application/json']],
     ['hyper', ['csv', 'json'], 'csv'],
   ])(
     'Test to throw error when context path ending format %p not matched (No matter "Accept" header %p match or not).',
@@ -98,12 +118,15 @@ describe('Test to call check usable format function', () => {
   it.each([
     ['json', ['json', 'hyper'], false],
     ['json', ['json', 'hyper'], '*/*'],
+    ['json', ['json', 'hyper'], ['text/html', 'application/json']],
     ['json', ['json', 'hyper'], 'hyper'],
     ['csv', ['json', 'csv'], false],
     ['csv', ['json', 'csv'], '*/*'],
+    ['csv', ['json', 'csv'], ['text/html', 'application/json']],
     ['csv', ['json', 'csv'], 'json'],
     ['hyper', ['csv', 'hyper'], false],
     ['hyper', ['csv', 'hyper'], '*/*'],
+    ['hyper', ['csv', 'hyper'], ['text/html', 'application/json']],
     ['hyper', ['csv', 'hyper'], 'csv'],
   ])(
     'Test to get url ending format when context path ending format match (No matter "Accept" header %p match or not).',


### PR DESCRIPTION
## Description
- Check the array type when not set `format` field of `response-formats` options and URL does not specify format in the end.
- Update the CLI `vulcan init .` finished message

## Issue ticket number

closes #93

## Additional Context
