### PR TITLE
Chore(authenticator): match authenticator in middleware

### DIFF
--- a/packages/extension-authenticator-canner/src/lib/authenticator/pat.ts
+++ b/packages/extension-authenticator-canner/src/lib/authenticator/pat.ts
@@ -34,19 +34,7 @@ export class CannerPATAuthenticator extends BaseAuthenticator<CannerPATOptions> 
   }
 
   public async authCredential(context: KoaContext) {
-    const incorrect = {
-      status: AuthStatus.INDETERMINATE,
-      type: this.getExtensionId()!,
-    };
-    const authorize = context.request.headers['authorization'];
-    if (
-      // no need to check this.options because it a external extension,
-      // it must be configured correctly to be load into container and can be used in authenticate middleware
-      !authorize ||
-      !authorize.toLowerCase().startsWith(this.getExtensionId()!)
-    )
-      return incorrect;
-
+    const authorize = <string>context.request.headers['authorization'];
     if (isEmpty(this.options) || !this.options.host)
       throw new ConfigurationError(
         'please provide correct connection information to Canner Enterprise, including "host".'

--- a/packages/extension-authenticator-canner/src/test/cannerPATAuthenticator.spec.ts
+++ b/packages/extension-authenticator-canner/src/test/cannerPATAuthenticator.spec.ts
@@ -24,10 +24,6 @@ const getStubAuthenticator = async (
   return authenticator;
 };
 
-const expectIncorrect = {
-  status: AuthStatus.INDETERMINATE,
-  type: 'canner-pat',
-};
 const expectFailed = (
   message = 'authenticate user by "canner-pat" type failed.'
 ) => ({
@@ -65,47 +61,6 @@ it.each([
   await expect(authenticator.authCredential(ctx)).rejects.toThrow(
     'please provide correct connection information to Canner Enterprise, including "host".'
   );
-});
-
-it('Test to auth credential failed when request header not exist "authorization" key', async () => {
-  // Arrange
-  const ctx = {
-    ...sinon.stubInterface<KoaContext>(),
-    request: {
-      ...sinon.stubInterface<Request>(),
-      headers: {
-        ...sinon.stubInterface<IncomingHttpHeaders>(),
-      },
-    },
-  } as KoaContext;
-  const authenticator = await getStubAuthenticator(mockOptions);
-
-  // Act
-  const result = await authenticator.authCredential(ctx);
-
-  // Assert
-  expect(result).toEqual(expectIncorrect);
-});
-
-it('Should auth credential failed when request header "authorization" not start with "canner-pat"', async () => {
-  // Arrange
-  const ctx = {
-    ...sinon.stubInterface<KoaContext>(),
-    request: {
-      ...sinon.stubInterface<Request>(),
-      headers: {
-        ...sinon.stubInterface<IncomingHttpHeaders>(),
-        authorization: 'Incorrect-Prefix 1234567890',
-      },
-    },
-  } as KoaContext;
-  const authenticator = await getStubAuthenticator(mockOptions);
-
-  // Act
-  const result = await authenticator.authCredential(ctx);
-
-  // Assert
-  expect(result).toEqual(expectIncorrect);
 });
 
 // the situation of status code 4xx, 5xx(including 401, 403) is handled by axios

--- a/packages/serve/src/lib/auth/httpBasicAuthenticator.ts
+++ b/packages/serve/src/lib/auth/httpBasicAuthenticator.ts
@@ -111,17 +111,11 @@ export class BasicAuthenticator extends BaseAuthenticator<BasicOptions> {
       status: AuthStatus.INDETERMINATE,
       type: this.getExtensionId()!,
     };
-    if (isEmpty(this.options)) return incorrect;
-
-    const authorize = context.request.headers['authorization'];
-    if (
-      !this.getOptions() ||
-      !authorize ||
-      !authorize.toLowerCase().startsWith(this.getExtensionId()!)
-    )
-      return incorrect;
+    // will not auth user if vulcan.yaml didn't configure this authenticator
+    if (isEmpty(this.options) || !this.getOptions()) return incorrect;
 
     // validate request auth token
+    const authorize = <string>context.request.headers['authorization'];
     const token = authorize.trim().split(' ')[1];
     const bareToken = Buffer.from(token, 'base64').toString();
 

--- a/packages/serve/src/lib/auth/passwordFileAuthenticator.ts
+++ b/packages/serve/src/lib/auth/passwordFileAuthenticator.ts
@@ -92,16 +92,11 @@ export class PasswordFileAuthenticator extends BaseAuthenticator<PasswordFileOpt
       status: AuthStatus.INDETERMINATE,
       type: this.getExtensionId()!,
     };
-    if (isEmpty(this.options)) return incorrect;
+    // will not auth user if vulcan.yaml didn't configure this authenticator
+    if (isEmpty(this.options) || !this.getOptions()) return incorrect;
 
-    const authorize = context.request.headers['authorization'];
-    if (
-      !this.getOptions() ||
-      !authorize ||
-      !authorize.toLowerCase().startsWith(this.getExtensionId()!)
-    )
-      return incorrect;
     // validate request auth token
+    const authorize = <string>context.request.headers['authorization'];
     const token = authorize.trim().split(' ')[1];
     const bareToken = Buffer.from(token, 'base64').toString();
     try {

--- a/packages/serve/src/lib/auth/simpleTokenAuthenticator.ts
+++ b/packages/serve/src/lib/auth/simpleTokenAuthenticator.ts
@@ -63,15 +63,10 @@ export class SimpleTokenAuthenticator extends BaseAuthenticator<SimpleTokenOptio
       status: AuthStatus.INDETERMINATE,
       type: this.getExtensionId()!,
     };
-    if (isEmpty(this.options)) return incorrect;
+    if (isEmpty(this.options) || !this.getOptions()) return incorrect;
 
-    const authorize = context.request.headers['authorization'];
-    if (
-      !authorize ||
-      !authorize.toLowerCase().startsWith(this.getExtensionId()!)
-    )
-      return incorrect;
     // validate request auth token
+    const authorize = <string>context.request.headers['authorization'];
     const token = authorize.trim().split(' ')[1];
     try {
       return await this.validate(token);

--- a/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
@@ -44,10 +44,24 @@ export class AuthCredentialsMiddleware extends BaseAuthMiddleware {
     // The endpoint not need contains auth credentials
     if (checkIsPublicEndpoint(this.projectOptions, context.path)) return next();
 
+    const authorize = context.request?.headers['authorization'];
+    if (!authorize) {
+      throw new UserError('Please provide proper authorization information', {
+        httpCode: 401,
+        code: 'vulcan.unauthorized',
+      });
+    }
+
     // pass current context to auth token for users
     for (const name of Object.keys(this.authenticators)) {
+      const authenticator = this.authenticators[name];
+      if (
+        !authorize.toLowerCase().startsWith(authenticator.getExtensionId()!)
+      ) {
+        continue;
+      }
       // auth token
-      const result = await this.authenticators[name].authCredential(context);
+      const result = await authenticator.authCredential(context);
       // if state is indeterminate, change to next authentication
       if (result.status === AuthStatus.INDETERMINATE) continue;
       // if state is failed, return directly

--- a/packages/serve/test/auth/basicAuthenticator.spec.ts
+++ b/packages/serve/test/auth/basicAuthenticator.spec.ts
@@ -60,7 +60,7 @@ describe('Test http basic authenticator', () => {
     },
   ] as Array<AuthUserListOptions>;
 
-  it.each([[{}], [{ 'non-basic': {} }], [{ basic: {} }]])(
+  it.each([[{}]])(
     'Should auth incorrect when options = %p in options',
     async (options) => {
       // Arrange
@@ -78,44 +78,6 @@ describe('Test http basic authenticator', () => {
       expect(result).toEqual(expectIncorrect);
     }
   );
-  it('Test to auth credential failed when request header not exist "authorization" key', async () => {
-    // Arrange
-    const ctx = {
-      ...sinon.stubInterface<KoaContext>(),
-      request: {
-        ...sinon.stubInterface<Request>(),
-        headers: {
-          ...sinon.stubInterface<IncomingHttpHeaders>(),
-        },
-      },
-    };
-
-    // Act
-    const result = await authCredential(ctx, { basic: {} });
-
-    // Assert
-    expect(result).toEqual(expectIncorrect);
-  });
-
-  it('Should auth credential failed when request header "authorization" not start with "basic"', async () => {
-    // Arrange
-    const ctx = {
-      ...sinon.stubInterface<KoaContext>(),
-      request: {
-        ...sinon.stubInterface<Request>(),
-        headers: {
-          ...sinon.stubInterface<IncomingHttpHeaders>(),
-          authorization: '',
-        },
-      },
-    };
-
-    // Act
-    const result = await authCredential(ctx, { basic: {} });
-
-    // Assert
-    expect(result).toEqual(expectIncorrect);
-  });
 
   it('Should auth credential failed when request header "authorization" not match in empty "users-list" options', async () => {
     // Arrange

--- a/packages/serve/test/auth/passwordFileAuthenticator.spec.ts
+++ b/packages/serve/test/auth/passwordFileAuthenticator.spec.ts
@@ -53,7 +53,7 @@ describe('Test password-file authenticator', () => {
     },
   ];
 
-  it.each([[{}], [{ 'simple-token': [] }], [{ basic: {} }]])(
+  it.each([[{}]])(
     'Should auth incorrect when options = %p in options',
     async (options) => {
       // Arrange
@@ -71,48 +71,6 @@ describe('Test password-file authenticator', () => {
       expect(result).toEqual(expectIncorrect);
     }
   );
-  it('Test to auth credential failed when request header not exist "authorization" key', async () => {
-    // Arrange
-    const ctx = {
-      ...sinon.stubInterface<KoaContext>(),
-      request: {
-        ...sinon.stubInterface<Request>(),
-        headers: {
-          ...sinon.stubInterface<IncomingHttpHeaders>(),
-        },
-      },
-    } as KoaContext;
-
-    // Act
-    const result = await authCredential(ctx, {
-      'password-file': { path: '', users: [] },
-    });
-
-    // Assert
-    expect(result).toEqual(expectIncorrect);
-  });
-
-  it('Should auth credential failed when request header "authorization" not start with "password-file"', async () => {
-    // Arrange
-    const ctx = {
-      ...sinon.stubInterface<KoaContext>(),
-      request: {
-        ...sinon.stubInterface<Request>(),
-        headers: {
-          ...sinon.stubInterface<IncomingHttpHeaders>(),
-          authorization: '',
-        },
-      },
-    } as KoaContext;
-
-    // Act
-    const result = await authCredential(ctx, {
-      'password-file': { path: '', users: [] },
-    });
-
-    // Assert
-    expect(result).toEqual(expectIncorrect);
-  });
 
   it('Should auth credential failed when "path" is empty in "password-file" options', async () => {
     // Arrange

--- a/packages/serve/test/auth/simpleTokenAuthenticator.spec.ts
+++ b/packages/serve/test/auth/simpleTokenAuthenticator.spec.ts
@@ -55,7 +55,7 @@ describe('Test simple-token authenticator', () => {
     },
   ] as SimpleTokenOptions;
 
-  it.each([[{}], [{ basic: {} }], [{ 'simple-token': [] }]])(
+  it.each([[{}]])(
     'Should auth incorrect when options = %p in options',
     async (options) => {
       // Arrange
@@ -73,44 +73,6 @@ describe('Test simple-token authenticator', () => {
       expect(result).toEqual(expectIncorrect);
     }
   );
-  it('Test to auth credential failed when request header not exist "authorization" key', async () => {
-    // Arrange
-    const ctx = {
-      ...sinon.stubInterface<KoaContext>(),
-      request: {
-        ...sinon.stubInterface<Request>(),
-        headers: {
-          ...sinon.stubInterface<IncomingHttpHeaders>(),
-        },
-      },
-    } as KoaContext;
-
-    // Act
-    const result = await authCredential(ctx, { 'simple-token': userLists });
-
-    // Assert
-    expect(result).toEqual(expectIncorrect);
-  });
-
-  it('Should auth credential failed when request header "authorization" not start with "simple-token"', async () => {
-    // Arrange
-    const ctx = {
-      ...sinon.stubInterface<KoaContext>(),
-      request: {
-        ...sinon.stubInterface<Request>(),
-        headers: {
-          ...sinon.stubInterface<IncomingHttpHeaders>(),
-          authorization: '',
-        },
-      },
-    } as KoaContext;
-
-    // Act
-    const result = await authCredential(ctx, { 'simple-token': userLists });
-
-    // Assert
-    expect(result).toEqual(expectIncorrect);
-  });
 
   it('Should auth credential failed when request header "authorization" not matched in empty simple-token" options', async () => {
     // Arrange


### PR DESCRIPTION
## Description
Refactor the authentication middleware to match the authenticator first then validate the user with the matched authenticator 

## Additional Context
We still having "INDETERMINATE" state in the build-in authenticators and check the authenticator is set proper, because build-in authenticators will always be initialized and the scenario is user send a request with the token identifier which is the authenticator that did not been configured in the vulcan.yaml file  
