### PR TITLE
Chore: update release assets info of the binary process

### DIFF
--- a/packages/doc/docs/get-started/installation.mdx
+++ b/packages/doc/docs/get-started/installation.mdx
@@ -11,22 +11,22 @@ We provide pre-built binaries for Linux, macOS, and Windows. The binary includes
 <Tabs groupId="install-os">
 <TabItem value="osx" label="MacOS">
 
-Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://github.com/Canner/vulcan-sql/releases/download/v0.6.0/vulcan.osx.0.6.0.tar.gz).
+Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://github.com/Canner/vulcan-sql/releases/latest/download/vulcan.osx.tar.gz).
 Once the download is complete, you'll need to extract the file and move it to `/usr/local/bin`:
 
 ```bash
-tar zxvf vulcan.osx.0.6.0.tar.gz
+tar zxvf vulcan.osx.tar.gz
 mv vulcan /usr/local/bin
 ```
 
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://github.com/Canner/vulcan-sql/releases/download/v0.6.0/vulcan.linux.0.6.0.tar.gz).
+Let's go ahead and grab the newest version of VulcanSQL CLI from this link: [vulcan](https://github.com/Canner/vulcan-sql/releases/latest/download/vulcan.linux.tar.gz).
 Once the download is complete, you'll need to extract the file and move it to `/usr/local/bin`:
 
 ```bash
-tar zxvf vulcan.linux.0.6.0.tar.gz
+tar zxvf vulcan.linux.tar.gz
 mv vulcan /usr/local/bin
 ```
 
@@ -34,7 +34,7 @@ mv vulcan /usr/local/bin
 
 <TabItem value="win" label="Windows">
 
-1. **Downloading the File**: Download the latest version of VulcanSQL CLI from: [vulcan.exe](https://github.com/Canner/vulcan-sql/releases/download/v0.6.0/vulcan.win.0.6.0.zip).
+1. **Downloading the File**: Download the latest version of VulcanSQL CLI from: [vulcan.exe](https://github.com/Canner/vulcan-sql/releases/latest/download/vulcan.win.zip).
 1. **Extracting the File**: Once the download is complete, locate the zip folder in your 'Downloads' directory. Extract the zip folder.
 1. **Moving the `vulcan.exe` File**: Inside the extracted folder, find the `vulcan.exe` file. Cut or copy this file and navigate to the location where you want to store it. This could be a specific directory or your desktop for easy access.
 


### PR DESCRIPTION
## Description

In the current Release process, we will compress the constructed binary files and put them into the assets in the release notes. The file format is `vulcan.{os}.{version}.{tar.gz/zip}`.

We should simplify. As we know, each Release Note not only has the assets part but also has the Release version number, so we will change the file name to no longer contain the version number part.

So, we will have the following changes:
1. Change the file name format.
   - Ubuntu: **vulcan.linux.tar.gz**
   - Mac OS: **vulcan.osx.tar.gz**
   - Windows: **vulcan.win.zip**

2. It is no longer necessary to change the download link in the docs


## Issue ticket number

closes #xx

## Additional Context

Reference doc: https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases#linking-to-the-latest-release