### PR TITLE
Fix: The "bcryptjs" dependency package missing after install the "serve" package

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "babel-jest": "27.5.1",
     "babel-plugin-import": "^1.13.5",
     "babel-plugin-styled-components": "1.10.7",
-    "bcryptjs": "^2.4.3",
     "commitizen": "^4.2.5",
     "cypress": "^9.1.0",
     "cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
## Description
According to #175, the reason is that the "bcryptjs" package install in `devDenependecies`, so when users install the @vulcan/serve, the "bcryptjs" wouldn't be installed, so the solution is moving the "bcryptjs" package to `denependecies` in `package.json` to make it work.

## Issue ticket number

closes #175


