### PR TITLE
Fix: Face issue when testing the VulcanSQL integration with Canner Enteprise

### DIFF
--- a/packages/extension-store-canner/src/lib/canner/profileReader.ts
+++ b/packages/extension-store-canner/src/lib/canner/profileReader.ts
@@ -2,7 +2,6 @@ import {
   Profile,
   ProfileReader,
   VulcanExtensionId,
-  VulcanInternalExtension,
   ConfigurationError,
 } from '@vulcan-sql/core';
 import { CannerStoreConfig, getEnvConfig } from '../config';
@@ -19,7 +18,6 @@ export interface CannerProfileReaderOptions {
  * Used the string to identify the extension Id not by the enum "LocalFileProfileReader".
  * Because if we create another enum to extend the 'LocalFileProfileReader', it seems unnecessary to give the new enum only has 'Canner' as its type."
  *  */
-@VulcanInternalExtension()
 @VulcanExtensionId('Canner')
 export class CannerProfileReader extends ProfileReader {
   private envConfig: CannerStoreConfig = getEnvConfig();
@@ -58,7 +56,7 @@ export class CannerProfileReader extends ProfileReader {
         ) as ArtifactIndicator;
         const workspaceSqlName = indicator[workspaceId];
         const profile = {
-          name: `profile-${workspaceSqlName}`,
+          name: `canner-${workspaceSqlName}`,
           type: 'canner',
           connection: {
             user,

--- a/packages/extension-store-canner/src/lib/canner/profileReader.ts
+++ b/packages/extension-store-canner/src/lib/canner/profileReader.ts
@@ -3,7 +3,7 @@ import {
   ProfileReader,
   VulcanExtensionId,
   VulcanInternalExtension,
-  ConfigurationError
+  ConfigurationError,
 } from '@vulcan-sql/core';
 import { CannerStoreConfig, getEnvConfig } from '../config';
 import { createStorageService } from '../storageService';
@@ -38,7 +38,11 @@ export class CannerProfileReader extends ProfileReader {
     });
     // get the indicator files path of each workspaces
     const files = await getIndicatorFilesOfWorkspaces(filesInfo);
-    this.logger.debug('Succeed to get the indicator files of each workspaces');
+    this.logger.debug(
+      `Succeed to get the indicator files of each workspaces: ${JSON.stringify(
+        files
+      )}`
+    );
 
     // generate profiles from the indicator files of each workspaces
     const { user, password, host, port } = this.envConfig.profile;
@@ -65,7 +69,7 @@ export class CannerProfileReader extends ProfileReader {
           },
           allow: '*',
         } as Profile<Record<string, any>>;
-        this.logger.debug(`created ${profile.name}.`);
+        this.logger.debug(`created "${profile.name}".`);
         return profile;
       })
     );

--- a/packages/extension-store-canner/src/test/cannerPersistenceStore.spec.ts
+++ b/packages/extension-store-canner/src/test/cannerPersistenceStore.spec.ts
@@ -139,7 +139,6 @@ describe('Test CannerPersistenceStore', () => {
 
   it('Should load successfully when "specs" field is "oas3" format ', async () => {
     // Arrange
-
     // test artifacts from each workspaces downloaded from storage
     const artifacts = {
       ws1: {
@@ -156,7 +155,12 @@ describe('Test CannerPersistenceStore', () => {
           oas3: {
             ...sinon.stubInterface<oas3.OpenAPIObject>(),
             paths: {
-              '/orders': {},
+              '/orders': {
+                get: {
+                  operationId: 'get/orders',
+                  summary: '/orders',
+                },
+              },
             },
           },
         },
@@ -175,7 +179,12 @@ describe('Test CannerPersistenceStore', () => {
           oas3: {
             ...sinon.stubInterface<oas3.OpenAPIObject>(),
             paths: {
-              '/products/:id': {},
+              '/products/:id': {
+                get: {
+                  operationId: 'get/products/:id',
+                  summary: '/products/:id',
+                },
+              },
             },
           },
         },
@@ -209,10 +218,19 @@ describe('Test CannerPersistenceStore', () => {
             description: 'Data API for Canner Enterprise',
           },
           paths: {
-            [`${fakeWorkspaces.ws1.sqlName}/orders`]:
-              artifacts['ws1'].specs['oas3'].paths['/orders'],
-            [`${fakeWorkspaces.ws2.sqlName}/products/:id`]:
-              artifacts['ws2'].specs['oas3'].paths['/products/:id'],
+            [`${fakeWorkspaces.ws1.sqlName}/orders`]: {
+              get: {
+                operationId: `get/${fakeWorkspaces.ws1.sqlName}/orders`,
+                summary: `/${fakeWorkspaces.ws1.sqlName}/orders`,
+              },
+            },
+
+            [`${fakeWorkspaces.ws2.sqlName}/products/:id`]: {
+              get: {
+                operationId: `get/${fakeWorkspaces.ws2.sqlName}/products/:id`,
+                summary: `/${fakeWorkspaces.ws2.sqlName}/products/:id`,
+              },
+            },
           },
         },
       },

--- a/packages/extension-store-canner/src/test/cannerPersistenceStore.spec.ts
+++ b/packages/extension-store-canner/src/test/cannerPersistenceStore.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '../lib/canner/persistenceStore';
 
 describe('Test CannerPersistenceStore', () => {
+  const fakePath = 'fake-path';
   // fake workspaceId
   const fakeWorkspaces = {
     // fake workspace id and sql name
@@ -41,21 +42,25 @@ describe('Test CannerPersistenceStore', () => {
   };
   const fakeStorageListedObjectsInfo = {
     ws1: {
-      indicator: { name: `${fakeWorkspaces.ws1.id}/vulcansql/indicator.json` },
+      indicator: {
+        name: `${fakePath}/${fakeWorkspaces.ws1.id}/vulcansql/indicator.json`,
+      },
       artifact: {
-        name: `${fakeWorkspaces.ws1.id}/vulcansql/${fakeWorkspaces.ws1.folders[1]}/result.json`,
+        name: `${fakePath}/${fakeWorkspaces.ws1.id}/vulcansql/${fakeWorkspaces.ws1.folders[1]}/result.json`,
       },
       others: [
-        { name: `${fakeWorkspaces.ws1.id}/notebook` },
-        { name: `${fakeWorkspaces.ws1.id}/notebook_output` },
+        { name: `${fakePath}/${fakeWorkspaces.ws1.id}/notebook` },
+        { name: `${fakePath}/${fakeWorkspaces.ws1.id}/notebook_output` },
       ],
     },
     ws2: {
-      indicator: { name: `${fakeWorkspaces.ws2.id}/vulcansql/indicator.json` },
-      artifact: {
-        name: `${fakeWorkspaces.ws2.id}/vulcansql/${fakeWorkspaces.ws2.folders[1]}/result.json`,
+      indicator: {
+        name: `${fakePath}/${fakeWorkspaces.ws2.id}/vulcansql/indicator.json`,
       },
-      others: [{ name: `${fakeWorkspaces.ws2.id}/data` }],
+      artifact: {
+        name: `${fakePath}/${fakeWorkspaces.ws2.id}/vulcansql/${fakeWorkspaces.ws2.folders[1]}/result.json`,
+      },
+      others: [{ name: `${fakePath}/${fakeWorkspaces.ws2.id}/data` }],
     },
   };
 
@@ -128,8 +133,14 @@ describe('Test CannerPersistenceStore', () => {
       .stub(storageServiceModule, 'createStorageService')
       .resolves(stubStorageService);
 
-    const stubOption = sinon.stubInterface<ArtifactBuilderOptions>();
-    const store = new CannerPersistenceStore(stubOption, {}, 'Canner');
+    const store = new CannerPersistenceStore(
+      {
+        ...sinon.stubInterface<ArtifactBuilderOptions>(),
+        filePath: fakePath,
+      },
+      {},
+      'Canner'
+    );
 
     // Act, Assert
     await expect(store.load()).rejects.toThrowError(
@@ -269,8 +280,14 @@ describe('Test CannerPersistenceStore', () => {
       .stub(storageServiceModule, 'createStorageService')
       .resolves(stubStorageService);
 
-    const stubOption = sinon.stubInterface<ArtifactBuilderOptions>();
-    const store = new CannerPersistenceStore(stubOption, {}, 'Canner');
+    const store = new CannerPersistenceStore(
+      {
+        ...sinon.stubInterface<ArtifactBuilderOptions>(),
+        filePath: fakePath,
+      },
+      {},
+      'Canner'
+    );
 
     const mergedArtifact = JSON.parse((await store.load()).toString('utf-8'));
     // Act, Assert

--- a/packages/extension-store-canner/src/test/cannerProfileReader.spec.ts
+++ b/packages/extension-store-canner/src/test/cannerProfileReader.spec.ts
@@ -122,7 +122,7 @@ describe('Test CannerProfileReader', () => {
     };
     const expected = [
       {
-        name: `profile-${fakeWorkspaces.ws1.sqlName}`,
+        name: `canner-${fakeWorkspaces.ws1.sqlName}`,
         type: 'canner',
         connection: {
           ...connectionInfo,
@@ -131,7 +131,7 @@ describe('Test CannerProfileReader', () => {
         allow: '*',
       },
       {
-        name: `profile-${fakeWorkspaces.ws2.sqlName}`,
+        name: `canner-${fakeWorkspaces.ws2.sqlName}`,
         type: 'canner',
         connection: {
           ...connectionInfo,

--- a/packages/serve/src/lib/evaluator/evaluator.ts
+++ b/packages/serve/src/lib/evaluator/evaluator.ts
@@ -53,6 +53,7 @@ export class Evaluator {
         );
         continue;
       }
+      logger.debug(`profile: ${profile.name}, allow: ${profile.allow}`);
       this.profiles.set(profile.name, this.getConstraints(profile.allow));
     }
   }


### PR DESCRIPTION
## Description
Faced the issues when testing the VulcanSQL Integration with Canner Enterprise:

1. API Documentation is not consistent for the API prefix when getting the artifacts from Canner Enterprise and merging to one artifact, we need to make the `operationId` and `summary` field add the workspace SQL name in `specs`, then it could solve the solution.

2. The generated canner profile name in `CannerProfileReader` is not the same as `CannerPersistenceStore`, so we need to fix it to the same `canner-{workspaceSqlName}`.

## Issue ticket number

closes N/A


## Screenshot for integrating with Canner Enterprise.
We opened a Canner Enterprise of PR testing env and create two workspaces `w1` and `w2` with the tables:
![PR env - w1](https://github.com/Canner/vulcan-sql/assets/5389253/7ad9141c-baa9-4617-9c3b-749133e21c61)

![PR env - w2](https://github.com/Canner/vulcan-sql/assets/5389253/f612f45e-7531-428c-b3ae-d4cc2bc767cb)


Use the In the VulcanSQL `labs` and create two profiles `canner-w1` and `canner-w2` with temporal PAT fo connecting Canner Enterprise by `extension-driver-canner` through PG Wire Protocol:
![截圖 2023-06-12 下午3 44 23](https://github.com/Canner/vulcan-sql/assets/5389253/f54fa26a-1b8b-4a53-926a-ca2c36c57f61)


Below, we put the two SQL with API Schema definition to query `w1` and  run `vulcan build` for building the SQL and API schema to the artifact for `w1`
![截圖 2023-06-12 下午3 41 29](https://github.com/Canner/vulcan-sql/assets/5389253/25ba9119-ce4b-4075-8b9c-1c81971d1879)

Upload them to Canner Enterprise, and see the uploaded artifacts in VulcanSQL folder of `w1`:

![截圖 2023-06-12 下午4 00 13](https://github.com/Canner/vulcan-sql/assets/5389253/5335cd65-6371-4b6d-89d6-f532db6ab20a)
![截圖 2023-06-12 下午4 00 18](https://github.com/Canner/vulcan-sql/assets/5389253/208f2474-b24e-4d9c-82ec-1e289cd018c3)

Do the same steps for `w2`, put the two SQL with API Schema definition to query `w2` and  run `vulcan build` for building the SQL and API 

![截圖 2023-06-12 下午3 41 49](https://github.com/Canner/vulcan-sql/assets/5389253/c569fc4e-b1d8-447f-8ddc-a8ec6f4db14f)

Upload them to Canner Enterprise, and see the uploaded artifacts in VulcanSQL folder of `w2`:
![截圖 2023-06-12 下午3 39 13](https://github.com/Canner/vulcan-sql/assets/5389253/11de80d2-09ee-42b5-826e-88d5d108a023)
![截圖 2023-06-12 下午3 39 02](https://github.com/Canner/vulcan-sql/assets/5389253/cb52de92-3e1c-4430-a641-31b93a97aa9e)

Now we delete the SQLs and API schemas files, in the `lasbs` project, and update the `vulcan.yaml` for `artifact` options, `extensions` and `profiles` like below to use the Canner extension:

HINT: currently, the extension not include Canner PAT authenticator, because it's developing, so we will make `auth` options keep `enabled: false`.

```yaml
....
artifact:
  provider: Canner # use Canner Persistence Store
  serializer: JSON
  # Path to build result
  filePath: fe54258b-da25-408b-a019-efb3b36f1b47 # root path

extensions:
  duckdb: "@vulcan-sql/extension-driver-duckdb"
  # Needed extensions for integrating with Canner Enterprise
  canner-driver: "@vulcan-sql/extension-driver-canner"
  canner-store: "@vulcan-sql/extension-store-canner"

profiles:
  # Specify the Canner profile reader to create profiles with different databases indicating to the workspaces of Canner Enterprise
  - type: Canner # use Canner Profile Reader
    options:
      path: fe54258b-da25-408b-a019-efb3b36f1b47 # root path
```

Then set some  environment variables we need:

```bash
MINIO_ACCESS_KEY=<ACCESS-KEY>
MINIO_BUCKET=<BUCKET>
MINIO_PORT=9000
MINIO_SECRET_KEY=<SECRETE-KEY>
MINIO_SSL=false
MINIO_URL=<IP>

PROFILE_CANNER_DRIVER_HOST=<IP>
PROFILE_CANNER_DRIVER_PASSWORD=<PAT>
PROFILE_CANNER_DRIVER_USER=<USER>
```

Finally, run `vulcan serve` to fetch the artifacts from Canner Enterprise, and generate Canner Enterprise Profiles settings:

![截圖 2023-06-12 下午3 23 20](https://github.com/Canner/vulcan-sql/assets/5389253/39df87c5-1356-44a8-8e3a-4adeccc0c560)

Open the API documentation URL, we will see the workspace SQL Name in the prefix for the `w1` and `w2` Data API:

![截圖 2023-06-12 下午3 21 39](https://github.com/Canner/vulcan-sql/assets/5389253/c543fcf7-b88f-4961-a24a-036d0c51c325)

Send request to `/api/w1/activity_logs?operation=VIEW` to query and you will see the result:
![截圖 2023-06-12 下午3 22 18](https://github.com/Canner/vulcan-sql/assets/5389253/83904dc5-ec8f-4952-b5c7-5c23d5a344e3)

Send request to `/api/w2/resource_metadata?data_type=DATA_SOURCE_TABLE` to query and you will see the result:

![截圖 2023-06-12 下午3 22 44](https://github.com/Canner/vulcan-sql/assets/5389253/27871a48-4193-4c96-bfe7-065355f73ab0)

You could also see the logs in VulcanSQL:

![截圖 2023-06-12 下午3 23 36](https://github.com/Canner/vulcan-sql/assets/5389253/bc282eb6-efe3-4264-be3a-5e227619dbeb)

Done :)

## Additional Context


- add the `logger.debug` could see the workspaces indicator information in `CannerProfileReader` and `CannerPersistenceStore`.
- remove unnecessary `@VulcanInternalExtension()` in `CannerProfileReader` and `CannerPersistenceStore`, because both of them are not internal extensions, thet load by external extension type, so the `VulcanInternalExtension` won't be used