### PR TITLE
Feature: improve duckdbDataSource performance

### DIFF
--- a/packages/core/src/lib/utils/analyzer.ts
+++ b/packages/core/src/lib/utils/analyzer.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { isEmpty } from 'lodash';
+
+interface ConcurrentPerformanceRecord {
+  [key: string]: [{ group?: string; diff?: number }];
+}
+let is_analysis = false;
+let performanceRecord: ConcurrentPerformanceRecord = {};
+let keyStatistics: Record<
+  string,
+  {
+    min?: number;
+    max?: number;
+    avg?: number;
+    median?: number;
+    p90?: number;
+  }
+> = {};
+export class PerformanceAnalysis {
+  public static collect(
+    key: string,
+    start: number,
+    end: number,
+    group?: string
+  ) {
+    if (!start || !end) {
+      throw new Error(
+        `should provide start and end time when doing performance analysis task "${key}"`
+      );
+    }
+    if (!performanceRecord[key]) {
+      performanceRecord[key] = [] as any;
+    }
+    const diff = end - start;
+    performanceRecord[key].push({ group, diff });
+    if (process.env['PRINT_COLLECTION']) {
+      console.log(
+        `${key}: collected, start: ${start}, end: ${end}, diff: ${diff}`
+      );
+    }
+  }
+
+  public static count(): boolean {
+    // sort by diff
+    if (isEmpty(performanceRecord)) {
+      console.log('performanceRecord is empty');
+      return false;
+    }
+    Object.values(performanceRecord).map((records) => {
+      records.sort((a, b) => {
+        return <number>a.diff - <number>b.diff;
+      });
+    });
+    // count statistics
+    Object.entries(performanceRecord).map(([key, records]) => {
+      const count = records.length;
+      const min = records[0].diff;
+      const max = records[count - 1].diff;
+      const avg =
+        records.reduce((acc, cur) => {
+          return acc + <number>cur.diff;
+        }, 0) / count;
+      const median = records[Math.floor(count / 2)].diff;
+      const p90 = records[Math.floor(count * 0.9)].diff;
+      keyStatistics[key] = { min, max, avg, median, p90 };
+    });
+    return true;
+  }
+
+  public static getStatistic(key: string): any {
+    return keyStatistics[key];
+  }
+
+  public static clean = () => {
+    performanceRecord = {};
+    keyStatistics = {};
+  };
+
+  // write to txt file
+  // write by key
+  public static writePerformanceReport() {
+    const filePath = path.join('./performanceRecord.txt');
+    // write by key
+    // print current date, time as humun readable format
+    fs.appendFileSync(filePath, `------${new Date().toLocaleString()}\n`);
+    for (const key of Object.keys(keyStatistics)) {
+      fs.appendFileSync(filePath, `${key}\n`);
+      let staticLine = '';
+      if (keyStatistics[key]) {
+        const statics = keyStatistics[key];
+        Object.entries(statics).map(([k, v]) => {
+          staticLine += `${k}: ${v}, `;
+        });
+        fs.appendFileSync(filePath, `${staticLine}\n`);
+      }
+    }
+    fs.appendFileSync(filePath, `------\n`);
+  }
+}
+
+export function getAnalysis() {
+  const counted = PerformanceAnalysis.count();
+  if (counted && !is_analysis) {
+    PerformanceAnalysis.writePerformanceReport();
+    console.log('performance analysis finished');
+    console.log('check the performanceRecord.txt file for details');
+    is_analysis = true;
+  }
+}

--- a/packages/core/src/lib/utils/analyzer.ts
+++ b/packages/core/src/lib/utils/analyzer.ts
@@ -106,7 +106,7 @@ export class PerformanceAnalysis {
   // write to txt file
   public static writePerformanceReport() {
     const filePath = path.join('./performanceRecord.txt');
-    // print current date, time as humun readable format
+    // print current date, time as human readable format
     fs.appendFileSync(filePath, `------${new Date().toLocaleString()}\n`);
     for (const key of Object.keys(keyStatistics)) {
       fs.appendFileSync(filePath, `${key}\n`);

--- a/packages/core/src/lib/utils/analyzer.ts
+++ b/packages/core/src/lib/utils/analyzer.ts
@@ -17,6 +17,32 @@ let keyStatistics: Record<
     p90?: number;
   }
 > = {};
+/**
+  * This is a performance analysis tool for concurrent tasks
+  * You can use it to collect the start and end time of a task, the collected data with the same key will be summarized
+  * the summarzied report contains the min, max, avg, median, p90 of the task 
+  * When the code snippet is executed, the performance analysis tool will automatically collect the start and end time of the task
+  * 
+  * example: 
+  *   const start = Date.now();
+  *   await fn_to_measure()
+  *   const end = Date.now();
+  *   PerformanceAnalysis.collect('fn_to_measure', start, end)
+  * 
+  * You can choose when to summarize the performance data
+  * for example, you can summarize the performance data before server closed
+  * 
+  *   public async close() {
+      if (this.servers) {
+        ... close server
+      }
+      PerformanceAnalysis.count();
+    }
+  *
+  * Note: If you want to view the performance by each API call, you can use k6 or you can specify the group name when collecting the performance data
+  *       and implement another count & writePerformanceReport funtion to summarize the performance data by group name
+  * 
+  */
 export class PerformanceAnalysis {
   public static collect(
     key: string,
@@ -42,7 +68,7 @@ export class PerformanceAnalysis {
   }
 
   public static count(): boolean {
-    // sort by diff
+    // sort by time diff
     if (isEmpty(performanceRecord)) {
       console.log('performanceRecord is empty');
       return false;
@@ -78,10 +104,8 @@ export class PerformanceAnalysis {
   };
 
   // write to txt file
-  // write by key
   public static writePerformanceReport() {
     const filePath = path.join('./performanceRecord.txt');
-    // write by key
     // print current date, time as humun readable format
     fs.appendFileSync(filePath, `------${new Date().toLocaleString()}\n`);
     for (const key of Object.keys(keyStatistics)) {
@@ -103,8 +127,9 @@ export function getAnalysis() {
   const counted = PerformanceAnalysis.count();
   if (counted && !is_analysis) {
     PerformanceAnalysis.writePerformanceReport();
-    console.log('performance analysis finished');
-    console.log('check the performanceRecord.txt file for details');
+    console.log(
+      'performance analysis finished, check the performanceRecord.txt file for details'
+    );
     is_analysis = true;
   }
 }

--- a/packages/core/src/lib/utils/index.ts
+++ b/packages/core/src/lib/utils/index.ts
@@ -4,3 +4,4 @@ export * from './module';
 export * from './streams';
 export * from './errors';
 export * from './flattenElements';
+export * from './analyzer';

--- a/packages/core/test/analyzer.spec.ts
+++ b/packages/core/test/analyzer.spec.ts
@@ -33,7 +33,6 @@ describe('Performance Analysis', () => {
     await collect('waitOneSec');
     expect(PerformanceAnalysis.count()).toBeTruthy();
   });
-  //   expect performanceRecord.txt exists when getStatistics() is called
   it('should write performance data to file', async () => {
     await collect('waitOneSec');
     await collect('waitAnotherSec');

--- a/packages/core/test/analyzer.spec.ts
+++ b/packages/core/test/analyzer.spec.ts
@@ -1,0 +1,42 @@
+import { PerformanceAnalysis, getAnalysis } from '../src/lib/utils/analyzer';
+import * as fs from 'fs';
+
+async function waitOneSec(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, 1000);
+  });
+}
+
+async function collect(key: string): Promise<void> {
+  const t1 = new Date().getTime();
+  await waitOneSec();
+  const t2 = new Date().getTime();
+  PerformanceAnalysis.collect(key, t1, t2);
+}
+
+describe('Performance Analysis', () => {
+  beforeEach(() => {
+    PerformanceAnalysis.clean();
+    if (fs.existsSync('performanceRecord.txt')) {
+      fs.unlinkSync('performanceRecord.txt');
+    }
+  });
+  it('should collect performance data', async () => {
+    await collect('waitOneSec');
+    expect(PerformanceAnalysis.count()).toBeTruthy();
+  });
+  //   expect performanceRecord.txt exists when getStatistics() is called
+  it('should write performance data to file', async () => {
+    await collect('waitOneSec');
+    await collect('waitAnotherSec');
+    PerformanceAnalysis.count();
+    getAnalysis();
+    expect(fs.existsSync('performanceRecord.txt')).toBeTruthy();
+    // expect file have two lines
+    const data = fs.readFileSync('performanceRecord.txt', 'utf8');
+    const lines = data.split('\n').filter((line) => line !== '');
+    expect(lines.length).toBe(4);
+  });
+});

--- a/packages/core/test/analyzer.spec.ts
+++ b/packages/core/test/analyzer.spec.ts
@@ -23,6 +23,12 @@ describe('Performance Analysis', () => {
       fs.unlinkSync('performanceRecord.txt');
     }
   });
+  afterEach(() => {
+    PerformanceAnalysis.clean();
+    if (fs.existsSync('performanceRecord.txt')) {
+      fs.unlinkSync('performanceRecord.txt');
+    }
+  });
   it('should collect performance data', async () => {
     await collect('waitOneSec');
     expect(PerformanceAnalysis.count()).toBeTruthy();
@@ -37,6 +43,6 @@ describe('Performance Analysis', () => {
     // expect file have two lines
     const data = fs.readFileSync('performanceRecord.txt', 'utf8');
     const lines = data.split('\n').filter((line) => line !== '');
-    expect(lines.length).toBe(4);
+    expect(lines.length).toBe(6);
   });
 });

--- a/packages/extension-driver-duckdb/README.md
+++ b/packages/extension-driver-duckdb/README.md
@@ -41,3 +41,7 @@
          url_style?: string
          use_ssl?: boolean
    ```
+
+ 4. Environment Variables
+    - DUCKDB_EXECUTE_CHUNK_SIZE: Optional, dafult 2000. The data chunk size, we will acquire this size of data using conn.all() at once and get the rest of data using conn.stream to prevent from OOM, this parameter will affect the **API performance** and **server memory usage**.
+    - DUCKDB_THREADS: Optional, if not been set, use used duckdb default thread value.

--- a/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
+++ b/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
@@ -246,9 +246,24 @@ export class DuckDBDataSource extends DataSource<any, DuckDBOptions> {
     });
   }
 
+  // set duckdb thread to number
+  private async setThread(db: duckdb.Database) {
+    const thread = process.env['THREADS'];
+
+    if (!thread) return;
+    await new Promise((resolve, reject) => {
+      db.run(`SET threads=${Number(thread)}`, (err: any) => {
+        if (err) reject(err);
+        this.logger.debug(`Set thread to ${thread}`);
+        resolve(true);
+      });
+    });
+  }
+
   private async initDatabase(dbPath: string) {
     const db = new duckdb.Database(dbPath);
     const conn = db.connect();
+    await this.setThread(db);
     await this.installExtensions(conn);
     return db;
   }

--- a/packages/extension-driver-duckdb/src/lib/sqlBuilder.ts
+++ b/packages/extension-driver-duckdb/src/lib/sqlBuilder.ts
@@ -42,7 +42,7 @@ export const buildSQL = (
   builtSQL = addLimit(builtSQL, operations.limit);
   builtSQL = addOffset(builtSQL, operations.offset);
 
-  const chunkSql = `SELECT * FROM (${builtSQL}) LIMIT ${chunkSize};`;
-  const streamSql = `SELECT * FROM (${builtSQL}) OFFSET ${chunkSize};`;
-  return [chunkSql, streamSql];
+  const firstDataSql = `SELECT * FROM (${builtSQL}) LIMIT ${chunkSize};`;
+  const restDataSql = `SELECT * FROM (${builtSQL}) OFFSET ${chunkSize};`;
+  return [firstDataSql, restDataSql];
 };

--- a/packages/extension-driver-duckdb/src/lib/sqlBuilder.ts
+++ b/packages/extension-driver-duckdb/src/lib/sqlBuilder.ts
@@ -26,15 +26,23 @@ export const isNoOP = (
   return true;
 };
 
+const duckdbExecuteChunkSize =
+  process.env['DUCKDB_EXECUTE_CHUNK_SIZE'] || '2000';
+
+export const chunkSize = Number(duckdbExecuteChunkSize);
+
 export const buildSQL = (
   sql: string,
   operations: Partial<Parameterized<SQLClauseOperation>>
-): string => {
-  if (isNoOP(operations)) return sql;
+): string[] => {
+  if (isNoOP(operations) && !/^select/.test(sql.toLowerCase()))
+    return [sql, ''];
   let builtSQL = '';
   builtSQL += `SELECT * FROM (${removeEndingSemiColon(sql)})`;
   builtSQL = addLimit(builtSQL, operations.limit);
   builtSQL = addOffset(builtSQL, operations.offset);
-  builtSQL += ';';
-  return builtSQL;
+
+  const chunkSql = `SELECT * FROM (${builtSQL}) LIMIT ${chunkSize};`;
+  const streamSql = `SELECT * FROM (${builtSQL}) OFFSET ${chunkSize};`;
+  return [chunkSql, streamSql];
 };

--- a/packages/extension-driver-duckdb/tests/duckdbDataSource.spec.ts
+++ b/packages/extension-driver-duckdb/tests/duckdbDataSource.spec.ts
@@ -206,7 +206,7 @@ it('Should throw error from upstream', async () => {
       operations: {} as any,
       profileName: 'mocked-profile',
     })
-  ).rejects.toThrow(/^Parser Error: syntax error at or near "wrong"/);
+  ).rejects.toThrow(/^Parser Error: syntax error at or near/);
 });
 
 it('Should return empty data and column with zero result', async () => {
@@ -275,7 +275,7 @@ it('Should print queries without binding when log-queries = true', async () => {
     profileName: 'mocked-profile',
   });
   // Assert
-  expect(logs.slice(-1)[0][0]).toBe(`select $1::INTEGER as test`);
+  expect(/select \$1::INTEGER as test/.test(logs.slice(-1)[0][0])).toBe(true);
 });
 
 it('Should print queries with binding when log-queries = true and log-parameters = true', async () => {
@@ -316,7 +316,7 @@ it('Should print queries with binding when log-queries = true and log-parameters
     profileName: 'mocked-profile',
   });
   // Assert
-  expect(logs.slice(-1)[0][0]).toBe(`select $1::INTEGER as test`);
+  expect(/select \$1::INTEGER as test/.test(logs.slice(-1)[0][0])).toBe(true);
   expect(logs.slice(-1)[0][1]).toEqual([1234]);
 });
 

--- a/packages/extension-driver-duckdb/tests/duckdbDataSource.spec.ts
+++ b/packages/extension-driver-duckdb/tests/duckdbDataSource.spec.ts
@@ -104,7 +104,7 @@ it('Should work with memory-only database', async () => {
   // Assert
   expect(columns).toEqual([{ name: 'test', type: 'number' }]);
   expect(data).toEqual([{ test: 579 }]);
-});
+}, 20000);
 
 it('Should work with persistent database', async () => {
   // Arrange

--- a/packages/extension-driver-duckdb/tests/duckdbDataSource.spec.ts
+++ b/packages/extension-driver-duckdb/tests/duckdbDataSource.spec.ts
@@ -130,22 +130,12 @@ it('Should work with persistent database', async () => {
   });
   const columns = getColumns();
   const data = await streamToArray(getData());
-  const db = new duckdb.Database(testFile);
-  const result = await getQueryResults(
-    db,
-    'select * from "users" where age < 200 order by id desc'
-  );
   // Assert
   expect(columns.length).toBe(4);
   expect(columns).toContainEqual({ name: 'id', type: 'number' });
   expect(columns).toContainEqual({ name: 'name', type: 'string' });
   expect(columns).toContainEqual({ name: 'age', type: 'number' });
   expect(columns).toContainEqual({ name: 'enabled', type: 'boolean' });
-  expect(data.length).toEqual(result.length);
-  for (let i = 0; i < data.length; i++) {
-    expect(data[i]).toEqual(result[i]);
-  }
-  expect(data).toEqual(result);
   expect(data.length).toBe(2);
   expect(data[0]).toEqual({
     id: 2,
@@ -156,7 +146,7 @@ it('Should work with persistent database', async () => {
   expect(data[1]).toEqual({ id: 1, name: 'freda', age: 18, enabled: true });
 });
 
-it('Should return correct data chunk', async () => {
+it('Should return the same data when using c.all and datasource.execute', async () => {
   // Arrange
   const dataSource = new DuckDBDataSource(null, 'duckdb', [
     {

--- a/packages/extension-driver-duckdb/tests/sqlBuilder.spec.ts
+++ b/packages/extension-driver-duckdb/tests/sqlBuilder.spec.ts
@@ -67,7 +67,10 @@ it('BuildSQL function should build sql with operations', async () => {
   // Act
   const result = builder.buildSQL(statement, { limit: '$1', offset: '$2' });
   // Arrange
-  expect(result).toBe(
-    'SELECT * FROM (SELECT * FROM users) LIMIT $1 OFFSET $2;'
+  expect(result[0]).toBe(
+    `SELECT * FROM (SELECT * FROM (SELECT * FROM users) LIMIT $1 OFFSET $2) LIMIT ${builder.chunkSize};`
+  );
+  expect(result[1]).toBe(
+    `SELECT * FROM (SELECT * FROM (SELECT * FROM users) LIMIT $1 OFFSET $2) OFFSET ${builder.chunkSize};`
   );
 });

--- a/packages/serve/src/lib/server.ts
+++ b/packages/serve/src/lib/server.ts
@@ -14,7 +14,6 @@ import {
   ConfigurationError,
   VulcanError,
   ICacheLayerRefresher,
-  getAnalysis,
 } from '@vulcan-sql/core';
 import { Container, TYPES } from '../containers';
 import { ServeConfig, sslFileOptions } from '../models';
@@ -129,7 +128,6 @@ export class VulcanServer {
     }
     this.cacheRefresher?.stop();
     this.container.unload();
-    getAnalysis();
   }
 
   /**

--- a/packages/serve/src/lib/server.ts
+++ b/packages/serve/src/lib/server.ts
@@ -14,6 +14,7 @@ import {
   ConfigurationError,
   VulcanError,
   ICacheLayerRefresher,
+  getAnalysis,
 } from '@vulcan-sql/core';
 import { Container, TYPES } from '../containers';
 import { ServeConfig, sslFileOptions } from '../models';
@@ -128,6 +129,7 @@ export class VulcanServer {
     }
     this.cacheRefresher?.stop();
     this.container.unload();
+    getAnalysis();
   }
 
   /**

--- a/types/duckdb.d.ts
+++ b/types/duckdb.d.ts
@@ -40,6 +40,7 @@ declare module 'duckdb' {
       sql: string,
       ...params: [...any, Callback<Statement>] | []
     ): Statement;
+    stream(sql: any, ...args: any[]): QueryResult;
   }
 
   export class Database {


### PR DESCRIPTION
## Description

- Add performance analysis tool
- Modify Duckdb data source execute method: 
    - Pararelize execution and use connection.all  instead of nextChunk

Note: 
With the same data, the performance of stream.nextChunk is 1.5~2 times of the performance of connection.all  

