### PR TITLE
Fix: Improper parameterizing of variables without values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 # testing folder from cli
 my-first-vulcan-project
 test-vulcan-project*
+
+# Local configuration
+.env.local

--- a/packages/core/src/lib/data-query/parameterizer.ts
+++ b/packages/core/src/lib/data-query/parameterizer.ts
@@ -1,4 +1,5 @@
 import { RequestParameter } from '@vulcan-sql/core/models';
+import { isUndefined } from 'lodash';
 
 type PrepareParameterFuncWithoutProfile = {
   (param: Omit<RequestParameter, 'profileName'>): Promise<string>;
@@ -28,6 +29,9 @@ export class Parameterizer implements IParameterizer {
   }
 
   public async generateIdentifier(value: any): Promise<string> {
+    // If there is no value, ignore parameterization.
+    if (isUndefined(value)) return '';
+
     if (this.valueToIdMapping.has(value))
       return this.valueToIdMapping.get(value)!;
     const id = await this.prepare({

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/constants.ts
@@ -6,3 +6,4 @@ export const REFERENCE_SEARCH_MAX_DEPTH = 100;
 export const SANITIZER_NAME = 'sanitize';
 export const PARAMETERIZER_VAR_NAME = 'parameterizer';
 export const RAW_FILTER_NAME = 'raw';
+export const VOID_FILTER_NAME = 'void';

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/index.ts
@@ -6,6 +6,8 @@ import { SanitizerBuilder } from './sanitizerBuilder';
 import { SanitizerRunner } from './sanitizerRunner';
 import { RawBuilder } from './rawBuilder';
 import { RawRunner } from './rawRunner';
+import { VoidFilterBuilder } from './voidFilterBuilder';
+import { VoidFilterRunner } from './voidFIlterRunner';
 
 export default [
   ReqTagBuilder,
@@ -16,4 +18,6 @@ export default [
   SanitizerRunner,
   RawBuilder,
   RawRunner,
+  VoidFilterBuilder,
+  VoidFilterRunner,
 ];

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/voidFIlterRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/voidFIlterRunner.ts
@@ -1,0 +1,13 @@
+import { FilterRunner, VulcanInternalExtension } from '@vulcan-sql/core/models';
+import { VOID_FILTER_NAME } from './constants';
+
+@VulcanInternalExtension()
+export class VoidFilterRunner extends FilterRunner {
+  public filterName = VOID_FILTER_NAME;
+
+  public async transform(): Promise<any> {
+    // Return undefined no matter what input value is.
+    // This filter is useful when we don't we to output the result. e.g. {{ arr.push(1) | void }}
+    return undefined;
+  }
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/voidFilterBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/voidFilterBuilder.ts
@@ -1,0 +1,10 @@
+import {
+  FilterBuilder,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+import { VOID_FILTER_NAME } from './constants';
+
+@VulcanInternalExtension()
+export class VoidFilterBuilder extends FilterBuilder {
+  public filterName = VOID_FILTER_NAME;
+}

--- a/packages/core/test/template-engine/built-in-extensions/query-builder/parameterize.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/query-builder/parameterize.spec.ts
@@ -155,3 +155,19 @@ it('Raw value should be wrapped again when it is assigned to variables and is re
     [['FREDA']]
   );
 });
+
+it('Nothing should be added into binding if the value is undefined', async () => {
+  await queryTest(
+    `{{ context.params.aaaa }}{{ context.params.name }}`,
+    [`$1`],
+    [['freda']]
+  );
+});
+
+it('Nothing should be added into binding if the value had been voided', async () => {
+  await queryTest(
+    `{{ context.params.name | void }}{{ context.params.name }}`,
+    [`$1`],
+    [['freda']]
+  );
+});

--- a/packages/doc/docs/api-building/sql-syntax.mdx
+++ b/packages/doc/docs/api-building/sql-syntax.mdx
@@ -2,6 +2,9 @@
 id: sql-syntax
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # SQL Syntax
 
 With VulcanSQL, you can build the APIs with SQL written in your `.sql` files.
@@ -315,6 +318,57 @@ SELECT {{ array | unique }} # result is 1,2,3,4
 ```
 
 You could also provide an argument `by` for deciding which field/column will operate the unique filter in the list from a variable, you could see the below for-loop expression sample.
+
+### Void Filter
+
+The void filter is the VulcanSQL custom filter which takes your input data into a blackhole. It's useful when you don't want your value to become part of a SQL query. For example, `Array.push` function returns the element you pushed, so the following SQL template will fail to be executed:
+
+<Tabs>
+
+<TabItem value="template" label="SQL Template">
+
+```sql
+{% set arr = [] %}
+{{ arr.push(1) }}
+SELECT {{ arr[0] }}
+```
+
+</TabItem>
+
+<TabItem value="result" label="Result">
+
+```sql
+$1
+SELECT $1
+```
+
+</TabItem>
+
+</Tabs>
+
+You can use this filter to void the result.
+
+<Tabs>
+
+<TabItem value="template" label="SQL Template">
+
+```sql
+{% set arr = [] %}
+{{ arr.push(1) | void }}
+SELECT {{ arr[0] }}
+```
+
+</TabItem>
+
+<TabItem value="result" label="Result">
+
+```sql
+SELECT $1
+```
+
+</TabItem>
+
+</Tabs>
 
 ## Use If-else / for-loop
 


### PR DESCRIPTION
## Description
1. Ignore parameterization of undefined value.
   ```sql
   {{ context.params.somethingUndefined }} -- output nothing 
   ```
2. Add `void` filter
    ```sql
    {% set someArr = [] %}
    {{ someArr.push(1) |  void }}
    
    select {{ someArr[0] }} as a;
    ```

Document
https://vulcan-sql-document-git-fix-avoid-pa-8e149a-vulcan-sql-document.vercel.app/docs/api-building/sql-syntax#void-filter

## Issue ticket number

closes #112

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
