### PR TITLE
Change the way to suppress the aws-sdk warning

### DIFF
--- a/packages/extension-driver-snowflake/src/index.ts
+++ b/packages/extension-driver-snowflake/src/index.ts
@@ -1,6 +1,7 @@
 // suppress the warning message from aws-sdk: Please migrate your code to use AWS SDK for JavaScript (v3).
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('aws-sdk/lib/maintenance_mode_message').suppress = true;
+// since in aws-sdk, they only check if AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE exists, but not the value
+// setting it to a string value of 1 should work
+process.env['AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE'] = '1';
 
 export * from './lib/snowflakeDataSource';
 import { SnowflakeDataSource } from './lib/snowflakeDataSource';


### PR DESCRIPTION
## Description
Using require seems to cause module not found issue. Setting env instead.

[CI failed link](https://app.circleci.com/pipelines/github/Canner/vulcan-sql/920/workflows/9613aabf-8595-46da-a93d-01cbc6e2ab50/jobs/2799)
