### PR TITLE
fix(doc): wrong api endpoint

### DIFF
--- a/packages/doc/docs/get-started/first-api.mdx
+++ b/packages/doc/docs/get-started/first-api.mdx
@@ -37,7 +37,7 @@ The following steps will differ depending on your installation method:
   In this quick-start project, we query the flights data from a CSV file with DuckDB. To test the API endpoint, try the following query in your browser or with curl:
 
   ```bash
-  curl http://localhost:3000/api/user
+  curl http://localhost:3000/api/flights
   ```
 
   You should see the response:


### PR DESCRIPTION
## Description

In this [page](https://vulcansql.com/docs/get-started/first-api), the api endpoint should be `http://localhost:3000/api/flights` instead of `http://localhost:3000/api/user`

## Issue ticket number

None

## Additional Context

None