### PR TITLE
Fix: Correct the profile of cache layer schema for Canner Persistence Store

### DIFF
--- a/packages/build/src/lib/schema-parser/schemaParser.ts
+++ b/packages/build/src/lib/schema-parser/schemaParser.ts
@@ -45,7 +45,6 @@ export class SchemaParser {
     for await (const schemaData of this.schemaReader.readSchema()) {
       const schema = await this.parseContent(schemaData);
       schema.metadata = metadata?.[schema.templateSource || schema.sourceName];
-      schema.urlPath = `/api${schema.urlPath}`
       // execute middleware
       await execute(schema);
       schemas.push(schema as APISchema);

--- a/packages/catalog-server/utils/vulcanSQLAdapter.ts
+++ b/packages/catalog-server/utils/vulcanSQLAdapter.ts
@@ -108,7 +108,7 @@ class VulcanSQLAdapter {
       return isParam
         ? result.replace(param, filter[key])
         : `${result}${querySymbol}${key}=${filter[key]}`;
-    }, schema.urlPath);
+    }, `/api${schema.urlPath}`);
 
     const actualUrl = `${VULCAN_SQL_HOST}${actualPath}`;
     console.log('actualUrl: ', actualUrl);

--- a/packages/extension-store-canner/src/lib/canner/persistenceStore.ts
+++ b/packages/extension-store-canner/src/lib/canner/persistenceStore.ts
@@ -141,13 +141,17 @@ export class CannerPersistenceStore extends PersistentStore {
           merged.templates[workspaceSourceName] = value;
         });
         // API Schemas
+        const profile = `canner-${workspaceSqlName}`;
         artifact.schemas.forEach((schema) => {
           // concat the workspace sql name prefix to urlPath, urlPath has the "/" prefix, so concat directly
           schema.urlPath = `${workspaceSqlName}${schema.urlPath}`;
           // concat the workspace sql name prefix to template source, so it could find the "sourceName" in templates
           schema.templateSource = `${workspaceSqlName}/${schema.templateSource}`;
           // replace the profile to the canner enterprise integration used profile name, it will match to the profiles from canner profile reader.
-          schema.profiles = [`canner-${workspaceSqlName}`];
+          schema.profiles = [profile];
+          schema.cache =
+            schema.cache?.map((cacheData) => ({ ...cacheData, profile })) || [];
+
           merged.schemas.push(schema);
         });
         // Specs, only support the oas3 specification for canner enterprise integration used

--- a/packages/extension-store-canner/src/test/cannerPersistenceStore.spec.ts
+++ b/packages/extension-store-canner/src/test/cannerPersistenceStore.spec.ts
@@ -2,7 +2,11 @@ import * as sinon from 'ts-sinon';
 import faker from '@faker-js/faker';
 import * as oas3 from 'openapi3-ts';
 import { BaseStorageService } from '@canner/canner-storage';
-import { APISchema, ArtifactBuilderOptions } from '@vulcan-sql/core';
+import {
+  APISchema,
+  ArtifactBuilderOptions,
+  CacheLayerInfo,
+} from '@vulcan-sql/core';
 import * as storageServiceModule from '../lib/storageService';
 import {
   BuiltInArtifact,
@@ -160,6 +164,12 @@ describe('Test CannerPersistenceStore', () => {
             urlPath: '/orders',
             templateSource: 'sales/orders',
             profiles: [faker.word.noun()],
+            cache: [
+              {
+                ...sinon.stubInterface<CacheLayerInfo>(),
+                profile: faker.lorem.word(),
+              },
+            ],
           },
         ],
         specs: {
@@ -184,6 +194,7 @@ describe('Test CannerPersistenceStore', () => {
             urlPath: '/products/:id',
             templateSource: 'marketing/products',
             profiles: [faker.word.noun()],
+            cache: [],
           },
         ],
         specs: {
@@ -213,11 +224,17 @@ describe('Test CannerPersistenceStore', () => {
           urlPath: `${fakeWorkspaces.ws1.sqlName}/orders`,
           templateSource: `${fakeWorkspaces.ws1.sqlName}/sales/orders`,
           profiles: [`canner-${fakeWorkspaces.ws1.sqlName}`],
+          cache: [
+            {
+              profile: `canner-${fakeWorkspaces.ws1.sqlName}`,
+            },
+          ],
         },
         {
           urlPath: `${fakeWorkspaces.ws2.sqlName}/products/:id`,
           templateSource: `${fakeWorkspaces.ws2.sqlName}/marketing/products`,
           profiles: [`canner-${fakeWorkspaces.ws2.sqlName}`],
+          cache: [],
         },
       ],
       specs: {

--- a/packages/serve/src/lib/catalog-router/catalogRouters.ts
+++ b/packages/serve/src/lib/catalog-router/catalogRouters.ts
@@ -43,7 +43,7 @@ export class CatalogRouters extends CatalogRouter {
       const baseUrl = `${ctx.protocol}://${ctx.host}`;
       const result = {
         ...schema,
-        url: `${baseUrl}${schema.urlPath}`,
+        url: `${baseUrl}/api${schema.urlPath}`,
         apiDocUrl: `${baseUrl}${this.getAPIDocUrl(schema)}`,
         shareKey: this.getShareKey(ctx.request.headers.authorization),
         responseFormat: responseFormatOption.enabled
@@ -60,7 +60,7 @@ export class CatalogRouters extends CatalogRouter {
       const result = schemas.map((schema) => {
         return {
           ...schema,
-          url: `${baseUrl}${schema.urlPath}`,
+          url: `${baseUrl}/api${schema.urlPath}`,
           apiDocUrl: `${baseUrl}${this.getAPIDocUrl(schema)}`,
           shareKey: this.getShareKey(ctx.request.headers.authorization),
         };

--- a/packages/serve/src/lib/route/route-component/restfulRoute.ts
+++ b/packages/serve/src/lib/route/route-component/restfulRoute.ts
@@ -8,7 +8,7 @@ export class RestfulRoute extends BaseRoute {
   constructor(options: RouteOptions) {
     super(options);
     const { apiSchema } = options;
-    this.urlPath = apiSchema.urlPath;
+    this.urlPath = this.combineURLs('/api', apiSchema.urlPath);
   }
 
   public async respond(ctx: KoaContext) {

--- a/packages/serve/test/app.spec.ts
+++ b/packages/serve/test/app.spec.ts
@@ -386,7 +386,7 @@ describe('Test vulcan server for calling restful APIs', () => {
         .listen(faker.datatype.number({ min: 20000, max: 30000 }));
 
       // arrange input api url
-      const apiUrl = KoaRouter.url(schema.urlPath, ctx.params);
+      const apiUrl = KoaRouter.url('/api' + schema.urlPath, ctx.params);
 
       // arrange expected result
       const expected: RequestParameters = {};


### PR DESCRIPTION
## Description

For the Canner Enterprise product, the extension-store-canner pulls the result.json from Minio to merge into one file, it lacks the profile setting of the cache layer in the schema, so we need to fix it and let caching datasets functionality works.

## Issue ticket number

closes #275


## Screenshot for integrating with Canner Enterprise.

### Step 1: Check the connection and deploy Data API to the Canner Enterprise product

#### Step 1-1
Opened a Canner Enterprise of PR testing env and create the `w1` workspaces with the table:
![截圖 2023-08-14 下午1 29 38](https://github.com/Canner/vulcan-sql/assets/42527625/3964dccf-ebb7-49ba-8bee-1302898ef094)


#### Step 1-2.1
Use the In the VulcanSQL labs and create canner-w1 profiles with temporal PAT for connecting Canner Enterprise by extension-driver-canner through PG Wire Protocol:
![截圖 2023-08-14 下午1 34 33](https://github.com/Canner/vulcan-sql/assets/42527625/00fc7f32-3024-4360-9def-0ba4bdb1427d)


#### Step 1-2.2
Enable caching for vulcan.yaml
```yaml
cache:
  type: parquet
  folderPath: tmp
  loader: duckdb
```

#### Step 1-2.3
Apply my bugfix code for `package.json` of labs
```
{
  "name": "...",
  "dependencies": {
   ...
   "@vulcan-sql/extension-store-canner": "../../dist/packages/extension-store-canner",
  
  },
  ...
}

```

#### Step 1-3
Prepare Data APIs
![截圖 2023-08-14 下午1 38 34](https://github.com/Canner/vulcan-sql/assets/42527625/8f15792f-d317-46d4-90d6-263426c3a454)

#### Step 1-4
Add pkg-extension-store-canner in the Makefile and execute it
(Get the result.json)

#### Step 1-5
Upload them to Canner Enterprise, and see the uploaded artifacts in the vulcansql folder of w1:
![截圖 2023-08-14 下午1 39 53](https://github.com/Canner/vulcan-sql/assets/42527625/b3bf1592-693f-4a46-af30-d82556dc950b)

### Step 2: Check CannerPersistenceStore
Now we delete the SQLs and API schemas files, in the lasbs project, and update the vulcan.yaml for artifact options, extensions and profiles like below to use the Canner extension:


#### Step 2-1
```yaml
....
artifact:
  provider: Canner # use Canner Persistence Store
  serializer: JSON
  # Path to build result
  filePath: fe54258b-da25-408b-a019-efb3b36f1b47 # root path

extensions:
  duckdb: "@vulcan-sql/extension-driver-duckdb"
  # Needed extensions for integrating with Canner Enterprise
  canner-driver: "@vulcan-sql/extension-driver-canner"
  canner-store: "@vulcan-sql/extension-store-canner"

profiles:
  # Specify the Canner profile reader to create profiles with different databases indicating to the workspaces of Canner Enterprise
  - type: Canner # use Canner Profile Reader
    options:
      path: fe54258b-da25-408b-a019-efb3b36f1b47 # root path
```

#### Step 2-2
Then set some environment variables we need:
```bash

export MINIO_ACCESS_KEY=<ACCESS-KEY>
export MINIO_BUCKET=<BUCKET>
export MINIO_PORT=9000
export MINIO_SECRET_KEY=<SECRETE-KEY>
export MINIO_SSL=false
export MINIO_URL=<IP>

export PROFILE_CANNER_DRIVER_HOST=<IP>
export PROFILE_CANNER_DRIVER_PASSWORD=<PAT>
export PROFILE_CANNER_DRIVER_USER=<USER>
export STORAGE_PROVIDER=<PROVIDER> # E.g., MINIO

```

#### Step 2-3.1
Finally, run vulcan serve to fetch the artifacts from Canner Enterprise, and generate Canner Enterprise Profiles settings:
![截圖 2023-08-14 下午1 56 40](https://github.com/Canner/vulcan-sql/assets/42527625/b1590038-f3b5-4d05-a440-af8b4740c9f3)



#### Step 2-3.2
Open the API documentation URL, we will see the workspace SQL Name in the prefix for the w1 Data API:
![截圖 2023-08-14 下午1 54 54](https://github.com/Canner/vulcan-sql/assets/42527625/39c73d02-a099-4c85-8f0e-a7d51b6aa3cf)


#### Step 2-3.3
Send request to `/api/w1/activity_logs?operation=LOGIN` to query and you will see the result:
![截圖 2023-08-14 下午1 55 48](https://github.com/Canner/vulcan-sql/assets/42527625/18560e54-d4fd-4fab-aae4-4ceffdbbfa45)

![截圖 2023-08-14 下午1 53 28](https://github.com/Canner/vulcan-sql/assets/42527625/992d4140-22c1-46c4-a55a-0d38e39589d8)

#### Done.


## Additional Context

I will revert #273 in this PR as it was causing bugs with the Canner integration. It seems that this issue needs to be discussed in an Issue. cc @cyyeh 