### PR TITLE
Fix: Catch all errors to prevent server crashes

### DIFF
--- a/packages/extension-driver-pg/src/lib/pgDataSource.ts
+++ b/packages/extension-driver-pg/src/lib/pgDataSource.ts
@@ -54,6 +54,13 @@ export class PGDataSource extends DataSource<any, PGOptions> {
     const { pool, options } = this.poolMapping.get(profileName)!;
     this.logger.debug(`Acquiring connection from ${profileName}`);
     const client = await pool.connect();
+    // listen the pg connection event errors when executing query
+    pool.on('error', (err) => {
+      //  Ignore the error and display warn message
+      this.logger.warn(
+        `Pool client of profile instance ${profileName} connecting failed, detail error, ${err}`
+      );
+    });
     this.logger.debug(`Acquired connection from ${profileName}`);
     try {
       const cursor = client.query(

--- a/packages/serve/src/lib/server.ts
+++ b/packages/serve/src/lib/server.ts
@@ -12,6 +12,7 @@ import {
   ArtifactBuilder,
   InternalError,
   ConfigurationError,
+  VulcanError,
 } from '@vulcan-sql/core';
 import { Container, TYPES } from '../containers';
 import { ServeConfig, sslFileOptions } from '../models';
@@ -87,6 +88,7 @@ export class VulcanServer {
     this.servers = this.runServer(app);
     return this.servers;
   }
+
   public async close() {
     if (this.servers) {
       if (this.servers['http']) this.servers['http'].close();
@@ -146,3 +148,12 @@ export class VulcanServer {
       .listen(httpsPort);
   }
 }
+
+// Listen the all uncaught errors (including event emitter errors) to prevent server stop.
+process.on('uncaughtException', async (err) => {
+  // Display non vulcan error
+  if (!(err instanceof VulcanError)) {
+    logger.warn('Unexpected error happened', err);
+    logger.debug('Make server keep listening');
+  }
+});

--- a/packages/serve/src/lib/server.ts
+++ b/packages/serve/src/lib/server.ts
@@ -36,6 +36,13 @@ export class VulcanServer {
     this.config = config;
     this.container = new Container();
   }
+
+  private uncaughtErrorHandler = async (err: any) => {
+    // Display non vulcan error
+    if (!(err instanceof VulcanError))
+      logger.warn('Unexpected error happened', err);
+    logger.debug('Make server keep listening');
+  };
   /**
    * Start the vulcan server. default http port is 3000, you could also change it by setting "port" under config.
    *
@@ -94,7 +101,10 @@ export class VulcanServer {
       if (this.servers['http']) this.servers['http'].close();
       if (this.servers['https']) this.servers['https'].close();
       this.servers = undefined;
+      // remove 'uncaughtException' listener
+      process.off('uncaughtException', this.uncaughtErrorHandler);
     }
+
     this.container.unload();
   }
 
@@ -109,6 +119,9 @@ export class VulcanServer {
 
     const httpPort = this.config['port'] || 3000;
     const httpServer = http.createServer(app.getHandler()).listen(httpPort);
+
+    // Listen the all uncaught errors (including event emitter errors) to prevent server stop.
+    process.on('uncaughtException', this.uncaughtErrorHandler);
 
     if (enabled && options['type'] === ResolverType.LOCAL) {
       const httpsServer = this.createHttpsServer(
@@ -148,11 +161,3 @@ export class VulcanServer {
       .listen(httpsPort);
   }
 }
-
-// Listen the all uncaught errors (including event emitter errors) to prevent server stop.
-process.on('uncaughtException', async (err) => {
-  // Display non vulcan error
-  if (!(err instanceof VulcanError))
-    logger.warn('Unexpected error happened', err);
-  logger.debug('Make server keep listening');
-});

--- a/packages/serve/src/lib/server.ts
+++ b/packages/serve/src/lib/server.ts
@@ -152,8 +152,7 @@ export class VulcanServer {
 // Listen the all uncaught errors (including event emitter errors) to prevent server stop.
 process.on('uncaughtException', async (err) => {
   // Display non vulcan error
-  if (!(err instanceof VulcanError)) {
+  if (!(err instanceof VulcanError))
     logger.warn('Unexpected error happened', err);
-    logger.debug('Make server keep listening');
-  }
+  logger.debug('Make server keep listening');
 });


### PR DESCRIPTION
## Description

- Catch all unexpected errors and keep the server still  listening
   - using `process.on('uncaughtException', (err) => {....})` to catch, including event emitter errors.
- Ignore and warn the connection failed message when executing query in pg driver

## Issue ticket number

closes #102 

## Additional Context
