### PR TITLE
Fix: change the output format to JSON string of hugging face extension

### DIFF
--- a/labs/playground1/Makefile
+++ b/labs/playground1/Makefile
@@ -6,7 +6,7 @@ start: build test-data/moma.db ../../node_modules
 	@vulcan start
 
 # build the required packages
-build: pkg-core pkg-build pkg-serve pkg-catalog-server pkg-cli pkg-extension-driver-duckdb pkg-extension-authenticator-canner pkg-extension-driver-clickhouse
+build: pkg-core pkg-build pkg-serve pkg-catalog-server pkg-cli pkg-extension-driver-duckdb pkg-extension-authenticator-canner pkg-extension-driver-clickhouse pkg-extension-huggingface
 
 
 # build for core pakge
@@ -62,8 +62,15 @@ pkg-extension-driver-clickhouse: ../../node_modules
 	mkdir -p ./labs/playground1/node_modules/@vulcan-sql; \
 	rm -rf ./labs/playground1/node_modules/@vulcan-sql/extension-driver-clickhouse; \
 	cp -R ./dist/packages/extension-driver-clickhouse ./labs/playground1/node_modules/@vulcan-sql; \
-	cp -R ./packages/extension-driver-clickhouse/node_modules/@clickhouse ./labs/playground1/node_modules
+	cp -R ./packages/extension-driver-clickhouse/node_modules ./labs/playground1
 
+pkg-extension-huggingface: ../../node_modules
+	@cd ../..; \
+	yarn nx build extension-huggingface; \
+	mkdir -p ./labs/playground1/node_modules/@vulcan-sql; \
+	rm -rf ./labs/playground1/node_modules/@vulcan-sql/extension-huggingface; \
+	cp -R ./dist/packages/extension-huggingface ./labs/playground1/node_modules/@vulcan-sql; \
+	cp -R ./packages/extension-huggingface/node_modules ./labs/playground1
 
 # build and install for cli pakge
 pkg-cli: ../../node_modules

--- a/packages/doc/docs/extensions/huggingface-table-question-answering.mdx
+++ b/packages/doc/docs/extensions/huggingface-table-question-answering.mdx
@@ -42,7 +42,9 @@ The [Table Question Answering](https://huggingface.co/docs/api-inference/detaile
 
 Using the `huggingface_table_question_answering` filter.
 
-Sample 1:
+The result will be converted to a JSON string from `huggingface_table_question_answering`. You could decompress the JSON string and use the result by itself.
+
+**Sample 1 - send the data from variable by [set tag](https://vulcansql.com/docs/develop/advance#set-variables):**
 
 ```sql
 {% set data = [
@@ -67,14 +69,36 @@ Sample 1:
 SELECT {{ data | huggingface_table_question_answering(query="How many repositories related to data-lake topic?") }}
 ```
 
-Sample 2:
+**Sample 1 - Response:**
+
+```json
+[
+  {
+    "result": "{\"answer\":\"COUNT > vulcan-sql, accio\",\"coordinates\":[[0,0],[1,0]],\"cells\":[\"vulcan-sql\",\"accio\"],\"aggregator\":\"COUNT\"}"
+  }
+]
+```
+
+**Sample 2 - send the data from [req tag](https://vulcansql.com/docs/develop/predefined-queries):**
 
 ```sql
-{% req products %}
-  SELECT * FROM products
+{% req artists %}
+  SELECT * FROM artists
 {% endreq %}
 
-SELECT {{ products.value() | huggingface_table_question_answering(query="How many products related to 3C type?", model="microsoft/tapex-base-finetuned-wtq", wait_for_model=true, use_cache=true) }}
+{% set question = "List display name where gender are female?" %}
+
+SELECT {{ products.value() | huggingface_table_question_answering(query=question, model="microsoft/tapex-base-finetuned-wtq", wait_for_model=true, use_cache=true) }}
+```
+
+**Sample 2 - Response:**
+
+```json
+[
+  {
+    "result": "{\"answer\":\"Irene Aronson, Ruth Asawa, Isidora Aschheim, Geneviève Asse, Dana Atchley, Aino Aalto, Berenice Abbott\",\"coordinates\":[[8,1],[16,1],[17,1],[23,1],[25,1],[29,1],[35,1]],\"cells\":[\"Irene Aronson\",\"Ruth Asawa\",\"Isidora Aschheim\",\"Geneviève Asse\",\"Dana Atchley\",\"Aino Aalto\",\"Berenice Abbott\"],\"aggregator\":\"NONE\"}"
+  }
+]
 ```
 
 ### Arguments

--- a/packages/extension-huggingface/README.md
+++ b/packages/extension-huggingface/README.md
@@ -33,7 +33,9 @@ The [Table Question Answering](https://huggingface.co/docs/api-inference/detaile
 
 Using the `huggingface_table_question_answering` filter.
 
-Sample 1:
+The result will be converted to a JSON string from `huggingface_table_question_answering`. You could decompress the JSON string and use the result by itself.
+
+**Sample 1 - send the data from variable by [set tag](https://vulcansql.com/docs/develop/advance#set-variables):**
 
 ```sql
 {% set data = [
@@ -55,18 +57,40 @@ Sample 1:
 ] %}
 
 -- The source data for "huggingface_table_question_answering" needs to be an array of objects.
-SELECT {{ data | huggingface_table_question_answering(query="How many repositories related to data-lake topic?") }}
+SELECT {{ data | huggingface_table_question_answering(query="How many repositories related to data-lake topic?") }} as result
 ```
 
-Sample 2:
+**Sample 1 - Response:**
+
+```json
+[
+  {
+    "result": "{\"answer\":\"COUNT > vulcan-sql, accio\",\"coordinates\":[[0,0],[1,0]],\"cells\":[\"vulcan-sql\",\"accio\"],\"aggregator\":\"COUNT\"}"
+  }
+]
+```
+
+**Sample 2 - send the data from [req tag](https://vulcansql.com/docs/develop/predefined-queries):**
 
 ```sql
-{% req products %}
-  SELECT * FROM products
+{% req artists %}
+  SELECT * FROM artists
 {% endreq %}
+
+{% set question = "List display name where gender are female?" %}
 
 -- The "model" keyword argument is optional. If not provided, the default value is 'google/tapas-base-finetuned-wtq'.
 -- The "wait_for_model" keyword argument is optional. If not provided, the default value is false.
 -- The "use_cache" keyword argument is optional. If not provided, the default value is true.
-SELECT {{ products.value() | huggingface_table_question_answering(query="How many products related to 3C type?", model="microsoft/tapex-base-finetuned-wtq", wait_for_model=true, use_cache=true) }}
+SELECT {{ products.value() | huggingface_table_question_answering(query=question, model="microsoft/tapex-base-finetuned-wtq", wait_for_model=true, use_cache=true) }}
+```
+
+**Sample 2 - Response:**
+
+```json
+[
+  {
+    "result": "{\"answer\":\"Irene Aronson, Ruth Asawa, Isidora Aschheim, Geneviève Asse, Dana Atchley, Aino Aalto, Berenice Abbott\",\"coordinates\":[[8,1],[16,1],[17,1],[23,1],[25,1],[29,1],[35,1]],\"cells\":[\"Irene Aronson\",\"Ruth Asawa\",\"Isidora Aschheim\",\"Geneviève Asse\",\"Dana Atchley\",\"Aino Aalto\",\"Berenice Abbott\"],\"aggregator\":\"NONE\"}"
+  }
+]
 ```

--- a/packages/extension-huggingface/src/lib/filters/tableQuestionAnswering.ts
+++ b/packages/extension-huggingface/src/lib/filters/tableQuestionAnswering.ts
@@ -79,11 +79,8 @@ export const TableQuestionAnsweringFilter: FunctionalFilter = async ({
 
   try {
     const results = await request(url, context, token);
-    // result format, convert to suitable FunctionalFilter response => https://huggingface.co/docs/api-inference/detailed_parameters#question-answering-task
-    if (!results.aggregator || results.aggregator === 'NONE')
-      // trim the beginning & ending space if model returned answer exist the space, e.g: ' hello world'
-      return (results.answer as string).trim();
-    return results.cells.join(', ');
+    // convert to JSON string to make user get the whole result after parsing it in SQL
+    return JSON.stringify(results);
   } catch (error) {
     throw new InternalError(
       `Error when sending data to Hugging Face for executing TableQuestionAnswering tasks, details: ${


### PR DESCRIPTION
## Description
The HuggingFace library or API will respond to different results with an aggregator field ( e.g: `COUNT`, 'AVERAGE', 'NONE'....) according to the different models adopted, so we decide to dump the result object to JSON string and delegate user to decompose it and use the result according to different scenarios.

Below is a sample of the response to the HuggingFace table question answering:

```sql
{% set data = [
  {
    "repository": "vulcan-sql",
    "topic": ["analytics", "data-lake", "data-warehouse", "api-builder"],
    "description":"Create and share Data APIs fast! Data API framework for DuckDB, ClickHouse, Snowflake, BigQuery, PostgreSQL"
  },
  {
    "repository": "accio",
    "topic": ["data-analytics", "data-lake", "data-warehouse", "bussiness-intelligence"],
    "description": "Query Your Data Warehouse Like Exploring One Big View."
  },
  {
    "repository": "hell-word",
    "topic": [],
    "description": "Sample repository for testing"
  }
] %}

SELECT {{ data | huggingface_table_question_answering(query="How many repositories related to data-lake topic?") }} as result
```

Response:

![截圖 2023-07-25 下午12 31 05](https://github.com/Canner/vulcan-sql/assets/5389253/94e6b998-bb9f-47a5-9d4d-e10c4cced5a7)

Therefore, we convert to JSON string and response:

![截圖 2023-07-25 下午12 46 08](https://github.com/Canner/vulcan-sql/assets/5389253/3496c0cd-17f0-413d-90a0-8a1a60bc6bca)

## Issue ticket number

closes #xx

## Additional Context
- Decided to change the output format after discussing with @cyyeh to get the conclusion
- Update the [README](https://github.com/Canner/vulcan-sql/blob/fix/jsonsify-huggingface-extension-output/packages/extension-huggingface/README.md) and [official document](https://vulcan-sql-document-git-fix-jsonsify-3371bf-vulcan-sql-document.vercel.app/docs/extensions/huggingface-table-question-answering.