### PR TITLE
Feature: Dynamic data masking - custom string

### DIFF
--- a/packages/core/src/lib/template-engine/built-in-extensions/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/index.ts
@@ -2,5 +2,6 @@ import CustomError from './custom-error';
 import QueryBuilder from './query-builder';
 import SqlHelper from './sql-helper';
 import Validator from './validator';
+import Masking from './masking';
 
-export default [CustomError, QueryBuilder, SqlHelper, Validator];
+export default [CustomError, QueryBuilder, SqlHelper, Validator, Masking];

--- a/packages/core/src/lib/template-engine/built-in-extensions/masking/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/masking/index.ts
@@ -1,0 +1,4 @@
+import { MaskingTagBuilder } from './maskingTagBuilder';
+import { MaskingTagRunner } from './maskingTagRunner';
+
+export default [MaskingTagBuilder, MaskingTagRunner];

--- a/packages/core/src/lib/template-engine/built-in-extensions/masking/maskingTagBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/masking/maskingTagBuilder.ts
@@ -1,0 +1,115 @@
+import * as nunjucks from 'nunjucks';
+import { TagBuilder, VulcanInternalExtension } from '@vulcan-sql/core/models';
+import { SANITIZER_NAME } from '../query-builder/constants';
+
+@VulcanInternalExtension()
+export class MaskingTagBuilder extends TagBuilder {
+  public tags = ['masking'];
+
+  public parse(
+    parser: nunjucks.parser.Parser,
+    nodes: typeof nunjucks.nodes,
+    lexer: typeof nunjucks.lexer
+  ) {
+    // {% masking <column-name> <masking-function> %}
+    const token = parser.nextToken();
+    const columnName = parser.nextToken();
+    const functionName = parser.nextToken();
+    if (functionName.type === lexer.TOKEN_BLOCK_END) {
+      parser.fail(
+        `Expected a symbol, but got a block end`,
+        functionName.lineno,
+        functionName.colno
+      );
+    }
+
+    const argsNodeToPass = new nodes.NodeList(token.lineno, token.colno);
+    argsNodeToPass.addChild(
+      new nodes.Literal(columnName.lineno, columnName.colno, columnName.value)
+    );
+    switch (functionName.value) {
+      case 'partial': {
+        return this.parsePartial(parser, nodes, lexer, argsNodeToPass);
+      }
+
+      default:
+        parser.fail(
+          `Unknown function: ${functionName.value}`,
+          functionName.lineno,
+          functionName.colno
+        );
+    }
+  }
+
+  private parsePartial(
+    parser: nunjucks.parser.Parser,
+    nodes: typeof nunjucks.nodes,
+    lexer: typeof nunjucks.lexer,
+    argsNodeToPass: nunjucks.nodes.NodeList
+  ) {
+    const leftParen = parser.nextToken();
+    if (leftParen.type !== lexer.TOKEN_LEFT_PAREN) {
+      parser.fail(
+        `Expected a function start`,
+        leftParen.lineno,
+        leftParen.colno
+      );
+    }
+
+    const prefix = parser.parseExpression();
+    const commaOne = parser.nextToken();
+    if (commaOne.type !== lexer.TOKEN_COMMA) {
+      parser.fail(
+        `Expected a function has 3 arguments, but got 1`,
+        commaOne.lineno,
+        commaOne.colno
+      );
+    }
+
+    const padding = parser.parseExpression();
+    const commaTwo = parser.nextToken();
+    const commaCount = [commaOne, commaTwo].filter(
+      (token) => token.type === lexer.TOKEN_COMMA
+    ).length;
+    if (commaCount !== 2) {
+      parser.fail(
+        `Expected a function has 3 arguments, but got ${commaCount + 1}`,
+        commaTwo.lineno,
+        commaTwo.colno
+      );
+    }
+
+    const suffix = parser.parseExpression();
+    const rightParen = parser.nextToken();
+    if (rightParen.type !== lexer.TOKEN_RIGHT_PAREN) {
+      parser.fail(
+        `Expected a function end`,
+        rightParen.lineno,
+        rightParen.colno
+      );
+    }
+
+    parser.advanceAfterBlockEnd(rightParen.value);
+
+    argsNodeToPass.addChild(this.addSanitize(prefix));
+    argsNodeToPass.addChild(prefix);
+    argsNodeToPass.addChild(this.addSanitize(padding));
+    argsNodeToPass.addChild(this.addSanitize(suffix));
+    argsNodeToPass.addChild(suffix);
+    return this.createAsyncExtensionNode(argsNodeToPass);
+  }
+
+  private addSanitize(node: nunjucks.nodes.Node): nunjucks.nodes.Filter {
+    const filter = new nunjucks.nodes.Filter(node.lineno, node.colno);
+    filter.name = new nunjucks.nodes.Symbol(
+      node.lineno,
+      node.colno,
+      SANITIZER_NAME
+    );
+    const args = new nunjucks.nodes.NodeList(node.lineno, node.colno);
+    // The first argument is the target of the filter
+    args.addChild(node);
+    filter.args = args;
+    return filter;
+  }
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/masking/maskingTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/masking/maskingTagRunner.ts
@@ -1,0 +1,45 @@
+import * as nunjucks from 'nunjucks';
+import {
+  TagRunner,
+  TagRunnerOptions,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+import { InternalError } from '../../../utils/errors';
+
+@VulcanInternalExtension()
+export class MaskingTagRunner extends TagRunner {
+  public tags = ['masking'];
+
+  public async run({ args }: TagRunnerOptions) {
+    const columnName = args[0];
+    const prefix = args[1];
+    const prefixValue = args[2];
+    const padding = args[3];
+    const suffix = args[4];
+    const suffixValue = args[5];
+
+    if (prefixValue === undefined || suffixValue === undefined) {
+      throw new InternalError(`The parameter is invalid`);
+    }
+
+    if (typeof prefixValue !== 'number' || typeof suffixValue !== 'number') {
+      throw new InternalError(`The parameter is not number type`);
+    }
+
+    const suffixNumber = Number(suffixValue);
+    const unmaskedLength = Number(prefixValue) + suffixNumber;
+    const condition = `(length(${columnName}) > ${unmaskedLength})`;
+    const prefixSql = `substr(${columnName}, 1, ${prefix})`;
+    const pos = suffixNumber - 1;
+    const suffixSql = `substr(${columnName}, length(${columnName}) - ${pos}, ${suffix})`;
+    const result =
+      suffixNumber === 0
+        ? `concat(${prefixSql}, ${padding})`
+        : `concat(${prefixSql}, ${padding}, ${suffixSql})`;
+
+    // Consider the currently supported connector, using a general function to implement it.
+    return new nunjucks.runtime.SafeString(
+      `CASE WHEN ${condition} THEN ${result} ELSE ${padding} END`
+    );
+  }
+}

--- a/packages/core/test/template-engine/built-in-extensions/masking/masking.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/masking/masking.spec.ts
@@ -1,0 +1,249 @@
+import { createTestCompiler } from '../../testCompiler';
+
+it('Masking function that exposes the partial letters and adds a custom padding string in the middle', async () => {
+  // Arrange
+  const { compiler, loader, executeTemplate, getCreatedQueries } =
+    await createTestCompiler();
+
+  // {% masking <column-name> <masking-function> %}
+  const firstArgs = 2;
+  const thirdArgs = 3;
+  const unmaskedLength = firstArgs + thirdArgs;
+  const { compiledData } = await compiler.compile(
+    `{% masking id partial(${firstArgs}, 'xxxxxxx', ${thirdArgs}) %}`
+  );
+
+  // Action
+  loader.setSource('test', compiledData);
+  await executeTemplate('test');
+  const queries = await getCreatedQueries();
+
+  // Assert
+  const pos = thirdArgs - 1;
+  expect(queries[0]).toBe(
+    `CASE WHEN (length(id) > ${unmaskedLength}) THEN concat(substr(id, 1, $1), $2, substr(id, length(id) - ${pos}, $3)) ELSE $2 END`
+  );
+});
+
+it('Masking function that exposes part of the first few letters, should work fine', async () => {
+  // Arrange
+  const { compiler, loader, executeTemplate, getCreatedQueries } =
+    await createTestCompiler();
+
+  const firstArgs = 2;
+  const thirdArgs = 0;
+  const unmaskedLength = firstArgs + thirdArgs;
+  const { compiledData } = await compiler.compile(
+    `{% masking id partial(${firstArgs}, 'xxxxxxx', ${thirdArgs}) %}`
+  );
+
+  // Action
+  loader.setSource('test', compiledData);
+  await executeTemplate('test');
+  const queries = await getCreatedQueries();
+
+  // Assert
+  expect(queries[0]).toBe(
+    `CASE WHEN (length(id) > ${unmaskedLength}) THEN concat(substr(id, 1, $1), $2) ELSE $2 END`
+  );
+});
+
+it('Allow using set a variable for using partial masking function', async () => {
+  // Arrange
+  const { compiler, loader, executeTemplate, getCreatedQueries } =
+    await createTestCompiler();
+
+  // {% masking <column-name> <masking-function> %}
+  const firstArgs = 1;
+  const thirdArgs = 2;
+  const unmaskedLength = firstArgs + thirdArgs;
+  const { compiledData } = await compiler.compile(
+    `
+{% set suffix = 1 %}
+{% masking id partial(${firstArgs}, 'xxxxxxx', suffix + 1) %}
+`
+  );
+
+  // Action
+  loader.setSource('test', compiledData);
+  await executeTemplate('test');
+  const queries = await getCreatedQueries();
+
+  // Assert
+  const pos = thirdArgs - 1;
+  expect(queries[0]).toBe(
+    `CASE WHEN (length(id) > ${unmaskedLength}) THEN concat(substr(id, 1, $1), $2, substr(id, length(id) - ${pos}, $3)) ELSE $2 END`
+  );
+});
+
+it('If using set an invalid variable, extension should throw', async () => {
+  // Arrange
+  const { compiler, loader, executeTemplate } = await createTestCompiler();
+  const { compiledData } = await compiler.compile(
+    `
+{% set padding = 'xxxxxxx' %}
+{% masking id partial(1, 'xxxxxxx', suffix) %}
+`
+  );
+
+  // Action, Assert
+  loader.setSource('test', compiledData);
+  await expect(executeTemplate('test')).rejects.toThrow(
+    `The parameter is invalid`
+  );
+});
+
+it('Allow using set dynamic parameter for using partial masking function', async () => {
+  // Arrange
+  const {
+    compiler,
+    loader,
+    executeTemplate,
+    getCreatedQueries,
+    getCreatedBinding,
+  } = await createTestCompiler();
+
+  const padding = 'xxxxx';
+  const firstArgs = 1;
+  const thirdArgs = 2;
+  const unmaskedLength = firstArgs + thirdArgs;
+  const { compiledData } = await compiler.compile(
+    `
+{% set suffix = 1 %}
+{% masking id partial(${firstArgs}, context.params.padding, suffix + 1) %}
+`
+  );
+
+  // Action
+  loader.setSource('test', compiledData);
+  await executeTemplate('test', {
+    padding,
+  });
+  const queries = await getCreatedQueries();
+  const binding = await getCreatedBinding();
+
+  // Assert
+  const pos = thirdArgs - 1;
+  expect(queries[0]).toBe(
+    `CASE WHEN (length(id) > ${unmaskedLength}) THEN concat(substr(id, 1, $1), $2, substr(id, length(id) - ${pos}, $3)) ELSE $2 END`
+  );
+  expect(binding[0].get('$1')).toBe(firstArgs);
+  expect(binding[0].get('$2')).toBe(padding);
+  expect(binding[0].get('$3')).toBe(thirdArgs);
+});
+
+it('If an argument is not a symbol, extension should throw', async () => {
+  // Arrange
+  const { compiler } = await createTestCompiler();
+
+  // Action, Assert
+  await expect(compiler.compile(`{% masking id %}`)).rejects.toThrow(
+    `Expected a symbol, but got a block end`
+  );
+});
+
+it('If not the partial masking function, extension should throw', async () => {
+  // Arrange
+  const { compiler } = await createTestCompiler();
+
+  // Action, Assert
+  await expect(
+    compiler.compile(`{% masking id fakeFunc(2, 'xxxxxxx', 2) %}`)
+  ).rejects.toThrow(`Unknown function: fakeFunc`);
+});
+
+it('If not correct use the masking function, extension should throw', async () => {
+  // Arrange
+  const { compiler } = await createTestCompiler();
+
+  // Action, Assert
+  await expect(compiler.compile(`{% masking id partial %}`)).rejects.toThrow(
+    `Expected a function start`
+  );
+});
+
+it('Parser masking syntax position works fine', async () => {
+  const { compiler, loader, executeTemplate, getCreatedQueries } =
+    await createTestCompiler();
+
+  const { compiledData } = await compiler.compile(
+    `AA{% masking id partial(2, 'xxxxxxx', 3) %}AA`
+  );
+
+  // Action
+  loader.setSource('test', compiledData);
+  await executeTemplate('test');
+  const queries = await getCreatedQueries();
+
+  // Assert
+  expect(queries[0]).toBe(
+    `AACASE WHEN (length(id) > 5) THEN concat(substr(id, 1, $1), $2, substr(id, length(id) - 2, $3)) ELSE $2 ENDAA`
+  );
+});
+
+it('If not correct use the masking function whole syntax, the extension should throw', async () => {
+  // Arrange
+  const { compiler } = await createTestCompiler();
+
+  // Action, Assert
+  await expect(
+    compiler.compile(`{% masking id partial(2, 'xxxxxxx', 3 %}`)
+  ).rejects.toThrow(`Expected a function end`);
+});
+
+it('The toleration of spaces for masking function args, extension should work well', async () => {
+  // Arrange
+  const { compiler, loader, executeTemplate, getCreatedQueries } =
+    await createTestCompiler();
+
+  const { compiledData } = await compiler.compile(
+    `{% masking id partial(2,                'xxxxxxx'                   , 3) %}`
+  );
+
+  // Action
+  loader.setSource('test', compiledData);
+  await executeTemplate('test');
+  const queries = await getCreatedQueries();
+
+  // Assert
+  expect(queries[0]).toBe(
+    `CASE WHEN (length(id) > 5) THEN concat(substr(id, 1, $1), $2, substr(id, length(id) - 2, $3)) ELSE $2 END`
+  );
+});
+
+it('If only one argument for masking function, extension should throw', async () => {
+  // Arrange
+  const { compiler } = await createTestCompiler();
+
+  // Action, Assert
+  await expect(compiler.compile(`{% masking id partial(2) %}`)).rejects.toThrow(
+    `Expected a function has 3 arguments, but got 1`
+  );
+});
+
+it('If only two arguments for masking function, extension should throw', async () => {
+  // Arrange
+  const { compiler } = await createTestCompiler();
+
+  // Action, Assert
+  await expect(
+    compiler.compile(`{% masking id partial(2, 'xxxxxxx') %}`)
+  ).rejects.toThrow(`Expected a function has 3 arguments, but got 2`);
+});
+
+it('If an argument of the partial masking function is a string type, extension should throw', async () => {
+  // Arrange
+  const { compiler, loader, executeTemplate } = await createTestCompiler();
+
+  const firstArgs = '2';
+  const thirdArgs = '3';
+  const { compiledData } = await compiler.compile(
+    `{% masking id partial('${firstArgs}' | int , 'xxxxxxx', '${thirdArgs}' ) %}`
+  );
+
+  // Action, Assert
+  loader.setSource('test', compiledData);
+  await expect(executeTemplate('test')).rejects.toThrow(
+    `The parameter is not number type`
+  );
+});

--- a/packages/doc/docs/api-building/sql-syntax.mdx
+++ b/packages/doc/docs/api-building/sql-syntax.mdx
@@ -81,6 +81,7 @@ VulcanSQL use the [Nunjucks](https://mozilla.github.io/nunjucks/templating.html#
     - Set the dynamic parameter to the variable by `set`.
     - Define a [SQL Builder](./predefined-queries) feature.
     - Define the Main builder.
+    - Dynamic Data Masking feature by `masking` tag.
 
 In the `{% ... %}`, you could write **Python language syntax** code, because the [nunjucks](https://mozilla.github.io/nunjucks/templating.html#tags) is based on [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) and it is a Python package.
 
@@ -165,7 +166,7 @@ Below are some examples:
 {% set array = [{name: "Tom"}, {name: "Tom"}, {name: "Joy"}] %}
 ---
 # Sample 2: set dynamic parameter
-`{% set someVar = context.params.age %}
+{% set someVar = context.params.age %}
 ```
 
 ## Display the variable / dynamic parameter
@@ -369,6 +370,50 @@ SELECT $1
 </TabItem>
 
 </Tabs>
+
+## Dynamic Data Masking
+
+Dynamic Data Masking is a Column-level security feature, it could limit exposure of sensitive data.
+
+### Using `masking` tag
+
+You can use the masking tag with `{% ... %}` , the syntax like the below:
+
+```sql
+-- <masking-function> is 'partial' function
+{% masking <column-name> <masking-function> %}
+```
+
+### Using `partial` function
+
+VulcanSQL provides the `partial` masking function with a custom string, the syntax like the below:
+
+```js
+partial(prefix total number, padding, suffix total number);
+```
+
+Let's see an example, and assuming that we have a `users` table:
+
+The original data like:
+
+| id          | name    |
+| ----------- | ------- |
+| AB1234567CD | Ivan    |
+| EF2345678GH | William |
+
+```sql
+SELECT
+  {% masking id partial(2, 'xxxxxxx', 2) %} as id,
+  name
+FROM users;
+```
+
+We'll get the result below:
+
+| id          | name    |
+| ----------- | ------- |
+| ABxxxxxxxCD | Ivan    |
+| EFxxxxxxxGH | William |
 
 ## Use If-else / for-loop
 

--- a/packages/extension-driver-snowflake/test/snowflakeDataSource.spec.ts
+++ b/packages/extension-driver-snowflake/test/snowflakeDataSource.spec.ts
@@ -18,7 +18,7 @@ it('Data source should be activate without any error when all profiles are valid
   dataSource = new SnowflakeDataSource({}, '', [snow.getProfile('profile1')]);
   // Act, Assert
   await expect(dataSource.activate()).resolves.not.toThrow();
-});
+}, 10000);
 
 it('Data source should throw an error when any of profiles is invalid', async () => {
   // Arrange


### PR DESCRIPTION
## Description

I made the masking tag, and support the partial masking function.

The built-in tag `masking` is added using the following syntax:
```
{% masking <column-name> <masking-function> %}
```

For an example of SQL
```sql
SELECT
  {% masking id partial(2, 'xxxxxxx', 0) %} as id,
  name
FROM user;
```
```sql
SELECT
  {% masking id partial(2, 'xxxxxxx', 2) %} as id,
  name
FROM user;
```

## Issue ticket number

closes #139

## test (yarn run jest masking)
<img width="1179" alt="螢幕快照 2023-01-13 下午3 31 46" src="https://user-images.githubusercontent.com/42527625/212263099-eea966c6-777a-4346-8ceb-337980acc65f.png">


## Additional Context

 - Implementing the partial function is based on considering the currently supported connectors and using a generic function to implement it.
 - Per discussion with Ivan before, maybe... in order to cope with different connectors, it may be possible in the future that implement a masking function for each connector
