### PR TITLE
Fix: Improve the stabilities of PostgreSQL and DuckDB drivers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "class-validator": "^0.13.2",
     "commander": "^9.4.0",
     "dayjs": "^1.11.2",
-    "duckdb": "0.4.1-dev2371.0",
+    "duckdb": "0.5.1",
     "glob": "^8.0.1",
     "inquirer": "^8.0.0",
     "inversify": "^6.0.1",

--- a/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
+++ b/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
@@ -28,9 +28,6 @@ export interface DuckDBOptions {
   'log-parameters'?: boolean;
 }
 
-/// NOTICE: We're using the dev version of duckdb nodejs client for stream data support
-/// It might contain some issues.
-
 @VulcanExtensionId('duckdb')
 export class DuckDBDataSource extends DataSource<any, DuckDBOptions> {
   private dbMapping = new Map<

--- a/packages/extension-driver-pg/test/errorHandler.spec.ts
+++ b/packages/extension-driver-pg/test/errorHandler.spec.ts
@@ -1,0 +1,87 @@
+import { PGServer } from './pgServer';
+import { PGDataSource } from '../src';
+import { streamToArray } from '@vulcan-sql/core';
+
+let pg: PGServer;
+let dataSource: PGDataSource;
+
+afterEach(async () => {
+  try {
+    if (dataSource) await dataSource.destroy();
+  } catch {
+    // ignore
+  }
+  try {
+    await pg.destroy();
+  } catch {
+    // ignore
+  }
+}, 30000);
+
+it(
+  'Data source should throw an error when executing queries on disconnected sources',
+  async () => {
+    // Arrange
+    pg = new PGServer();
+    await pg.prepare();
+    dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
+    await dataSource.activate();
+    const { getData } = await dataSource.execute({
+      statement: 'SELECT 1',
+      bindParams: new Map(),
+      profileName: 'profile1',
+      operations: {} as any,
+    });
+    // We must consume the steam or the connection won't be released.
+    await streamToArray(getData());
+    // Close the pg server
+    await pg.destroy();
+
+    // Act, Assert
+    await expect(
+      dataSource.execute({
+        statement: 'SELECT 1',
+        bindParams: new Map(),
+        profileName: 'profile1',
+        operations: {} as any,
+      })
+    ).rejects.toThrow();
+  },
+  5 * 60 * 1000
+);
+
+it(
+  'Data source should reconnect when the source was disconnected and reconnected',
+  async () => {
+    // Arrange
+    pg = new PGServer();
+    await pg.prepare();
+    dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
+    await dataSource.activate();
+    const { getData } = await dataSource.execute({
+      statement: 'SELECT 1',
+      bindParams: new Map(),
+      profileName: 'profile1',
+      operations: {} as any,
+    });
+    // We must consume the steam or the connection won't be released.
+    await streamToArray(getData());
+    // Close the pg server
+    await pg.destroy();
+    // Start the pg server again
+    await pg.prepare();
+
+    // Act
+    const { getData: getSecondData } = await dataSource.execute({
+      statement: 'SELECT 1 as a',
+      bindParams: new Map(),
+      profileName: 'profile1',
+      operations: {} as any,
+    });
+    const data = await streamToArray(getSecondData());
+
+    // Assert
+    expect(data).toEqual([{ a: 1 }]);
+  },
+  5 * 60 * 1000
+);

--- a/packages/extension-driver-pg/test/pgDataSource.spec.ts
+++ b/packages/extension-driver-pg/test/pgDataSource.spec.ts
@@ -24,20 +24,7 @@ afterAll(async () => {
 
 it('Data source should be activate without any error when all profiles are valid', async () => {
   // Arrange
-  dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
-  ]);
+  dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
   // Act, Assert
   await expect(dataSource.activate()).resolves.not.toThrow();
 });
@@ -45,18 +32,7 @@ it('Data source should be activate without any error when all profiles are valid
 it('Data source should throw error when activating if any profile is invalid', async () => {
   // Arrange
   dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
+    pg.getProfile('profile1'),
     {
       name: 'wrong-password',
       type: 'pg',
@@ -76,20 +52,7 @@ it('Data source should throw error when activating if any profile is invalid', a
 
 it('Data source should return correct rows with 2 chunks', async () => {
   // Arrange
-  dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
-  ]);
+  dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
   // Act
   const { getData } = await dataSource.execute({
@@ -105,20 +68,7 @@ it('Data source should return correct rows with 2 chunks', async () => {
 
 it('Data source should return correct rows with 1 chunk', async () => {
   // Arrange
-  dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
-  ]);
+  dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
   // Act
   const { getData } = await dataSource.execute({
@@ -134,20 +84,7 @@ it('Data source should return correct rows with 1 chunk', async () => {
 
 it('Data source should return empty data with no row', async () => {
   // Arrange
-  dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
-  ]);
+  dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
   // Act
   const { getData } = await dataSource.execute({
@@ -229,20 +166,7 @@ it('Data source should release the connection when finished no matter success or
 
 it('Data source should work with prepare statements', async () => {
   // Arrange
-  dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
-  ]);
+  dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
   // Act
   const bindParams = new Map();
@@ -273,20 +197,7 @@ it('Data source should work with prepare statements', async () => {
 
 it('Data source should return correct column types', async () => {
   // Arrange
-  dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
-  ]);
+  dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
   // Act
   const { getColumns, getData } = await dataSource.execute({
@@ -308,20 +219,7 @@ it('Data source should return correct column types', async () => {
 
 it('Data source should release connection when readable stream is destroyed', async () => {
   // Arrange
-  dataSource = new PGDataSource({}, '', [
-    {
-      name: 'profile1',
-      type: 'pg',
-      connection: {
-        host: pg.host,
-        user: pg.user,
-        password: pg.password,
-        database: pg.database,
-        port: pg.port,
-      } as PGOptions,
-      allow: '*',
-    },
-  ]);
+  dataSource = new PGDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
   // Act
   const { getData } = await dataSource.execute({

--- a/packages/extension-driver-pg/test/pgServer.ts
+++ b/packages/extension-driver-pg/test/pgServer.ts
@@ -3,6 +3,7 @@ import * as Docker from 'dockerode';
 import faker from '@faker-js/faker';
 import { Client } from 'pg';
 import * as BPromise from 'bluebird';
+import { PGOptions } from '../src/lib/pgDataSource';
 
 const docker = new Docker();
 
@@ -60,6 +61,21 @@ export class PGServer {
 
   public async destroy() {
     await this.container?.remove({ force: true });
+  }
+
+  public getProfile(name: string) {
+    return {
+      name,
+      type: 'pg',
+      connection: {
+        host: this.host,
+        user: this.user,
+        password: this.password,
+        database: this.database,
+        port: this.port,
+      } as PGOptions,
+      allow: '*',
+    };
   }
 
   private async waitPGReady() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,10 +2828,10 @@ dotenv@~10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
-duckdb@0.4.1-dev2371.0:
-  version "0.4.1-dev2371.0"
-  resolved "https://registry.yarnpkg.com/duckdb/-/duckdb-0.4.1-dev2371.0.tgz#14680c7db68da9acb6e166ee83cc02f85ec19b01"
-  integrity sha512-MS/5HlJbrbSvh6iie0TTXjRqU4vYQID6A5+sWB8axoUg8A7tPTVou7TqzJULcVq32IZwcYL8HRjyiOrjD7Rp+w==
+duckdb@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/duckdb/-/duckdb-0.5.1.tgz#265d8c20a16bb39801b388f314b2076ff5dabb68"
+  integrity sha512-4z2VeoszKPkZwtbgYmEqZngdz5tsgVvsT8eFQFgkgbyQWis0BMGEP2VhaVQFgWFl5MZW27JIQOLGI5d6GugqmA==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "*"


### PR DESCRIPTION
## Description
PG
- Remove the duplicated event register because it adds listeners for each request but never removes them.
- Fix duplicated connection pools issue.
- Add test cases for error handlers.

DuckDB
- upgrade to 0.5.1

## Issue ticket number

closes #106

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
