### PR TITLE
Feature: add cache checking middleware and APISchema #151

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "koa2-ratelimit": "^1.1.1",
     "lodash": "^4.17.21",
     "md5": "^2.3.0",
+    "ms": "3.0.0-canary.1",
     "nunjucks": "^3.2.3",
     "openapi3-ts": "^2.0.2",
     "ora": "^5.4.1",

--- a/packages/build/src/lib/schema-parser/middleware/addParameter.ts
+++ b/packages/build/src/lib/schema-parser/middleware/addParameter.ts
@@ -1,5 +1,6 @@
 import { FieldInType, ValidatorDefinition } from '@vulcan-sql/core';
 import { RawAPISchema, SchemaParserMiddleware } from './middleware';
+import { PARAMETER_METADATA_NAME } from './constants';
 
 interface Parameter {
   name: string;
@@ -14,9 +15,9 @@ export class AddParameter extends SchemaParserMiddleware {
 
     const metadata = schemas.metadata;
     // Skip validation if no metadata found
-    if (!metadata?.['parameter.vulcan.com']) return next();
+    if (!metadata?.[PARAMETER_METADATA_NAME]) return next();
 
-    const parameters: Parameter[] = metadata['parameter.vulcan.com'];
+    const parameters: Parameter[] = metadata[PARAMETER_METADATA_NAME];
     parameters.forEach((parameter) => {
       // We only check the first value of nested parameters
       const name = parameter.name.split('.')[0];

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -29,7 +29,7 @@ export class CheckCache extends SchemaParserMiddleware {
         const { refreshTime, refreshExpression } = cache;
         if (refreshTime && refreshExpression) {
           throw new ConfigurationError(
-            `The cache ${cache.cacheTableName} of Schema file ${schemas.urlPath} is invalid: Can not configure refreshTime and refreshExpression at the same time, please pick one`
+            `The cache ${cache.cacheTableName} of Schema ${schemas.urlPath} is invalid: Can not configure refreshTime and refreshExpression at the same time, please pick one`
           );
         }
 

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -3,12 +3,6 @@ import { RawAPISchema, SchemaParserMiddleware } from './middleware';
 import { CACHE_METADATA_NAME } from './constants';
 import ms, { StringValue } from 'ms';
 
-interface RefreshOption {
-  intervalType?: string;
-  timeInterval?: string;
-  cacheTableName?: string;
-  urlPath?: string;
-}
 export class CheckCache extends SchemaParserMiddleware {
   public async handle(schemas: RawAPISchema, next: () => Promise<void>) {
     // check .yaml file has cache configuration

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -3,6 +3,12 @@ import { RawAPISchema, SchemaParserMiddleware } from './middleware';
 import { CACHE_METADATA_NAME } from './constants';
 import ms, { StringValue } from 'ms';
 
+interface RefreshOption {
+  intervalType?: string;
+  timeInterval?: string;
+  cacheTableName?: string;
+  urlPath?: string;
+}
 export class CheckCache extends SchemaParserMiddleware {
   public async handle(schemas: RawAPISchema, next: () => Promise<void>) {
     // check .yaml file has cache configuration
@@ -22,20 +28,20 @@ export class CheckCache extends SchemaParserMiddleware {
         `Can not configure the cache setting in schema "${schemas.urlPath}", {% cache %} tag not been used in SQL file.`
       );
     }
-    this.checkRefreshSettings(schemas);
     this.checkCacheTableName(schemas);
-    this.checkIndexesHasValue(schemas);
     this.checkSQLHasValue(schemas);
     this.assignCacheProfile(schemas);
+    this.checkRefreshSettings(schemas);
+    this.checkIndexesHasValue(schemas);
 
     await next();
   }
 
   private checkRefreshSettings(schemas: RawAPISchema) {
-    const caches = schemas?.cache;
+    const { cache: caches, urlPath } = schemas;
     caches?.forEach((cache): void => {
       // refreshTime and refreshExpression can not be set at the same time
-      const { refreshTime, refreshExpression } = cache;
+      const { refreshTime, refreshExpression, cacheTableName } = cache;
       if (refreshTime && refreshExpression) {
         throw new ConfigurationError(
           `Can not set "refreshTime" and "refreshExpression" at the same time in cache "${cache.cacheTableName}" of schema "${schemas.urlPath}"`
@@ -43,71 +49,68 @@ export class CheckCache extends SchemaParserMiddleware {
       }
       // check "every" of "refreshTime" and "refreshExpression" are valid
       if (refreshTime) {
-        this.checkRefreshInterval(
-          refreshTime.every,
-          cache.cacheTableName,
-          schemas.urlPath,
-          'refreshTime'
-        );
+        const refreshOption: RefreshOption = {
+          intervalType: 'refreshTime',
+          timeInterval: refreshTime.every,
+          cacheTableName,
+          urlPath,
+        };
+        this.checkRefreshInterval(refreshOption);
       }
       if (refreshExpression) {
-        this.checkRefreshInterval(
-          refreshExpression.every,
-          cache.cacheTableName,
-          schemas.urlPath,
-          'refreshExpression'
-        );
+        const refreshOption: RefreshOption = {
+          intervalType: 'refreshExpression',
+          timeInterval: refreshExpression.every,
+          cacheTableName,
+          urlPath,
+        };
+        this.checkRefreshInterval(refreshOption);
       }
     });
   }
 
-  private checkRefreshInterval(
-    timeInterval: string | undefined,
-    cacheTableName: string | undefined,
-    schemaPath: string | undefined,
-    intervalType: 'refreshTime' | 'refreshExpression'
-  ) {
+  private checkRefreshInterval(checkOption: RefreshOption) {
+    const { intervalType, timeInterval, cacheTableName, urlPath } = checkOption;
     const interval = ms(timeInterval as StringValue);
     if (isNaN(interval)) {
       throw new ConfigurationError(
-        `The "every" of "${intervalType}" in cache "${cacheTableName}" of schema "${schemaPath}" is invalid: Invalid time string to convert.`
+        `The "every" of "${intervalType}" in cache "${cacheTableName}" of schema "${urlPath}" is invalid: Invalid time string to convert.`
       );
     }
     if (interval < 0) {
       throw new ConfigurationError(
-        `The "every" of "${intervalType}" in cache "${cacheTableName}" of schema "${schemaPath}" is invalid: Time can not be negative.`
+        `The "every" of "${intervalType}" in cache "${cacheTableName}" of schema "${urlPath}" is invalid: Time can not be negative.`
       );
     }
   }
 
   private checkCacheTableName(schemas: RawAPISchema) {
     const caches = schemas?.cache;
-    const cacheTableNameSet = new Set();
+    const cacheTableNames = [] as string[];
     caches?.forEach((cache) => {
       const { cacheTableName } = cache;
 
       // should have table name
       if (!cacheTableName) {
         throw new ConfigurationError(
-          `The cacheTableName of cache in schema "${schemas.urlPath}" is not defined.`
+          `The "cacheTableName" of cache in schema "${schemas.urlPath}" is not defined.`
         );
       }
       // table name should be unique
-      if (cacheTableNameSet.has(cacheTableName)) {
+      if (cacheTableNames.includes(cacheTableName)) {
         throw new ConfigurationError(
           `The cacheTableName "${cacheTableName}" of cache in schema "${schemas.urlPath}" is not unique.`
         );
       }
       // table naming pattern
       // 1. start with a letter or underscore, and can only contain letters, numbers, and underscores
-      // 2. the subcharactors contain letters, numbers, underscore, and dollar sign
-      const pattern = /^[a-zA-Z_][a-zA-Z0-9_$]+$/;
-      if (!pattern.test(cacheTableName)) {
+      // 2. the sub-characters contain letters, numbers, underscore, and dollar sign
+      if (!/^[a-zA-Z_][a-zA-Z0-9_$]+$/.test(cacheTableName)) {
         throw new ConfigurationError(
           `The cacheTableName "${cacheTableName}" in schema "${schemas.urlPath}" should meet the pattern "/^[a-zA-Z_][a-zA-Z0-9_$]+$/".`
         );
       }
-      cacheTableNameSet.add(cacheTableName);
+      cacheTableNames.push(cacheTableName);
     });
   }
 
@@ -118,22 +121,20 @@ export class CheckCache extends SchemaParserMiddleware {
       const { sql } = cache;
       if (!sql) {
         throw new ConfigurationError(
-          `The sql of cache "${cache.cacheTableName}" in schema "${schemas.urlPath}" is not defined or is empty.`
+          `The "sql" of cache "${cache.cacheTableName}" in schema "${schemas.urlPath}" is not defined or is empty.`
         );
       }
     });
   }
   // check indexes value is not empty
   private checkIndexesHasValue(schemas: RawAPISchema) {
-    const caches = schemas?.cache;
-
-    caches?.forEach((cache) => {
-      const { indexes } = cache;
+    const { cache: caches, urlPath } = schemas;
+    caches?.forEach(({ indexes, cacheTableName }) => {
       if (indexes) {
         Object.entries(indexes).forEach(([indexName, columnName]) => {
           if (!columnName || typeof columnName !== 'string') {
             throw new ConfigurationError(
-              `The index "${indexName}" of cache "${cache.cacheTableName}" in schema "${schemas.urlPath}" should be a string.`
+              `The index "${indexName}" of cache "${cacheTableName}" in schema "${urlPath}" should be a string.`
             );
           }
         });
@@ -144,25 +145,25 @@ export class CheckCache extends SchemaParserMiddleware {
   // assign the first profile in the schemas.profiles to the cache.profile if cache.profile is not defined
   // cache profile should exist in schemas.profiles
   private assignCacheProfile(schemas: RawAPISchema) {
-    const caches = schemas?.cache;
-    const profiles = schemas?.profiles;
-    if (profiles) {
-      const defaultProfile = profiles[0];
-      caches?.forEach((cache) => {
-        if (!cache.profile) {
-          cache.profile = defaultProfile;
-        } else {
-          // if cache.profile is not in profiles, throw error
-          const isProfileExist = profiles.some(
-            (profile) => profile === cache.profile
-          );
-          if (!isProfileExist) {
-            throw new ConfigurationError(
-              `The profile "${cache.profile}" of cache "${cache.cacheTableName}" in schema "${schemas.urlPath}" is not defined in the schema profiles.`
-            );
-          }
-        }
-      });
+    const { cache: caches, profiles, urlPath } = schemas;
+    if (!profiles) {
+      throw new ConfigurationError(
+        `The "profiles" of schema "${schemas.urlPath}" is not defined.`
+      );
+    }
+    const defaultProfile = profiles[0];
+    for (const cache of caches!) {
+      const { profile, cacheTableName } = cache;
+      if (!profile) {
+        cache.profile = defaultProfile;
+        continue;
+      }
+      // if cache.profile is not in profiles, throw error
+      if (!profiles.includes(profile)) {
+        throw new ConfigurationError(
+          `The profile "${profile}" of cache "${cacheTableName}" in schema "${urlPath}" is not defined in the schema profiles.`
+        );
+      }
     }
   }
 }

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -1,0 +1,25 @@
+import { ConfigurationError } from '@vulcan-sql/core';
+import { RawAPISchema, SchemaParserMiddleware } from './middleware';
+import { CACHE_METADATA_NAME } from './constants';
+
+export class CheckCache extends SchemaParserMiddleware {
+  public async handle(schemas: RawAPISchema, next: () => Promise<void>) {
+    // check .yaml file has cache configuration
+    const caches = schemas?.cache;
+    if (!caches) return next()
+
+    // throw if cache not used in .sql file 
+    const metadata = schemas.metadata;
+    if (!(caches && metadata?.[CACHE_METADATA_NAME]?.['isUsedTag'])){
+      throw new ConfigurationError('your SQL will use the cache feature, not YAML defined.')  
+    } 
+
+    // check if refreshTime and refreshExpression is set at the same time
+    caches.forEach(({refreshTime, refreshExpression}): void => {
+      if (refreshTime && refreshExpression){
+        throw new ConfigurationError('can not configure refreshTime and refreshExpression at the same time, please pick one')
+      }
+    });
+    await next();
+  }
+}

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -14,69 +14,155 @@ export class CheckCache extends SchemaParserMiddleware {
     // throw if cache not used in .sql file
     if (isUsedCache && !caches) {
       throw new ConfigurationError(
-        `{% cache %} tag was used in SQL file, but the cache configurations was not found in Schema ${schemas.urlPath}.`
+        `{% cache %} tag was used in SQL file, but the cache configurations was not found in schema "${schemas.urlPath}".`
       );
     }
     if (!isUsedCache && caches) {
       throw new ConfigurationError(
-        `Can not configurate the cache setting in Schema ${schemas.urlPath}, {% cache %} tag not been used in SQL file.`
+        `Can not configure the cache setting in schema "${schemas.urlPath}", {% cache %} tag not been used in SQL file.`
       );
     }
+    this.checkRefreshSettings(schemas);
+    this.checkCacheTableName(schemas);
+    this.checkIndexesHasValue(schemas);
+    this.checkSQLHasValue(schemas);
+    this.assignCacheProfile(schemas);
 
-    if (caches) {
-      caches.forEach((cache): void => {
-        // refreshTime and refreshExpression can not be set at the same time
-        const { refreshTime, refreshExpression } = cache;
-        if (refreshTime && refreshExpression) {
-          throw new ConfigurationError(
-            `The cache ${cache.cacheTableName} of Schema ${schemas.urlPath} is invalid: Can not configure refreshTime and refreshExpression at the same time, please pick one`
-          );
-        }
+    await next();
+  }
 
-        // check "every" of "refreshTime" is valid
-        let every = refreshTime?.['every'];
-        if (every) {
-          const { isValid, error } = this.checkRefreshInterval(every);
-          if (!isValid) {
+  private checkRefreshSettings(schemas: RawAPISchema) {
+    const caches = schemas?.cache;
+    caches?.forEach((cache): void => {
+      // refreshTime and refreshExpression can not be set at the same time
+      const { refreshTime, refreshExpression } = cache;
+      if (refreshTime && refreshExpression) {
+        throw new ConfigurationError(
+          `Can not set "refreshTime" and "refreshExpression" at the same time in cache "${cache.cacheTableName}" of schema "${schemas.urlPath}"`
+        );
+      }
+      // check "every" of "refreshTime" and "refreshExpression" are valid
+      if (refreshTime) {
+        this.checkRefreshInterval(
+          refreshTime.every,
+          cache.cacheTableName,
+          schemas.urlPath,
+          'refreshTime'
+        );
+      }
+      if (refreshExpression) {
+        this.checkRefreshInterval(
+          refreshExpression.every,
+          cache.cacheTableName,
+          schemas.urlPath,
+          'refreshExpression'
+        );
+      }
+    });
+  }
+
+  private checkRefreshInterval(
+    timeInterval: string | undefined,
+    cacheTableName: string | undefined,
+    schemaPath: string | undefined,
+    intervalType: 'refreshTime' | 'refreshExpression'
+  ) {
+    const interval = ms(timeInterval as StringValue);
+    if (isNaN(interval)) {
+      throw new ConfigurationError(
+        `The "every" of "${intervalType}" in cache "${cacheTableName}" of schema "${schemaPath}" is invalid: Invalid time string to convert.`
+      );
+    }
+    if (interval < 0) {
+      throw new ConfigurationError(
+        `The "every" of "${intervalType}" in cache "${cacheTableName}" of schema "${schemaPath}" is invalid: Time can not be negative.`
+      );
+    }
+  }
+
+  private checkCacheTableName(schemas: RawAPISchema) {
+    const caches = schemas?.cache;
+    const cacheTableNameSet = new Set();
+    caches?.forEach((cache) => {
+      const { cacheTableName } = cache;
+
+      // should have table name
+      if (!cacheTableName) {
+        throw new ConfigurationError(
+          `The cacheTableName of cache in schema "${schemas.urlPath}" is not defined.`
+        );
+      }
+      // table name should be unique
+      if (cacheTableNameSet.has(cacheTableName)) {
+        throw new ConfigurationError(
+          `The cacheTableName "${cacheTableName}" of cache in schema "${schemas.urlPath}" is not unique.`
+        );
+      }
+      // table naming pattern
+      // 1. start with a letter or underscore, and can only contain letters, numbers, and underscores
+      // 2. the subcharactors contain letters, numbers, underscore, and dollar sign
+      const pattern = /^[a-zA-Z_][a-zA-Z0-9_$]+$/;
+      if (!pattern.test(cacheTableName)) {
+        throw new ConfigurationError(
+          `The cacheTableName "${cacheTableName}" in schema "${schemas.urlPath}" should meet the pattern "/^[a-zA-Z_][a-zA-Z0-9_$]+$/".`
+        );
+      }
+      cacheTableNameSet.add(cacheTableName);
+    });
+  }
+
+  // check sql is not empty
+  private checkSQLHasValue(schemas: RawAPISchema) {
+    const caches = schemas?.cache;
+    caches?.forEach((cache) => {
+      const { sql } = cache;
+      if (!sql) {
+        throw new ConfigurationError(
+          `The sql of cache "${cache.cacheTableName}" in schema "${schemas.urlPath}" is not defined or is empty.`
+        );
+      }
+    });
+  }
+  // check indexes value is not empty
+  private checkIndexesHasValue(schemas: RawAPISchema) {
+    const caches = schemas?.cache;
+
+    caches?.forEach((cache) => {
+      const { indexes } = cache;
+      if (indexes) {
+        Object.entries(indexes).forEach(([indexName, columnName]) => {
+          if (!columnName || typeof columnName !== 'string') {
             throw new ConfigurationError(
-              `The "every" of "refreshTime" in cache ${cache.cacheTableName} of schema ${schemas.urlPath} is invalid: ${error}`
+              `The index "${indexName}" of cache "${cache.cacheTableName}" in schema "${schemas.urlPath}" should be a string.`
             );
           }
-        }
-        // check "every" of "refreshExpression" is valid
-        every = refreshExpression?.['every'];
-        if (every) {
-          const { isValid, error } = this.checkRefreshInterval(every);
-          if (!isValid) {
+        });
+      }
+    });
+  }
+
+  // assign the first profile in the schemas.profiles to the cache.profile if cache.profile is not defined
+  // cache profile should exist in schemas.profiles
+  private assignCacheProfile(schemas: RawAPISchema) {
+    const caches = schemas?.cache;
+    const profiles = schemas?.profiles;
+    if (profiles) {
+      const defaultProfile = profiles[0];
+      caches?.forEach((cache) => {
+        if (!cache.profile) {
+          cache.profile = defaultProfile;
+        } else {
+          // if cache.profile is not in profiles, throw error
+          const isProfileExist = profiles.some(
+            (profile) => profile === cache.profile
+          );
+          if (!isProfileExist) {
             throw new ConfigurationError(
-              `The "every" of "refreshExpression" in cache ${cache.cacheTableName} of schema ${schemas.urlPath} is invalid: ${error}`
+              `The profile "${cache.profile}" of cache "${cache.cacheTableName}" in schema "${schemas.urlPath}" is not defined in the schema profiles.`
             );
           }
         }
       });
     }
-    await next();
-  }
-
-  private checkRefreshInterval(timeInterval: string) {
-    let isValid = true;
-    let error = null;
-
-    const interval = ms(timeInterval as StringValue);
-    if (isNaN(interval)) {
-      isValid = false;
-      error = 'Invalid time string to convert.';
-      return {
-        isValid,
-        error,
-      };
-    }
-    if (interval < 0) {
-      return {
-        isValid: false,
-        error: 'Time can not be negitive.',
-      };
-    }
-    return { isValid, error };
   }
 }

--- a/packages/build/src/lib/schema-parser/middleware/checkCache.ts
+++ b/packages/build/src/lib/schema-parser/middleware/checkCache.ts
@@ -1,25 +1,56 @@
 import { ConfigurationError } from '@vulcan-sql/core';
 import { RawAPISchema, SchemaParserMiddleware } from './middleware';
 import { CACHE_METADATA_NAME } from './constants';
+import ms, { StringValue } from 'ms';
 
 export class CheckCache extends SchemaParserMiddleware {
   public async handle(schemas: RawAPISchema, next: () => Promise<void>) {
     // check .yaml file has cache configuration
     const caches = schemas?.cache;
-    if (!caches) return next()
-
-    // throw if cache not used in .sql file 
     const metadata = schemas.metadata;
-    if (!(caches && metadata?.[CACHE_METADATA_NAME]?.['isUsedTag'])){
-      throw new ConfigurationError('your SQL will use the cache feature, not YAML defined.')  
-    } 
+    const isUsedCache = metadata?.[CACHE_METADATA_NAME]?.['isUsedTag'];
+    if (!isUsedCache && !caches) return next();
 
-    // check if refreshTime and refreshExpression is set at the same time
-    caches.forEach(({refreshTime, refreshExpression}): void => {
-      if (refreshTime && refreshExpression){
-        throw new ConfigurationError('can not configure refreshTime and refreshExpression at the same time, please pick one')
-      }
-    });
+    // throw if cache not used in .sql file
+    if (isUsedCache && !caches) {
+      throw new ConfigurationError(
+        "Cache feature was used in SQL file, but didn't find the cache configurations in YAML file."
+      );
+    }
+
+    if (caches) {
+      caches.forEach(({ refreshTime, refreshExpression }): void => {
+        // refreshTime and refreshExpression can not be set at the same time
+        if (refreshTime && refreshExpression) {
+          throw new ConfigurationError(
+            'can not configure refreshTime and refreshExpression at the same time, please pick one'
+          );
+        }
+        // the "every" in refreshTime or refreshExpression should be valid
+        const timeInterval =
+          refreshTime?.['every'] || refreshExpression?.['every'];
+        if (timeInterval) {
+          let interval: number;
+          try {
+            interval = ms(timeInterval as StringValue);
+          } catch (error) {
+            throw new ConfigurationError(
+              'invalid refreshTime representation, check node library "ms" for the valid representation'
+            );
+          }
+          if (isNaN(interval)) {
+            throw new ConfigurationError(
+              'invalid refreshTime representation, check node library "ms" for the valid representation'
+            );
+          }
+          if (interval < 0) {
+            throw new ConfigurationError(
+              'invalid refreshTime representation, refreshTime can not be negitive'
+            );
+          }
+        }
+      });
+    }
     await next();
   }
 }

--- a/packages/build/src/lib/schema-parser/middleware/constants.ts
+++ b/packages/build/src/lib/schema-parser/middleware/constants.ts
@@ -1,0 +1,2 @@
+export const PARAMETER_METADATA_NAME = 'parameter.vulcan.com';
+export const CACHE_METADATA_NAME = 'cache.vulcan.com'

--- a/packages/build/src/lib/schema-parser/middleware/index.ts
+++ b/packages/build/src/lib/schema-parser/middleware/index.ts
@@ -1,7 +1,7 @@
 import { ClassType } from '@vulcan-sql/core';
 import { GenerateUrl } from './generateUrl';
 import { CheckValidator } from './checkValidator';
-import { CheckCache } from './checkCache'
+import { CheckCache } from './checkCache';
 import { TransformValidator } from './transformValidator';
 import { GenerateTemplateSource } from './generateTemplateSource';
 import { AddParameter } from './addParameter';
@@ -40,5 +40,5 @@ export const SchemaParserMiddlewares: ClassType<SchemaParserMiddleware>[] = [
   ExtractPaginationParams, // ExtractPaginationParams should be loaded after SetConstraints
   ResponseSampler,
   CheckProfile,
-  CheckCache,
+  CheckCache, // checkCache should be loaded after checkProfile
 ];

--- a/packages/build/src/lib/schema-parser/middleware/index.ts
+++ b/packages/build/src/lib/schema-parser/middleware/index.ts
@@ -1,6 +1,7 @@
 import { ClassType } from '@vulcan-sql/core';
 import { GenerateUrl } from './generateUrl';
 import { CheckValidator } from './checkValidator';
+import { CheckCache } from './checkCache'
 import { TransformValidator } from './transformValidator';
 import { GenerateTemplateSource } from './generateTemplateSource';
 import { AddParameter } from './addParameter';
@@ -39,4 +40,5 @@ export const SchemaParserMiddlewares: ClassType<SchemaParserMiddleware>[] = [
   ExtractPaginationParams, // ExtractPaginationParams should be loaded after SetConstraints
   ResponseSampler,
   CheckProfile,
+  CheckCache,
 ];

--- a/packages/build/src/lib/schema-parser/middleware/index.ts
+++ b/packages/build/src/lib/schema-parser/middleware/index.ts
@@ -40,5 +40,5 @@ export const SchemaParserMiddlewares: ClassType<SchemaParserMiddleware>[] = [
   ExtractPaginationParams, // ExtractPaginationParams should be loaded after SetConstraints
   ResponseSampler,
   CheckProfile,
-  CheckCache, // checkCache should be loaded after checkProfile
+  CheckCache, // CheckCache should be loaded after checkProfile
 ];

--- a/packages/build/src/lib/schema-parser/middleware/middleware.ts
+++ b/packages/build/src/lib/schema-parser/middleware/middleware.ts
@@ -1,5 +1,6 @@
 import {
   APISchema,
+  CacheLayerInfo,
   FieldDataType,
   RequestSchema as RequestParameter,
   ResponseProperty,
@@ -17,14 +18,19 @@ export interface RawResponseProperty extends Omit<ResponseProperty, 'type'> {
   type: string | FieldDataType | Array<RawResponseProperty>;
 }
 
+export interface RawCacheLayerInfo extends Omit<CacheLayerInfo, 'profile'> {
+  profile?: string;
+}
+
 export interface RawAPISchema
-  extends DeepPartial<Omit<APISchema, 'request' | 'response'>> {
+  extends DeepPartial<Omit<APISchema, 'request' | 'response' | 'cache'>> {
   /** Indicate the identifier of this schema from the source, it might be uuid, file path, url ...etc, depend on the provider */
   sourceName: string;
   request?: DeepPartial<RawRequestParameter[]>;
   response?: DeepPartial<RawResponseProperty[]>;
   metadata?: Record<string, any>;
   profile?: string;
+  cache?: Array<RawCacheLayerInfo>;
 }
 
 @injectable()

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -101,7 +101,7 @@ it('Should throw an error when the value of "every" of "refreshTime" is a invali
     ],
   };
   await expect(middleware.handle(schemas, next)).rejects.toThrow(
-    'The "every" of "refreshTime" in cache "cache_table_name" of schema "/urlPath" is invalid: Invalid time string to convert.'
+    'The "refreshTime.every" of cache "cache_table_name" in schema "/urlPath" is invalid: Invalid time string to convert.'
   );
   expect(next).not.toHaveBeenCalled();
 });
@@ -125,7 +125,7 @@ it('Should throw an error when a converted value of "every" of "refreshTime" is 
     ],
   };
   await expect(middleware.handle(schemas, next)).rejects.toThrow(
-    'The "every" of "refreshTime" in cache "cache_table_name" of schema "/urlPath" is invalid: Time can not be negative.'
+    'The "refreshTime.every" of cache "cache_table_name" in schema "/urlPath" is invalid: Time can not be negative.'
   );
   expect(next).not.toHaveBeenCalled();
 });
@@ -174,7 +174,7 @@ it('Should throw an error when the value of "every" of "refreshExpression" is a 
     ],
   };
   await expect(middleware.handle(schemas, next)).rejects.toThrow(
-    'The "every" of "refreshExpression" in cache "cache_table_name" of schema "/urlPath" is invalid: Invalid time string to convert.'
+    'The "refreshExpression.every" of cache "cache_table_name" in schema "/urlPath" is invalid: Invalid time string to convert.'
   );
   expect(next).not.toHaveBeenCalled();
 });
@@ -197,7 +197,7 @@ it('Should throw an error when a negative refreshExpression interval is used', a
     ],
   };
   await expect(middleware.handle(schemas, next)).rejects.toThrow(
-    'The "every" of "refreshExpression" in cache "cache_table_name" of schema "/urlPath" is invalid: Time can not be negative.'
+    'The "refreshExpression.every" of cache "cache_table_name" in schema "/urlPath" is invalid: Time can not be negative.'
   );
   expect(next).not.toHaveBeenCalled();
 });

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   middleware = new CheckCache();
   next.mockClear();
 });
-it('should call next() when there are no caches or cache metadata', async () => {
+it('Should call next() when there are no caches or cache metadata', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     metadata: {},
@@ -17,7 +17,7 @@ it('should call next() when there are no caches or cache metadata', async () => 
   expect(next).toHaveBeenCalled();
 });
 
-it('should throw an error when caches is used but not been defined in schema.', async () => {
+it('Should throw an error when caches is used but not been defined in schema.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -33,7 +33,7 @@ it('should throw an error when caches is used but not been defined in schema.', 
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw an error when caches is not used but been defined in schema.', async () => {
+it('Should throw an error when caches is not used but been defined in schema.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -56,7 +56,7 @@ it('should throw an error when caches is not used but been defined in schema.', 
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw an error when both refreshTime and refreshExpression are defined.', async () => {
+it('Should throw an error when both refreshTime and refreshExpression are defined.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -81,7 +81,7 @@ it('should throw an error when both refreshTime and refreshExpression are define
 });
 
 // refreshTime expression test cases
-it('should throw an error when the value of "every" of "refreshTime" is a invalid string that can not be convert.', async () => {
+it('Should throw an error when the value of "every" of "refreshTime" is a invalid string that can not be convert.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -104,7 +104,7 @@ it('should throw an error when the value of "every" of "refreshTime" is a invali
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw an error when a converted value of "every" of "refreshTime" is negative.', async () => {
+it('Should throw an error when a converted value of "every" of "refreshTime" is negative.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -127,7 +127,7 @@ it('should throw an error when a converted value of "every" of "refreshTime" is 
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should call next function when schemas have cache with valid refreshTime representation', async () => {
+it('Should call next function when schemas have cache with valid refreshTime representation', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     metadata: {
@@ -148,7 +148,7 @@ it('should call next function when schemas have cache with valid refreshTime rep
 });
 
 // refreshExpression time expression test cases
-it('should throw an error when the value of "every" of "refreshExpression" is a invalid string that can not be convert.', async () => {
+it('Should throw an error when the value of "every" of "refreshExpression" is a invalid string that can not be convert.', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -170,7 +170,7 @@ it('should throw an error when the value of "every" of "refreshExpression" is a 
   );
   expect(next).not.toHaveBeenCalled();
 });
-it('should throw an error when a negative refreshExpression interval is used', async () => {
+it('Should throw an error when a negative refreshExpression interval is used', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
@@ -193,7 +193,7 @@ it('should throw an error when a negative refreshExpression interval is used', a
   expect(next).not.toHaveBeenCalled();
 });
 
-it('should call next function when schemas have cache with valid refreshExpression representation', async () => {
+it('Should call next function when schemas have cache with valid refreshExpression representation', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     metadata: {

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -290,13 +290,11 @@ it('Should throw an error when cacheTableName does not match the regex', async (
     'table_name_with_special_char_/',
   ];
   for (const cacheTableName of invalidCacheTableNames) {
-    if (schemas['cache']) {
-      schemas['cache'][0]['cacheTableName'] = cacheTableName;
-      await expect(middleware.handle(schemas, next)).rejects.toThrow(
-        `The cacheTableName "${cacheTableName}" in schema "/urlPath" should meet the pattern "/^[a-zA-Z_][a-zA-Z0-9_$]+$/`
-      );
-      expect(next).not.toHaveBeenCalled();
-    }
+    schemas['cache']![0]['cacheTableName'] = cacheTableName;
+    await expect(middleware.handle(schemas, next)).rejects.toThrow(
+      `The cacheTableName "${cacheTableName}" in schema "/urlPath" should meet the pattern "/^[a-zA-Z_][a-zA-Z0-9_$]+$/`
+    );
+    expect(next).not.toHaveBeenCalled();
   }
 });
 // should pass test if cacheTableName is valid and meet the regex
@@ -328,11 +326,9 @@ it('Should call next function when schemas have cache with valid cacheTableName'
   ];
 
   for (const cacheTableName of validCacheTableNames) {
-    if (schemas['cache']) {
-      schemas['cache'][0]['cacheTableName'] = cacheTableName;
-      await middleware.handle(schemas, next);
-      expect(next).toHaveBeenCalled();
-    }
+    schemas['cache']![0]['cacheTableName'] = cacheTableName;
+    await middleware.handle(schemas, next);
+    expect(next).toHaveBeenCalled();
   }
 });
 // checkSql
@@ -398,10 +394,8 @@ it('Should assign the first profile in the schemas.profiles to the cache.profile
     ],
   };
   await middleware.handle(schemas, next);
-  if (schemas.cache && schemas.profiles) {
-    expect(schemas.cache[0].profile).toEqual(schemas.profiles[0]);
-    expect(next).toHaveBeenCalled();
-  }
+  expect(schemas.cache![0].profile).toEqual(schemas.profiles![0]);
+  expect(next).toHaveBeenCalled();
 });
 
 it('Should assign the cache.profile to the cache.profile if cache.profile is defined', async () => {
@@ -422,10 +416,8 @@ it('Should assign the cache.profile to the cache.profile if cache.profile is def
     ],
   };
   await middleware.handle(schemas, next);
-  if (schemas.cache && schemas.profiles) {
-    expect(schemas.cache[0].profile).toEqual(schemas.profiles[1]);
-    expect(next).toHaveBeenCalled();
-  }
+  expect(schemas.cache![0].profile).toEqual(schemas.profiles![1]);
+  expect(next).toHaveBeenCalled();
 });
 
 it('Should throw an error when cache.profile is not in the schemas.profiles', async () => {

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -1,46 +1,185 @@
+import { RawAPISchema } from '@vulcan-sql/build';
 import { CheckCache } from '@vulcan-sql/build/schema-parser/middleware/checkCache';
-import { RawAPISchema } from '../../../src';
-
 
 let middleware: CheckCache;
 const next = jest.fn();
 
 beforeEach(() => {
-    middleware = new CheckCache();
-    next.mockClear();
+  middleware = new CheckCache();
+  next.mockClear();
+});
+it('should call next() when there are no caches or cache metadata', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {},
+  };
+  await middleware.handle(schemas, next);
+  expect(next).toHaveBeenCalled();
 });
 
-it('should not throw error if cache is not defined', async () => {
-    const schema: RawAPISchema = { sourceName: 'test' };
-    await middleware.handle(schema, next)
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-it('should throw error if cache is defined but not used in SQL file', async () => {
-    const schema: RawAPISchema = { sourceName: 'test', cache: [{ cacheTableName: 'test', sql: 'select * from test' }] };
-    await expect(middleware.handle(schema,next)).rejects.toThrow('your SQL will use the cache feature, not YAML defined.');
-    expect(next).not.toHaveBeenCalled();
+it('should throw an error when caches is used but not been defined in schema.', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    "Cache feature was used in SQL file, but didn't find the cache configurations in YAML file."
+  );
+  expect(next).not.toHaveBeenCalled();
 });
 
-it('should throw error if both refreshTime and refreshExpression are set', async () => {
-    const schema: RawAPISchema = { 
-        sourceName: 'test', 
-        cache: [
-        { cacheTableName: 'test1', sql: 'select * from test1', refreshTime: { every: '5m' }, refreshExpression: { expression: 'test' } },
-        { cacheTableName: 'test2', sql: 'select * from test2', refreshTime: { every: '5m' } }
-        ],
-        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
-    };
-    await expect(middleware.handle(schema,next)).rejects.toThrow('can not configure refreshTime and refreshExpression at the same time, please pick one');
-    expect(next).not.toHaveBeenCalled();
+it('should throw an error when both refreshTime and refreshExpression are defined.', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: '5m' },
+        refreshExpression: { expression: '*/5,*,*,*,*', every: '5m' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'can not configure refreshTime and refreshExpression at the same time, please pick one'
+  );
+  expect(next).not.toHaveBeenCalled();
 });
 
-it('should call next if cache is defined and used in SQL file', async () => {
-    const schema: RawAPISchema = { 
-        sourceName: 'test', 
-        cache: [{ cacheTableName: 'test', sql: 'select * from test' }],
-        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
-    };
-    await middleware.handle(schema, next);
-    expect(next).toHaveBeenCalledTimes(1);
+// refreshTime expression test cases
+it('should throw an error when an invalid refreshTime representation is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: 'invalidString' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, check node library "ms" for the valid representation'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
+it('should throw an error when a negative refreshTime interval is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: '-5m' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, refreshTime can not be negitive'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
+it('should call next function when schemas have cache with valid refreshTime representation', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshTime: { every: '5m' },
+      },
+    ],
+  };
+  await middleware.handle(schemas, next);
+  expect(next).toHaveBeenCalled();
+});
+
+// refreshExpression time expression test cases
+it('should throw an error when an invalid refreshExpression representation is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshExpression: { every: 'invalidString' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, check node library "ms" for the valid representation'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+it('should throw an error when a negative refreshExpression interval is used', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshExpression: { every: '-5m' },
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'invalid refreshTime representation, refreshTime can not be negitive'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
+it('should call next function when schemas have cache with valid refreshExpression representation', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'test_cache',
+        sql: 'SELECT * FROM test_table',
+        refreshExpression: { every: '5m' },
+      },
+    ],
+  };
+  await middleware.handle(schemas, next);
+  expect(next).toHaveBeenCalled();
 });

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -1,0 +1,46 @@
+import { CheckCache } from '@vulcan-sql/build/schema-parser/middleware/checkCache';
+import { RawAPISchema } from '../../../src';
+
+
+let middleware: CheckCache;
+const next = jest.fn();
+
+beforeEach(() => {
+    middleware = new CheckCache();
+    next.mockClear();
+});
+
+it('should not throw error if cache is not defined', async () => {
+    const schema: RawAPISchema = { sourceName: 'test' };
+    await middleware.handle(schema, next)
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+it('should throw error if cache is defined but not used in SQL file', async () => {
+    const schema: RawAPISchema = { sourceName: 'test', cache: [{ cacheTableName: 'test', sql: 'select * from test' }] };
+    await expect(middleware.handle(schema,next)).rejects.toThrow('your SQL will use the cache feature, not YAML defined.');
+    expect(next).not.toHaveBeenCalled();
+});
+
+it('should throw error if both refreshTime and refreshExpression are set', async () => {
+    const schema: RawAPISchema = { 
+        sourceName: 'test', 
+        cache: [
+        { cacheTableName: 'test1', sql: 'select * from test1', refreshTime: { every: '5m' }, refreshExpression: { expression: 'test' } },
+        { cacheTableName: 'test2', sql: 'select * from test2', refreshTime: { every: '5m' } }
+        ],
+        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
+    };
+    await expect(middleware.handle(schema,next)).rejects.toThrow('can not configure refreshTime and refreshExpression at the same time, please pick one');
+    expect(next).not.toHaveBeenCalled();
+});
+
+it('should call next if cache is defined and used in SQL file', async () => {
+    const schema: RawAPISchema = { 
+        sourceName: 'test', 
+        cache: [{ cacheTableName: 'test', sql: 'select * from test' }],
+        metadata: { 'cache.vulcan.com': { isUsedTag: true } }
+    };
+    await middleware.handle(schema, next);
+    expect(next).toHaveBeenCalledTimes(1);
+});

--- a/packages/build/test/schema-parser/middleware/checkCache.spec.ts
+++ b/packages/build/test/schema-parser/middleware/checkCache.spec.ts
@@ -60,6 +60,7 @@ it('Should throw an error when both refreshTime and refreshExpression are define
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -85,6 +86,7 @@ it('Should throw an error when the value of "every" of "refreshTime" is a invali
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -108,6 +110,7 @@ it('Should throw an error when a converted value of "every" of "refreshTime" is 
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -130,6 +133,7 @@ it('Should throw an error when a converted value of "every" of "refreshTime" is 
 it('Should call next function when schemas have cache with valid refreshTime representation', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -152,6 +156,7 @@ it('Should throw an error when the value of "every" of "refreshExpression" is a 
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -177,6 +182,7 @@ it('Should throw an error when a negative refreshExpression interval is used', a
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -199,6 +205,7 @@ it('Should throw an error when a negative refreshExpression interval is used', a
 it('Should call next function when schemas have cache with valid refreshExpression representation', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -221,6 +228,7 @@ it('Should throw an error when cacheTableName is not defined', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -233,7 +241,7 @@ it('Should throw an error when cacheTableName is not defined', async () => {
     ],
   } as any;
   await expect(middleware.handle(schemas, next)).rejects.toThrow(
-    'The cacheTableName of cache in schema "/urlPath" is not defined.'
+    'The "cacheTableName" of cache in schema "/urlPath" is not defined.'
   );
   expect(next).not.toHaveBeenCalled();
 });
@@ -242,6 +250,7 @@ it('Should throw an error when cacheTableName is not unique', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -268,6 +277,7 @@ it('Should throw an error when cacheTableName does not match the regex', async (
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -301,6 +311,7 @@ it('Should throw an error when cacheTableName does not match the regex', async (
 it('Should call next function when schemas have cache with valid cacheTableName', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -336,6 +347,7 @@ it('Should throw an error when sql is not defined', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -348,7 +360,7 @@ it('Should throw an error when sql is not defined', async () => {
     ],
   } as any;
   await expect(middleware.handle(schemas, next)).rejects.toThrow(
-    'The sql of cache "cache_table_name" in schema "/urlPath" is not defined or is empty.'
+    'The "sql" of cache "cache_table_name" in schema "/urlPath" is not defined or is empty.'
   );
   expect(next).not.toHaveBeenCalled();
 });
@@ -357,6 +369,7 @@ it('Should throw an error when indexes is empty', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',
     urlPath: '/urlPath',
+    profiles: ['profile1'],
     metadata: {
       'cache.vulcan.com': {
         isUsedTag: true,
@@ -377,6 +390,29 @@ it('Should throw an error when indexes is empty', async () => {
 });
 
 // assign profile
+// should throw error if not profiles in schemas
+it('Should throw an error when there is no profile in schemas', async () => {
+  const schemas: RawAPISchema = {
+    sourceName: 'test',
+    urlPath: '/urlPath',
+    metadata: {
+      'cache.vulcan.com': {
+        isUsedTag: true,
+      },
+    },
+    cache: [
+      {
+        cacheTableName: 'cache_table_name',
+        sql: 'SELECT * FROM test_table',
+      },
+    ],
+  };
+  await expect(middleware.handle(schemas, next)).rejects.toThrow(
+    'The "profiles" of schema "/urlPath" is not defined.'
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
 it('Should assign the first profile in the schemas.profiles to the cache.profile if cache.profile is not defined', async () => {
   const schemas: RawAPISchema = {
     sourceName: 'test',

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -94,11 +94,20 @@ export class Sample {
   req?: KoaRequest;
 }
 
+export class RefreshTime {
+  every!: string;
+}
+
+export class RefreshExpression {
+  expression!: string;
+  every!: string;
+}
+
 export class CacheLayerInfo {
   cacheTableName!: string;
   sql!: string;
-  refreshTime?: Record<string, string>;
-  refreshExpression?: Record<string, string>;
+  refreshTime?: RefreshTime;
+  refreshExpression?: RefreshExpression;
   // index key name -> index column
   indexes?: Record<string, string>;
 }
@@ -122,7 +131,7 @@ export class APISchema {
   pagination?: PaginationSchema;
   sample?: Sample;
   profiles!: Array<string>;
-  cache?:Array<CacheLayerInfo>;
+  cache?: Array<CacheLayerInfo>;
 }
 
 export class BuiltArtifact {

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -94,6 +94,15 @@ export class Sample {
   req?: KoaRequest;
 }
 
+export class CacheLayerInfo {
+  cacheTableName!: string;
+  sql!: string;
+  refreshTime?: Record<string, string>;
+  refreshExpression?: Record<string, string>;
+  // index key name -> index column
+  indexes?: Record<string, string>;
+}
+
 export class APISchema {
   // graphql operation name
   operationName!: string;
@@ -113,6 +122,7 @@ export class APISchema {
   pagination?: PaginationSchema;
   sample?: Sample;
   profiles!: Array<string>;
+  cache?:Array<CacheLayerInfo>;
 }
 
 export class BuiltArtifact {

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -106,6 +106,7 @@ export class RefreshExpression {
 export class CacheLayerInfo {
   cacheTableName!: string;
   sql!: string;
+  profile!: string;
   refreshTime?: RefreshTime;
   refreshExpression?: RefreshExpression;
   // index key name -> index column

--- a/yarn.lock
+++ b/yarn.lock
@@ -5574,6 +5574,11 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+ms@3.0.0-canary.1:
+  version "3.0.0-canary.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-3.0.0-canary.1.tgz#c7b34fbce381492fd0b345d1cf56e14d67b77b80"
+  integrity sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"


### PR DESCRIPTION
## Description

This pull request adds a new middleware to validate cache configurations defined in the .yaml file. 

Validation logic:
 - if cache is used in .SQL file, but no cache configuration found in .yaml file, throw error.
 - if cache configuration is set, the refreshTime and refreshExpression can not exist at the same time.
 - the time interval(variable "every") in refreshTime and refreshExpression should be a valid string that can be parse by library ["ms"](https://github.com/vercel/ms), throw Error if not valid.


## Issue ticket number
issue #151 

## Additional Context
 - This PR does not include the validation of the variable "express" in refreshExpress and the indexes configuration.
 - the SQL defined in the .yaml file will be validated in another place(like SQL engine).
