### PR TITLE
fix(serve): the test cases of checking useable format  fail.

### DIFF
--- a/packages/doc/docs/api-building/sql-syntax.mdx
+++ b/packages/doc/docs/api-building/sql-syntax.mdx
@@ -348,7 +348,7 @@ SELECT {% for item in array | unique(by="name") %} {{ item.name }}, {% endfor %}
 
 ### if-else expression
 
-If you would like to check the condition, you can use the `if` tag with `{% ... %}` and end loop with `{% endif %}`, you could also use **else if** by \*\*\*\*`{% elif %}` and else by `{% else %}` , below is a sample:
+If you would like to check the condition, you can use the `if` tag with `{% ... %}` and end loop with `{% endif %}`, you could also use **else if** by `{% elif %}` and else by `{% else %}` , below is a sample:
 
 ```sql
 {% set gender = (context.params.gender | upper | raw) %}

--- a/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/response-format/helpers.spec.ts
@@ -47,12 +47,12 @@ describe('Test to call check usable format function', () => {
   );
 
   it.each([
-    ['json', [], 'json'],
-    ['csv', [], 'csv'],
-    ['hyper', [], 'hyper'],
+    [['json'], 'json'],
+    [['csv'], 'csv'],
+    [['hyper'], 'hyper'],
   ])(
     'Test to get "Accept" format %p when context path no ending format but "Accept" header matched.',
-    (format, supportedFormats, acceptFormat) => {
+    (formats, acceptFormat) => {
       // Arrange
       const expected = acceptFormat;
       const context = {
@@ -64,7 +64,7 @@ describe('Test to call check usable format function', () => {
       // Act
       const result = checkUsableFormat({
         context,
-        supportedFormats,
+        supportedFormats: formats,
         defaultFormat: 'json',
       });
 


### PR DESCRIPTION
## Description
Fix the test cases that fail when running the `checkUsableFormat` function in `helper.spect.ts` from PR #95.

## Issue ticket number


## Additional Context
