### PR TITLE
Fix: Fix the path of sql files not being recognized correctly in winOS

### DIFF
--- a/packages/build/src/lib/schema-parser/schema-reader/fileSchemaReader.ts
+++ b/packages/build/src/lib/schema-parser/schema-reader/fileSchemaReader.ts
@@ -57,7 +57,10 @@ export class FileSchemaReader extends SchemaReader {
   private async getSchemaFilePaths(): Promise<string[]> {
     return new Promise((resolve, reject) => {
       glob(
-        path.resolve(this.options!.folderPath, '**', '*.yaml'),
+        path
+          .resolve(this.options!.folderPath, '**', '*.yaml')
+          .split(path.sep)
+          .join('/'),
         { nodir: true },
         (err, files) => {
           if (err) return reject(err);

--- a/packages/build/test/document-generator/spec-generator/schema.ts
+++ b/packages/build/test/document-generator/spec-generator/schema.ts
@@ -25,10 +25,13 @@ import { Container } from 'inversify';
 
 const getSchemaPaths = () =>
   new Promise<string[]>((resolve, reject) => {
-    glob(path.resolve(__dirname, 'schemas', '*.yaml'), (err, paths) => {
-      if (err) return reject(err);
-      resolve(sortBy(paths));
-    });
+    glob(
+      path.resolve(__dirname, 'schemas', '*.yaml').split(path.sep).join('/'),
+      (err, paths) => {
+        if (err) return reject(err);
+        resolve(sortBy(paths));
+      }
+    );
   });
 
 class MockValidator extends InputValidator {

--- a/packages/core/src/lib/template-engine/template-providers/fileTemplateProvider.ts
+++ b/packages/core/src/lib/template-engine/template-providers/fileTemplateProvider.ts
@@ -49,7 +49,10 @@ export class FileTemplateProvider extends TemplateProvider {
   private async getTemplateFilePaths(): Promise<string[]> {
     return new Promise((resolve, reject) => {
       glob(
-        path.resolve(this.options.folderPath!, '**', '*.sql'),
+        path
+          .resolve(this.options.folderPath!, '**', '*.sql')
+          .split(path.sep)
+          .join('/'),
         { nodir: true },
         (err, files) => {
           if (err) return reject(err);


### PR DESCRIPTION
## Description

Fix the path of sql files not being recognized correctly in winOS
## Issue ticket number
#143 


## Additional Context
Windows use backslash when using path.resolve, e.g. `C:\\Users\\xxxxx\\cli`, but `glob` accepts only forward ward slash, so we make the windows path to linux path to make `glob` accepted

Glob: https://github.com/isaacs/node-glob#windows
Path separator: https://nodejs.org/api/path.html#pathsep