### PR TITLE
Fix: Rename the downloaded parquet file to add parquet extension

### DIFF
--- a/labs/playground1/Makefile
+++ b/labs/playground1/Makefile
@@ -6,7 +6,7 @@ start: build test-data/moma.db ../../node_modules
 	@vulcan start
 
 # build the required packages
-build: pkg-core pkg-build pkg-serve pkg-catalog-server pkg-cli pkg-extension-driver-duckdb pkg-extension-authenticator-canner pkg-extension-driver-clickhouse pkg-extension-huggingface
+build: pkg-core pkg-build pkg-serve pkg-catalog-server pkg-cli pkg-extension-driver-duckdb pkg-extension-authenticator-canner pkg-extension-driver-canner pkg-extension-driver-clickhouse pkg-extension-huggingface
 
 
 # build for core pakge
@@ -56,6 +56,13 @@ pkg-extension-authenticator-canner: ../../node_modules
 	rm -rf ./labs/playground1/node_modules/@vulcan-sql/extension-authenticator-canner; \
 	cp -R ./dist/packages/extension-authenticator-canner ./labs/playground1/node_modules/@vulcan-sql
 
+pkg-extension-driver-canner: ../../node_modules
+	@cd ../..; \
+	yarn nx build extension-driver-canner; \
+	mkdir -p ./labs/playground1/node_modules/@vulcan-sql; \
+	rm -rf ./labs/playground1/node_modules/@vulcan-sql/extension-driver-canner; \
+	cp -R ./dist/packages/extension-driver-canner ./labs/playground1/node_modules/@vulcan-sql; \
+	
 pkg-extension-driver-clickhouse: ../../node_modules
 	@cd ../..; \
 	yarn nx build extension-driver-clickhouse; \
@@ -71,6 +78,9 @@ pkg-extension-huggingface: ../../node_modules
 	rm -rf ./labs/playground1/node_modules/@vulcan-sql/extension-huggingface; \
 	cp -R ./dist/packages/extension-huggingface ./labs/playground1/node_modules/@vulcan-sql; \
 	cp -R ./packages/extension-huggingface/node_modules ./labs/playground1
+
+
+
 
 # build and install for cli pakge
 pkg-cli: ../../node_modules

--- a/labs/playground1/README.md
+++ b/labs/playground1/README.md
@@ -10,8 +10,9 @@ This project contains these resources for testing your development:
 ## Install
 
 ```bash
-cd ./lab/playground1
-make
+$ cd ./lab/playground1
+$ yarn
+$ make
 ```
 
 - This command installs VulcanSQL CLI too, you can use `vulcan start` instead of `make` if the source codes aren’t changed.

--- a/packages/extension-driver-canner/src/lib/cannerDataSource.ts
+++ b/packages/extension-driver-canner/src/lib/cannerDataSource.ts
@@ -92,7 +92,8 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
         // ex: https://cannerHost/data/canner/somePath/file-name?X-Amz-Algorithm=AWS4-HMAC-SHA256
         const fileName = url.split('/').pop()?.split('?')[0] || `part${index}`;
         const writeStream = fs.createWriteStream(
-          path.join(directory, fileName)
+          // rename to parquet extension to make cache layer could read
+          path.join(directory, `${fileName}.parquet`)
         );
         response.data.pipe(writeStream);
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description
When using  `exetnsion-driver-canner` and caching dataset feature, the parquet file was downloaded from Canner Enterprise, but not find it in the local folder and cause vulcan-sql to fail.
<img width="1067" alt="MicrosoftTeams-image (1)" src="https://github.com/Canner/vulcan-sql/assets/5389253/aa717702-97ea-4328-a3d0-f3408f66a769">

![MicrosoftTeams-image (2)](https://github.com/Canner/vulcan-sql/assets/5389253/ea50331e-fd2f-4e1f-b88f-f56cda98911a)

The reason is that the downloaded parquet file does not include `parquet` extension name, so it caused the cache layer could not to find the parquet file and failed. After renaming the filename when downloading, the issue has been fixed, see:

![截圖 2023-07-27 下午2 18 30](https://github.com/Canner/vulcan-sql/assets/5389253/2e332b69-8359-4b16-b8ec-8deba89741b0)


![截圖 2023-07-27 下午4 53 33](https://github.com/Canner/vulcan-sql/assets/5389253/b553997e-499f-4765-87bf-6286d7e92b33)


## Issue ticket number

closes #xx

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
