### PR TITLE
Fix: update "project.json" to sync and missed publish command for "extension-authenticator-canner"

### DIFF
--- a/packages/extension-authenticator-canner/project.json
+++ b/packages/extension-authenticator-canner/project.json
@@ -3,14 +3,33 @@
   "sourceRoot": "packages/extension-authenticator-canner/src",
   "targets": {
     "build": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "yarn ts-node ./tools/scripts/replaceAlias.ts extension-authenticator-canner"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "tsc"
+        }
+      ]
+    },
+    "tsc": {
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/packages/extension-authenticator-canner",
         "main": "packages/extension-authenticator-canner/src/index.ts",
         "tsConfig": "packages/extension-authenticator-canner/tsconfig.lib.json",
-        "assets": ["packages/extension-authenticator-canner/*.md"]
-      }
+        "assets": ["packages/extension-authenticator-canner/*.md"],
+        "buildableProjectDepsInPackageJsonType": "dependencies"
+      },
+      "dependsOn": [
+        {
+          "projects": "dependencies",
+          "target": "build"
+        }
+      ]
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",
@@ -26,6 +45,19 @@
         "jestConfig": "packages/extension-authenticator-canner/jest.config.ts",
         "passWithNoTests": true
       }
+    },
+    "publish": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "node ../../../tools/scripts/publish.mjs {args.tag} {args.version}",
+        "cwd": "dist/packages/extension-authenticator-canner"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "build"
+        }
+      ]
     }
   },
   "tags": []


### PR DESCRIPTION

## Description
Discover "project.json" missed "publish" command in "extension-authenticator-canner", so when do the publish to NPM, it not existed, and also discover other commands do not use `replaceAlias.ts` file, so we need to add it.

## Issue ticket number

N/A

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
