### PR TITLE
chore: change binary download links

### DIFF
--- a/packages/doc/docs/get-started/installation.mdx
+++ b/packages/doc/docs/get-started/installation.mdx
@@ -11,7 +11,7 @@ We provide pre-built binaries for Linux, macOS, and Windows. The binary includes
 <Tabs groupId="install-os">
 <TabItem value="osx" label="MacOS">
 
-Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://d3jr9lxbk67t5c.cloudfront.net/bin/vulcan.osx.0.6.0.tar.gz).
+Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://github.com/Canner/vulcan-sql/releases/download/v0.6.0/vulcan.osx.0.6.0.tar.gz).
 Once the download is complete, you'll need to extract the file and move it to `/usr/local/bin`:
 
 ```bash
@@ -22,7 +22,7 @@ mv vulcan /usr/local/bin
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://d3jr9lxbk67t5c.cloudfront.net/bin/vulcan.linux.0.6.0.tar.gz).
+Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://github.com/Canner/vulcan-sql/releases/download/v0.6.0/vulcan.linux.0.6.0.tar.gz).
 Once the download is complete, you'll need to extract the file and move it to `/usr/local/bin`:
 
 ```bash
@@ -34,7 +34,7 @@ mv vulcan /usr/local/bin
 
 <TabItem value="win" label="Windows">
 
-1. **Downloading the File**: Download the latest version of VulcanSQL CLI from: [vulcan.exe](https://d3jr9lxbk67t5c.cloudfront.net/bin/vulcan.win.0.6.0.zip).
+1. **Downloading the File**: Download the latest version of VulcanSQL CLI from: [vulcan.exe](https://github.com/Canner/vulcan-sql/releases/download/v0.6.0/vulcan.win.0.6.0.zip).
 1. **Extracting the File**: Once the download is complete, locate the zip folder in your 'Downloads' directory. Extract the zip folder.
 1. **Moving the `vulcan.exe` File**: Inside the extracted folder, find the `vulcan.exe` file. Cut or copy this file and navigate to the location where you want to store it. This could be a specific directory or your desktop for easy access.
 


### PR DESCRIPTION
## Description

change binary download links to ones on GitHub release in order to track binary VulcanSQL download number

## Issue ticket number

None

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->

None