### PR TITLE
Chore: Add additional catalog package.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -27,6 +27,5 @@
         "linter": "eslint"
       }
     }
-  },
-  "defaultProject": "catalog-server"
+  }
 }

--- a/packages/catalog-server/README.md
+++ b/packages/catalog-server/README.md
@@ -1,0 +1,45 @@
+# catalog-server
+
+This package serves as a catalog page for VulcanSQL.
+
+## Install
+
+1. Install package
+
+    ```bash
+    npm i @vulcan-sql/catalog-server
+    ```
+
+2. Use [@vulcan-sql/cli](https://www.npmjs.com/package/@vulcan-sql/cli) to start the catalog server.
+<br/>(The VulcanSQL server needs to listen first.)
+
+    ```bash
+    vulcan catalog
+    ```
+
+3. Open in browser. By default, it is http://localhost:4200.
+
+
+## Running a Production
+
+1. Use [@vulcan-sql/cli](https://www.npmjs.com/package/@vulcan-sql/cli) to generate the catalog server assets.
+
+    Node.js:
+    ```bash
+      vulcan package -o node -t catalog-server
+    ```
+    Copy the files in the `./dist` folder to your production servers. Then run `npm install` && `node index.js` to start the server.
+
+    Docker:
+    ```bash
+      vulcan package -o docker -t catalog-server
+      docker build -t <tag> ./dist
+    ```
+
+
+## Configurations (optional)
+
+```yaml
+catalog:
+  port: 4200
+```

--- a/packages/catalog-server/package.json
+++ b/packages/catalog-server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@vulcan-sql/catalog-server",
+  "description": "Catalog server for VulcanSQL",
+  "version": "0.4.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "vulcan",
+    "vulcan-sql",
+    "data",
+    "sql",
+    "database",
+    "data-warehouse",
+    "data-lake",
+    "api-builder",
+    "app"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Canner/vulcan-sql.git"
+  },
+  "license": "MIT"
+}

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -3,6 +3,11 @@ import { getReleaseTag, getVersionByArguments } from './version.mjs';
 import path from 'path';
 import fs from 'fs';
 
+// targetProject: ./packages/xxx
+const workspaceRoot = process.env.NX_WORKSPACE_ROOT;
+const targetProject = process.env.NX_TASK_TARGET_PROJECT
+const targetProjectPath = path.resolve(workspaceRoot, `packages/${targetProject}`)
+
 // node publish.mjs <tag> <version>
 // CWD: ./dist/packages/xxx
 const packageJSONPath = path.resolve(process.cwd(), 'package.json');
@@ -32,5 +37,14 @@ fs.writeFileSync(
   '//registry.npmjs.org/:_authToken=${NPM_TOKEN}',
   'utf-8'
 );
+
+// Replace the README.md from target project
+const readme = fs.readFileSync(`${targetProjectPath}/README.md`, 'utf-8');
+fs.writeFileSync(
+  'README.md',
+  readme,
+  'utf-8'
+)
+
 // Execute "npm publish" to publish
 execSync(`npm publish --tag ${tag}`);


### PR DESCRIPTION
## Description

Nx will not help to create `package.json` & `README.md` in the source of the `Next.js` package by default,
so the Catalog server needs to add `package.json` to provide `name` & `version` and add `README.md` for release.

## Additional Context
- remove default project setting

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
