### PR TITLE
Feature: add cache checking middleware and APISchema #151

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "koa2-ratelimit": "^1.1.1",
     "lodash": "^4.17.21",
     "md5": "^2.3.0",
+    "ms": "3.0.0-canary.1",
     "nunjucks": "^3.2.3",
     "openapi3-ts": "^2.0.2",
     "ora": "^5.4.1",

--- a/packages/build/src/lib/schema-parser/middleware/addParameter.ts
+++ b/packages/build/src/lib/schema-parser/middleware/addParameter.ts
@@ -1,5 +1,6 @@
 import { FieldInType, ValidatorDefinition } from '@vulcan-sql/core';
 import { RawAPISchema, SchemaParserMiddleware } from './middleware';
+import { PARAMETER_METADATA_NAME } from './constants';
 
 interface Parameter {
   name: string;
@@ -14,9 +15,9 @@ export class AddParameter extends SchemaParserMiddleware {
 
     const metadata = schemas.metadata;
     // Skip validation if no metadata found
-    if (!metadata?.['parameter.vulcan.com']) return next();
+    if (!metadata?.[PARAMETER_METADATA_NAME]) return next();
 
-    const parameters: Parameter[] = metadata['parameter.vulcan.com'];
+    const parameters: Parameter[] = metadata[PARAMETER_METADATA_NAME];
     parameters.forEach((parameter) => {
       // We only check the first value of nested parameters
       const name = parameter.name.split('.')[0];

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -29,7 +29,7 @@ export class CheckCache extends SchemaParserMiddleware {
         const { refreshTime, refreshExpression } = cache;
         if (refreshTime && refreshExpression) {
           throw new ConfigurationError(
-            `The cache ${cache.cacheTableName} of Schema file ${schemas.urlPath} is invalid: Can not configure refreshTime and refreshExpression at the same time, please pick one`
+            `The cache ${cache.cacheTableName} of Schema ${schemas.urlPath} is invalid: Can not configure refreshTime and refreshExpression at the same time, please pick one`
           );
         }
 

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -1,0 +1,25 @@
+import { ConfigurationError } from '@vulcan-sql/core';
+import { RawAPISchema, SchemaParserMiddleware } from './middleware';
+import { CACHE_METADATA_NAME } from './constants';
+
+export class CheckCache extends SchemaParserMiddleware {
+  public async handle(schemas: RawAPISchema, next: () => Promise<void>) {
+    // check .yaml file has cache configuration
+    const caches = schemas?.cache;
+    if (!caches) return next()
+
+    // throw if cache not used in .sql file 
+    const metadata = schemas.metadata;
+    if (!(caches && metadata?.[CACHE_METADATA_NAME]?.['isUsedTag'])){
+      throw new ConfigurationError('your SQL will use the cache feature, not YAML defined.')  
+    } 
+
+    // check if refreshTime and refreshExpression is set at the same time
+    caches.forEach(({refreshTime, refreshExpression}): void => {
+      if (refreshTime && refreshExpression){
+        throw new ConfigurationError('can not configure refreshTime and refreshExpression at the same time, please pick one')
+      }
+    });
+    await next();
+  }
+}

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -1,25 +1,56 @@
 import { ConfigurationError } from '@vulcan-sql/core';
 import { RawAPISchema, SchemaParserMiddleware } from './middleware';
 import { CACHE_METADATA_NAME } from './constants';
+import ms, { StringValue } from 'ms';
 
 export class CheckCache extends SchemaParserMiddleware {
   public async handle(schemas: RawAPISchema, next: () => Promise<void>) {
     // check .yaml file has cache configuration
     const caches = schemas?.cache;
-    if (!caches) return next()
-
-    // throw if cache not used in .sql file 
     const metadata = schemas.metadata;
-    if (!(caches && metadata?.[CACHE_METADATA_NAME]?.['isUsedTag'])){
-      throw new ConfigurationError('your SQL will use the cache feature, not YAML defined.')  
-    } 
+    const isUsedCache = metadata?.[CACHE_METADATA_NAME]?.['isUsedTag'];
+    if (!isUsedCache && !caches) return next();
 
-    // check if refreshTime and refreshExpression is set at the same time
-    caches.forEach(({refreshTime, refreshExpression}): void => {
-      if (refreshTime && refreshExpression){
-        throw new ConfigurationError('can not configure refreshTime and refreshExpression at the same time, please pick one')
-      }
-    });
+    // throw if cache not used in .sql file
+    if (isUsedCache && !caches) {
+      throw new ConfigurationError(
+        "Cache feature was used in SQL file, but didn't find the cache configurations in YAML file."
+      );
+    }
+
+    if (caches) {
+      caches.forEach(({ refreshTime, refreshExpression }): void => {
+        // refreshTime and refreshExpression can not be set at the same time
+        if (refreshTime && refreshExpression) {
+          throw new ConfigurationError(
+            'can not configure refreshTime and refreshExpression at the same time, please pick one'
+          );
+        }
+        // the "every" in refreshTime or refreshExpression should be valid
+        const timeInterval =
+          refreshTime?.['every'] || refreshExpression?.['every'];
+        if (timeInterval) {
+          let interval: number;
+          try {
+            interval = ms(timeInterval as StringValue);
+          } catch (error) {
+            throw new ConfigurationError(
+              'invalid refreshTime representation, check node library "ms" for the valid representation'
+            );
+          }
+          if (isNaN(interval)) {
+            throw new ConfigurationError(
+              'invalid refreshTime representation, check node library "ms" for the valid representation'
+            );
+          }
+          if (interval < 0) {
+            throw new ConfigurationError(
+              'invalid refreshTime representation, refreshTime can not be negitive'
+            );
+          }
+        }
+      });
+    }
     await next();
   }
 }

--- a/packages/build/src/lib/schema-parser/middleware/constants.ts
+++ b/packages/build/src/lib/schema-parser/middleware/constants.ts
@@ -1,0 +1,2 @@
+export const PARAMETER_METADATA_NAME = 'parameter.vulcan.com';
+export const CACHE_METADATA_NAME = 'cache.vulcan.com'

--- a/packages/build/src/lib/schema-parser/middleware/index.ts
+++ b/packages/build/src/lib/schema-parser/middleware/index.ts
@@ -1,6 +1,7 @@
 import { ClassType } from '@vulcan-sql/core';
 import { GenerateUrl } from './generateUrl';
 import { CheckValidator } from './checkValidator';
+import { CheckCache } from './checkCache'
 import { TransformValidator } from './transformValidator';
 import { GenerateTemplateSource } from './generateTemplateSource';
 import { AddParameter } from './addParameter';
@@ -39,4 +40,5 @@ export const SchemaParserMiddlewares: ClassType<SchemaParserMiddleware>[] = [
   ExtractPaginationParams, // ExtractPaginationParams should be loaded after SetConstraints
   ResponseSampler,
   CheckProfile,
+  CheckCache,
 ];

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   middleware = new CheckCache();
   next.mockClear();
 });
-it('should call next() when there are no caches or cache metadata', async () => {
+it('Should call next() when there are no caches or cache metadata', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     metadata: {},
@@ -17,7 +17,7 @@ it('should call next() when there are no caches or cache metadata', async () => 
   expect(next).toHaveBeenCalled();
 });
 
-it('should throw an error when caches is used but not been defined in schema.', async () => {
+it('Should throw an error when caches is used but not been defined in schema.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -33,7 +33,7 @@ it('should throw an error when caches is used but not been defined in schema.', 
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw an error when caches is not used but been defined in schema.', async () => {
+it('Should throw an error when caches is not used but been defined in schema.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -56,7 +56,7 @@ it('should throw an error when caches is not used but been defined in schema.', 
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw an error when both refreshTime and refreshExpression are defined.', async () => {
+it('Should throw an error when both refreshTime and refreshExpression are defined.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -81,7 +81,7 @@ it('should throw an error when both refreshTime and refreshExpression are define
 });
 
 // refreshTime expression test cases
-it('should throw an error when the value of "every" of "refreshTime" is a invalid string that can not be convert.', async () => {
+it('Should throw an error when the value of "every" of "refreshTime" is a invalid string that can not be convert.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -104,7 +104,7 @@ it('should throw an error when the value of "every" of "refreshTime" is a invali
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw an error when a converted value of "every" of "refreshTime" is negative.', async () => {
+it('Should throw an error when a converted value of "every" of "refreshTime" is negative.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -127,7 +127,7 @@ it('should throw an error when a converted value of "every" of "refreshTime" is 
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should call next function when schemas have cache with valid refreshTime representation', async () => {
+it('Should call next function when schemas have cache with valid refreshTime representation', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     metadata: {
@@ -148,7 +148,7 @@ it('should call next function when schemas have cache with valid refreshTime rep
 });
 
 // refreshExpression time expression test cases
-it('should throw an error when the value of "every" of "refreshExpression" is a invalid string that can not be convert.', async () => {
+it('Should throw an error when the value of "every" of "refreshExpression" is a invalid string that can not be convert.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -170,7 +170,7 @@ it('should throw an error when the value of "every" of "refreshExpression" is a 
   );
   expect(next).not.toHaveBeenCalled();
 });
-it('should throw an error when a negative refreshExpression interval is used', async () => {
+it('Should throw an error when a negative refreshExpression interval is used', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -193,7 +193,7 @@ it('should throw an error when a negative refreshExpression interval is used', a
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should call next function when schemas have cache with valid refreshExpression representation', async () => {
+it('Should call next function when schemas have cache with valid refreshExpression representation', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     metadata: {

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -1,46 +1,185 @@
+import { RawAPISchema } from '@vulcan-sql/build';
 import { CheckCache } from '@vulcan-sql/build/schema-parser/middleware/checkCache';
-import { RawAPISchema } from '../../../src';
-
 
 let middleware: CheckCache;
 const next = jest.fn();
 
 beforeEach(() => {
-    middleware = new CheckCache();
-    next.mockClear();
+  middleware = new CheckCache();
+  next.mockClear();
+});
+it('should call next() when there are no caches or cache metadata', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {},
+  };
+  await middleware.handle(schemas, next);
+  expect(next).toHaveBeenCalled();
 });
 
-it('should not throw error if cache is not defined', async () => {
-    const schema: RawAPISchema = { sourceName: 'test' };
-    await middleware.handle(schema, next)
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-it('should throw error if cache is defined but not used in SQL file', async () => {
-    const schema: RawAPISchema = { sourceName: 'test', cache: [{ cacheTableName: 'test', sql: 'select * from test' }] };
-    await expect(middleware.handle(schema,next)).rejects.toThrow('your SQL will use the cache feature, not YAML defined.');
-    expect(next).not.toHaveBeenCalled();
+it('should throw an error when caches is used but not been defined in schema.', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    "Cache feature was used in SQL file, but didn't find the cache configurations in YAML file."
+  );
+  expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw error if both refreshTime and refreshExpression are set', async () => {
-    const schema: RawAPISchema = { 
-        sourceName: 'test', 
-        cache: [
-        { cacheTableName: 'test1', sql: 'select * from test1', refreshTime: { every: '5m' }, refreshExpression: { expression: 'test' } },
-        { cacheTableName: 'test2', sql: 'select * from test2', refreshTime: { every: '5m' } }
-        ],
-        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
-    };
-    await expect(middleware.handle(schema,next)).rejects.toThrow('can not configure refreshTime and refreshExpression at the same time, please pick one');
-    expect(next).not.toHaveBeenCalled();
+it('should throw an error when both refreshTime and refreshExpression are defined.', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: '5m' },
+        refreshExpression: { expression: '*/5,*,*,*,*', every: '5m' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'can not configure refreshTime and refreshExpression at the same time, please pick one'
+  );
+  expect(next).not.toHaveBeenCalled();
 });
 
-it('should call next if cache is defined and used in SQL file', async () => {
-    const schema: RawAPISchema = { 
-        sourceName: 'test', 
-        cache: [{ cacheTableName: 'test', sql: 'select * from test' }],
-        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
-    };
-    await middleware.handle(schema, next);
-    expect(next).toHaveBeenCalledTimes(1);
+// refreshTime expression test cases
+it('should throw an error when an invalid refreshTime representation is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: 'invalidString' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, check node library "ms" for the valid representation'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
+it('should throw an error when a negative refreshTime interval is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: '-5m' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, refreshTime can not be negitive'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
+it('should call next function when schemas have cache with valid refreshTime representation', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: '5m' },
+      },
+    ],
+  };
+  await middleware.handle(schemas, next);
+  expect(next).toHaveBeenCalled();
+});
+
+// refreshExpression time expression test cases
+it('should throw an error when an invalid refreshExpression representation is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshExpression: { every: 'invalidString' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, check node library "ms" for the valid representation'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+it('should throw an error when a negative refreshExpression interval is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshExpression: { every: '-5m' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, refreshTime can not be negitive'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
+it('should call next function when schemas have cache with valid refreshExpression representation', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshExpression: { every: '5m' },
+      },
+    ],
+  };
+  await middleware.handle(schemas, next);
+  expect(next).toHaveBeenCalled();
 });

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -1,0 +1,46 @@
+import { CheckCache } from '@vulcan-sql/build/schema-parser/middleware/checkCache';
+import { RawAPISchema } from '../../../src';
+
+
+let middleware: CheckCache;
+const next = jest.fn();
+
+beforeEach(() => {
+    middleware = new CheckCache();
+    next.mockClear();
+});
+
+it('should not throw error if cache is not defined', async () => {
+    const schema: RawAPISchema = { sourceName: 'test' };
+    await middleware.handle(schema, next)
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+it('should throw error if cache is defined but not used in SQL file', async () => {
+    const schema: RawAPISchema = { sourceName: 'test', cache: [{ cacheTableName: 'test', sql: 'select * from test' }] };
+    await expect(middleware.handle(schema,next)).rejects.toThrow('your SQL will use the cache feature, not YAML defined.');
+    expect(next).not.toHaveBeenCalled();
+});
+
+it('should throw error if both refreshTime and refreshExpression are set', async () => {
+    const schema: RawAPISchema = { 
+        sourceName: 'test', 
+        cache: [
+        { cacheTableName: 'test1', sql: 'select * from test1', refreshTime: { every: '5m' }, refreshExpression: { expression: 'test' } },
+        { cacheTableName: 'test2', sql: 'select * from test2', refreshTime: { every: '5m' } }
+        ],
+        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
+    };
+    await expect(middleware.handle(schema,next)).rejects.toThrow('can not configure refreshTime and refreshExpression at the same time, please pick one');
+    expect(next).not.toHaveBeenCalled();
+});
+
+it('should call next if cache is defined and used in SQL file', async () => {
+    const schema: RawAPISchema = { 
+        sourceName: 'test', 
+        cache: [{ cacheTableName: 'test', sql: 'select * from test' }],
+        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
+    };
+    await middleware.handle(schema, next);
+    expect(next).toHaveBeenCalledTimes(1);
+});

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -94,11 +94,20 @@ export class Sample {
   req?: KoaRequest;
 }
 
+export class RefreshTime {
+  every!: string;
+}
+
+export class RefreshExpression {
+  expression!: string;
+  every!: string;
+}
+
 export class CacheLayerInfo {
   cacheTableName!: string;
   sql!: string;
-  refreshTime?: Record<string, string>;
-  refreshExpression?: Record<string, string>;
+  refreshTime?: RefreshTime;
+  refreshExpression?: RefreshExpression;
   // index key name -> index column
   indexes?: Record<string, string>;
 }
@@ -122,7 +131,7 @@ export class APISchema {
   pagination?: PaginationSchema;
   sample?: Sample;
   profiles!: Array<string>;
-  cache?:Array<CacheLayerInfo>;
+  cache?: Array<CacheLayerInfo>;
 }
 
 export class BuiltArtifact {

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -94,6 +94,15 @@ export class Sample {
   req?: KoaRequest;
 }
 
+export class CacheLayerInfo {
+  cacheTableName!: string;
+  sql!: string;
+  refreshTime?: Record<string, string>;
+  refreshExpression?: Record<string, string>;
+  // index key name -> index column
+  indexes?: Record<string, string>;
+}
+
 export class APISchema {
   // graphql operation name
   operationName!: string;
@@ -113,6 +122,7 @@ export class APISchema {
   pagination?: PaginationSchema;
   sample?: Sample;
   profiles!: Array<string>;
+  cache?:Array<CacheLayerInfo>;
 }
 
 export class BuiltArtifact {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5574,6 +5574,11 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+ms@3.0.0-canary.1:
+  version "3.0.0-canary.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-3.0.0-canary.1.tgz#c7b34fbce381492fd0b345d1cf56e14d67b77b80"
+  integrity sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"


### PR DESCRIPTION
## Description

This pull request adds a new middleware to validate cache configurations defined in the .yaml file. 

Validation logic:
 - if cache is used in .SQL file, but no cache configuration found in .yaml file, throw error.
 - if cache configuration is set, the refreshTime and refreshExpression can not exist at the same time.
 - the time interval(variable "every") in refreshTime and refreshExpression should be a valid string that can be parse by library ["ms"](https://github.com/vercel/ms), throw Error if not valid.


## Issue ticket number
issue #151 

## Additional Context
 - This PR does not include the validation of the variable "express" in refreshExpress and the indexes configuration.
 - the SQL defined in the .yaml file will be validated in another place(like SQL engine).
