### PR TITLE
Chore: Disable circleci DLC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ executors:
       # What software on the machine https://discuss.circleci.com/t/linux-machine-executor-update-2022-july-q3-update/44873
       image: ubuntu-2204:2022.07.1
       # About DLC https://circleci.com/docs/docker-layer-caching
-      docker_layer_caching: true
+      # We only build image when doing nightly builds, enabling DLC takes significant effect on billing but not on building speeds.
+      docker_layer_caching: false
     resource_class: large
 
 parameters:


### PR DESCRIPTION
## Description
Circle [Docker Layer Caching (DLC)](https://circleci.com/docs/docker-layer-caching/) used 30,000 credits this month, but it only benefits nightly build jobs, so we can disable it to save some credits.

## Issue ticket number

N/A

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
