### PR TITLE
Fix: skip export parquet file if it exists

### DIFF
--- a/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
@@ -43,31 +43,40 @@ export class CacheLayerLoader implements ICacheLayerLoader {
     templateName: string,
     cache: CacheLayerInfo
   ): Promise<void> {
-    const { cacheTableName, sql, profile, indexes } = cache;
+    const { cacheTableName, sql, profile, indexes, folderSubpath } = cache;
     const type = this.options.type!;
     const dataSource = this.dataSourceFactory(profile);
 
     // generate directory for cache file path to export
     // format => [folderPath]/[schema.templateSource]/[profileName]/[cacheTableName]]/[timestamp]
+    const subpath = folderSubpath || moment.utc().format('YYYYMMDDHHmmss');
     const directory = path.resolve(
       this.options.folderPath!,
       templateName,
       profile,
       cacheTableName,
-      moment.utc().format('YYYYMMDDHHmmss')
+      subpath
     );
-
-    if (!fs.existsSync(directory!))
-      fs.mkdirSync(directory!, { recursive: true });
-
-    // 1. export to cache files according to each schema set the cache value
-    this.logger.debug(`Start to export to ${type} file in "${directory}"`);
-    await dataSource.export({
-      sql,
-      directory,
-      profileName: profile,
-      type,
-    });
+    const parquetFiles = this.getParquetFiles(directory);
+    if (!parquetFiles.length) {
+      if (!fs.existsSync(directory!)) {
+        fs.mkdirSync(directory!, { recursive: true });
+      }
+      // 1. export to cache files according to each schema set the cache value
+      this.logger.debug(`Start to export to ${type} file in "${directory}"`);
+      await dataSource.export({
+        sql,
+        directory,
+        profileName: profile,
+        type,
+      });
+    } else {
+      this.logger.debug(
+        `Parquet file \n ${parquetFiles.join(
+          '\n  '
+        )} found in ${directory}, skip export`
+      );
+    }
     this.logger.debug(`Start to load ${cacheTableName} in "${directory}"`);
     // 2. load the files to cache data source
     await this.cacheStorage.import({
@@ -80,5 +89,17 @@ export class CacheLayerLoader implements ICacheLayerLoader {
       type,
       indexes,
     });
+  }
+
+  private getParquetFiles(directory: string): string[] {
+    if (!directory || !fs.existsSync(directory)) return [];
+    const files = fs.readdirSync(directory);
+    const parquetFiles = [];
+    for (const file of files) {
+      if (/\.parquet$/.test(file)) {
+        parquetFiles.push(file);
+      }
+    }
+    return parquetFiles;
   }
 }

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -114,6 +114,8 @@ export class CacheLayerInfo {
   refreshExpression?: RefreshExpression;
   // index key name -> index column
   indexes?: Record<string, string>;
+  // cache folder subpath
+  folderSubpath?: string;
 }
 
 export class APISchema {

--- a/packages/core/test/cache-layer/cacheLayerLoader.spec.ts
+++ b/packages/core/test/cache-layer/cacheLayerLoader.spec.ts
@@ -54,62 +54,62 @@ describe('Test cache layer loader', () => {
     fs.rmSync(folderPath, { recursive: true, force: true });
   });
 
-  // it.each([
-  //   {
-  //     templateName: 'template-1',
-  //     cache: {
-  //       cacheTableName: 'employees',
-  //       sql: sinon.default.stub() as any,
-  //       profile: profiles[0].name,
-  //     } as CacheLayerInfo,
-  //   },
-  //   {
-  //     templateName: 'template-1',
-  //     cache: {
-  //       cacheTableName: 'departments',
-  //       sql: sinon.default.stub() as any,
-  //       profile: profiles[1].name,
-  //     } as CacheLayerInfo,
-  //   },
-  //   {
-  //     templateName: 'template-2',
-  //     cache: {
-  //       cacheTableName: 'jobs',
-  //       sql: sinon.default.stub() as any,
-  //       profile: profiles[2].name,
-  //     } as CacheLayerInfo,
-  //   },
-  // ])(
-  //   'Should export and load $cache.cacheTableName successful when start loader with cache settings for $templateName',
-  //   async ({ templateName, cache }) => {
-  //     // Arrange
-  //     // Act
-  //     const loader = new CacheLayerLoader(options, stubFactory as any);
-  //     await loader.load(templateName, cache);
+  it.each([
+    {
+      templateName: 'template-1',
+      cache: {
+        cacheTableName: 'employees',
+        sql: sinon.default.stub() as any,
+        profile: profiles[0].name,
+      } as CacheLayerInfo,
+    },
+    {
+      templateName: 'template-1',
+      cache: {
+        cacheTableName: 'departments',
+        sql: sinon.default.stub() as any,
+        profile: profiles[1].name,
+      } as CacheLayerInfo,
+    },
+    {
+      templateName: 'template-2',
+      cache: {
+        cacheTableName: 'jobs',
+        sql: sinon.default.stub() as any,
+        profile: profiles[2].name,
+      } as CacheLayerInfo,
+    },
+  ])(
+    'Should export and load $cache.cacheTableName successful when start loader with cache settings for $templateName',
+    async ({ templateName, cache }) => {
+      // Arrange
+      // Act
+      const loader = new CacheLayerLoader(options, stubFactory as any);
+      await loader.load(templateName, cache);
 
-  //     // Assert
-  //     const actual = (
-  //       await getQueryResults(
-  //         "select * from information_schema.tables where table_schema = 'vulcan'"
-  //       )
-  //     ).map((row) => {
-  //       return {
-  //         table: row['table_name'],
-  //         schema: row['table_schema'],
-  //       };
-  //     });
-  //     expect(actual).toEqual(
-  //       expect.arrayContaining([
-  //         {
-  //           table: cache.cacheTableName,
-  //           schema: vulcanCacheSchemaName,
-  //         },
-  //       ])
-  //     );
-  //   },
-  //   // Set 50s timeout to test cache loader export and load data
-  //   50 * 10000
-  // );
+      // Assert
+      const actual = (
+        await getQueryResults(
+          "select * from information_schema.tables where table_schema = 'vulcan'"
+        )
+      ).map((row) => {
+        return {
+          table: row['table_name'],
+          schema: row['table_schema'],
+        };
+      });
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          {
+            table: cache.cacheTableName,
+            schema: vulcanCacheSchemaName,
+          },
+        ])
+      );
+    },
+    // Set 50s timeout to test cache loader export and load data
+    50 * 10000
+  );
   it.each([
     {
       templateName: 'template-1',


### PR DESCRIPTION
## Description

Skip exporting data if parquet file exists when loading cache