### PR TITLE
Fix: `vulcan package` throws exception using VulcanSQL cli in binary version

### DIFF
--- a/packages/build/src/models/extensions/packager/packager.ts
+++ b/packages/build/src/models/extensions/packager/packager.ts
@@ -83,6 +83,10 @@ export abstract class Packager<C = PackagerConfig> extends ExtensionBase<C> {
 
     packageJson['main'] = 'index.js';
 
+    if(!packageJson['dependencies']['@vulcan-sql/catalog-server']) {
+      throw new Error('Have you installed @vulcan-sql/catalog-server module?')
+    }
+
     // remove all dependencies except catalog-server
     for (const key in packageJson['dependencies']) {
       if (key !== '@vulcan-sql/catalog-server') {

--- a/packages/cli/src/commands/catalog.ts
+++ b/packages/cli/src/commands/catalog.ts
@@ -58,7 +58,8 @@ const serveCatalogByDocker = async (options: CatalogCommandOptions) => {
   const port = catalogConfig.port || Number(options.port);
   const VULCAN_SQL_HOST = `http://host.docker.internal:${config.port || 3000}`
 
-  const catalogVersion = process.env['CATALOG_DOCKER_VERSION']
+  // sync the version with binary package.json
+  const catalogVersion = JSON.parse(await fs.readFile(path.resolve('/snapshot/binary', 'package.json'), 'utf-8'))['version']
   const dockerImage = `ghcr.io/canner/vulcan-sql/catalog-server:${catalogVersion}`
   const containerName = "catalog-server"
 


### PR DESCRIPTION
## Description

1. In the `vulcan package` command line process,  add conditional `package.json` retrieving when the user is in binary mode. (#222)
2. Adjust the `vulcan catalog` version since it can read the `package.json` inside the binary.
3. Add an exception for catalog packager if the user not installed `@vulcan-sql/catalog-server`.

## Issue ticket number

closes #222

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
