### PR TITLE
Fix: Typo issue for "port" in the README at "extension-canner-authenticator".

### DIFF
--- a/packages/extension-authenticator-canner/README.md
+++ b/packages/extension-authenticator-canner/README.md
@@ -21,18 +21,18 @@ This extension let Data API request can be authenticated with [Canner PAT](https
 
    extensions:
      canner-authenticator: '@vulcan-sql/extension-authenticator-canner'
-   ``` 
+   ```
 
 3. Update `vulcan.yaml`, define your `canner-authenticator`
    ```yaml
    canner-authenticator:
-     # To having the same config structure to the authenticator middleware, we 
+     # To having the same config structure to the authenticator middleware, we need to put options under "options".
      options:
        canner-pat:
-          # your canner enterprise host
-          host: 'my-canner-host-dns'
-          # your canner enterprise post
-          post: 443
-          # indicate using http or https default is false
-          ssl: true
+         # your canner enterprise host
+         host: 'my-canner-host-dns'
+         # your canner enterprise port
+         port: 443
+         # indicate using http or https default is false
+         ssl: true
    ```


### PR DESCRIPTION
## Description
In the `extension-canner-authenticator` package, exist the typo for `port` options, it may need to fix, because the README also displays on [NPM package](https://www.npmjs.com/package/@vulcan-sql/extension-authenticator-canner).

## Issue ticket number

N/A

## Additional Context

N/A
