### PR TITLE
fix wrong api urls on openapi doc

### DIFF
--- a/packages/build/src/lib/schema-parser/schemaParser.ts
+++ b/packages/build/src/lib/schema-parser/schemaParser.ts
@@ -45,6 +45,7 @@ export class SchemaParser {
     for await (const schemaData of this.schemaReader.readSchema()) {
       const schema = await this.parseContent(schemaData);
       schema.metadata = metadata?.[schema.templateSource || schema.sourceName];
+      schema.urlPath = `/api${schema.urlPath}`
       // execute middleware
       await execute(schema);
       schemas.push(schema as APISchema);

--- a/packages/catalog-server/utils/vulcanSQLAdapter.ts
+++ b/packages/catalog-server/utils/vulcanSQLAdapter.ts
@@ -108,7 +108,7 @@ class VulcanSQLAdapter {
       return isParam
         ? result.replace(param, filter[key])
         : `${result}${querySymbol}${key}=${filter[key]}`;
-    }, `/api${schema.urlPath}`);
+    }, schema.urlPath);
 
     const actualUrl = `${VULCAN_SQL_HOST}${actualPath}`;
     console.log('actualUrl: ', actualUrl);

--- a/packages/serve/src/lib/catalog-router/catalogRouters.ts
+++ b/packages/serve/src/lib/catalog-router/catalogRouters.ts
@@ -43,7 +43,7 @@ export class CatalogRouters extends CatalogRouter {
       const baseUrl = `${ctx.protocol}://${ctx.host}`;
       const result = {
         ...schema,
-        url: `${baseUrl}/api${schema.urlPath}`,
+        url: `${baseUrl}${schema.urlPath}`,
         apiDocUrl: `${baseUrl}${this.getAPIDocUrl(schema)}`,
         shareKey: this.getShareKey(ctx.request.headers.authorization),
         responseFormat: responseFormatOption.enabled
@@ -60,7 +60,7 @@ export class CatalogRouters extends CatalogRouter {
       const result = schemas.map((schema) => {
         return {
           ...schema,
-          url: `${baseUrl}/api${schema.urlPath}`,
+          url: `${baseUrl}${schema.urlPath}`,
           apiDocUrl: `${baseUrl}${this.getAPIDocUrl(schema)}`,
           shareKey: this.getShareKey(ctx.request.headers.authorization),
         };

--- a/packages/serve/src/lib/route/route-component/restfulRoute.ts
+++ b/packages/serve/src/lib/route/route-component/restfulRoute.ts
@@ -8,7 +8,7 @@ export class RestfulRoute extends BaseRoute {
   constructor(options: RouteOptions) {
     super(options);
     const { apiSchema } = options;
-    this.urlPath = this.combineURLs('/api', apiSchema.urlPath);
+    this.urlPath = apiSchema.urlPath;
   }
 
   public async respond(ctx: KoaContext) {

--- a/packages/serve/test/app.spec.ts
+++ b/packages/serve/test/app.spec.ts
@@ -386,7 +386,7 @@ describe('Test vulcan server for calling restful APIs', () => {
         .listen(faker.datatype.number({ min: 20000, max: 30000 }));
 
       // arrange input api url
-      const apiUrl = KoaRouter.url('/api' + schema.urlPath, ctx.params);
+      const apiUrl = KoaRouter.url(schema.urlPath, ctx.params);
 
       // arrange expected result
       const expected: RequestParameters = {};


### PR DESCRIPTION
## Description

Fix wrong api URL path on Open API doc. Since the url path of API generated by VulcanSQL will start from '/api', but there's no `/api` prefix shown on Open API doc.

## Issue ticket number

None

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
