### PR TITLE
Fix: caching layer persistent

### DIFF
--- a/packages/core/src/containers/modules/dataSource.ts
+++ b/packages/core/src/containers/modules/dataSource.ts
@@ -8,7 +8,11 @@ import {
 import { Profile } from '../../models/profile';
 import { ClassType } from '../../lib/utils/module';
 import { ConfigurationError } from '@vulcan-sql/core/utils';
-import { ICacheLayerOptions, cacheProfileName } from '@vulcan-sql/core/models';
+import {
+  ICacheLayerOptions,
+  cacheLayerPersistentFileName,
+  cacheProfileName,
+} from '@vulcan-sql/core/models';
 import 'reflect-metadata';
 
 export const dataSourceModule = (
@@ -26,6 +30,7 @@ export const dataSourceModule = (
         type: options.loader!.toLocaleLowerCase(),
         // allow '*' to make every user request could use the cache-layer data source.
         allow: '*',
+        connection: { ['persistent-path']: cacheLayerPersistentFileName },
       } as Profile);
     }
 

--- a/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
@@ -43,31 +43,40 @@ export class CacheLayerLoader implements ICacheLayerLoader {
     templateName: string,
     cache: CacheLayerInfo
   ): Promise<void> {
-    const { cacheTableName, sql, profile, indexes } = cache;
+    const { cacheTableName, sql, profile, indexes, folderSubpath } = cache;
     const type = this.options.type!;
     const dataSource = this.dataSourceFactory(profile);
 
     // generate directory for cache file path to export
     // format => [folderPath]/[schema.templateSource]/[profileName]/[cacheTableName]]/[timestamp]
+    const subpath = folderSubpath || moment.utc().format('YYYYMMDDHHmmss');
     const directory = path.resolve(
       this.options.folderPath!,
       templateName,
       profile,
       cacheTableName,
-      moment.utc().format('YYYYMMDDHHmmss')
+      subpath
     );
-
-    if (!fs.existsSync(directory!))
-      fs.mkdirSync(directory!, { recursive: true });
-
-    // 1. export to cache files according to each schema set the cache value
-    this.logger.debug(`Start to export to ${type} file in "${directory}"`);
-    await dataSource.export({
-      sql,
-      directory,
-      profileName: profile,
-      type,
-    });
+    const parquetFiles = this.getParquetFiles(directory);
+    if (!parquetFiles.length) {
+      if (!fs.existsSync(directory!)) {
+        fs.mkdirSync(directory!, { recursive: true });
+      }
+      // 1. export to cache files according to each schema set the cache value
+      this.logger.debug(`Start to export to ${type} file in "${directory}"`);
+      await dataSource.export({
+        sql,
+        directory,
+        profileName: profile,
+        type,
+      });
+    } else {
+      this.logger.debug(
+        `Parquet file \n ${parquetFiles.join(
+          '\n  '
+        )} found in ${directory}, skip export`
+      );
+    }
     this.logger.debug(`Start to load ${cacheTableName} in "${directory}"`);
     // 2. load the files to cache data source
     await this.cacheStorage.import({
@@ -80,5 +89,17 @@ export class CacheLayerLoader implements ICacheLayerLoader {
       type,
       indexes,
     });
+  }
+
+  private getParquetFiles(directory: string): string[] {
+    if (!directory || !fs.existsSync(directory)) return [];
+    const files = fs.readdirSync(directory);
+    const parquetFiles = [];
+    for (const file of files) {
+      if (/\.parquet$/.test(file)) {
+        parquetFiles.push(file);
+      }
+    }
+    return parquetFiles;
   }
 }

--- a/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
@@ -94,12 +94,7 @@ export class CacheLayerLoader implements ICacheLayerLoader {
   private getParquetFiles(directory: string): string[] {
     if (!directory || !fs.existsSync(directory)) return [];
     const files = fs.readdirSync(directory);
-    const parquetFiles = [];
-    for (const file of files) {
-      if (/\.parquet$/.test(file)) {
-        parquetFiles.push(file);
-      }
-    }
+    const parquetFiles = files.filter((file) => /\.parquet$/.test(file));
     return parquetFiles;
   }
 }

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -114,6 +114,8 @@ export class CacheLayerInfo {
   refreshExpression?: RefreshExpression;
   // index key name -> index column
   indexes?: Record<string, string>;
+  // cache folder subpath
+  folderSubpath?: string;
 }
 
 export class APISchema {

--- a/packages/core/src/models/cacheLayerOptions.ts
+++ b/packages/core/src/models/cacheLayerOptions.ts
@@ -19,6 +19,11 @@ export interface ICacheLayerOptions {
 // The cache layer profile name is used to load the cache data to table name from cache files
 export const cacheProfileName = 'vulcan.cache';
 
+// The cache layer persistent file name, if the file name is set to ":memory:", it will use in-memory database
+export const cacheLayerPersistentFileName =
+  process.env['VULCAN_CACHE_LAYER_PERSISTENT_FILE_NAME'] ||
+  'vulcan_caching_layer.db';
+
 // The schema name for vulcan used to create table when loading cache files to cache data source
 export const vulcanCacheSchemaName = 'vulcan';
 

--- a/packages/core/test/cache-layer/cacheLayerLoader.spec.ts
+++ b/packages/core/test/cache-layer/cacheLayerLoader.spec.ts
@@ -54,62 +54,62 @@ describe('Test cache layer loader', () => {
     fs.rmSync(folderPath, { recursive: true, force: true });
   });
 
-  // it.each([
-  //   {
-  //     templateName: 'template-1',
-  //     cache: {
-  //       cacheTableName: 'employees',
-  //       sql: sinon.default.stub() as any,
-  //       profile: profiles[0].name,
-  //     } as CacheLayerInfo,
-  //   },
-  //   {
-  //     templateName: 'template-1',
-  //     cache: {
-  //       cacheTableName: 'departments',
-  //       sql: sinon.default.stub() as any,
-  //       profile: profiles[1].name,
-  //     } as CacheLayerInfo,
-  //   },
-  //   {
-  //     templateName: 'template-2',
-  //     cache: {
-  //       cacheTableName: 'jobs',
-  //       sql: sinon.default.stub() as any,
-  //       profile: profiles[2].name,
-  //     } as CacheLayerInfo,
-  //   },
-  // ])(
-  //   'Should export and load $cache.cacheTableName successful when start loader with cache settings for $templateName',
-  //   async ({ templateName, cache }) => {
-  //     // Arrange
-  //     // Act
-  //     const loader = new CacheLayerLoader(options, stubFactory as any);
-  //     await loader.load(templateName, cache);
+  it.each([
+    {
+      templateName: 'template-1',
+      cache: {
+        cacheTableName: 'employees',
+        sql: sinon.default.stub() as any,
+        profile: profiles[0].name,
+      } as CacheLayerInfo,
+    },
+    {
+      templateName: 'template-1',
+      cache: {
+        cacheTableName: 'departments',
+        sql: sinon.default.stub() as any,
+        profile: profiles[1].name,
+      } as CacheLayerInfo,
+    },
+    {
+      templateName: 'template-2',
+      cache: {
+        cacheTableName: 'jobs',
+        sql: sinon.default.stub() as any,
+        profile: profiles[2].name,
+      } as CacheLayerInfo,
+    },
+  ])(
+    'Should export and load $cache.cacheTableName successful when start loader with cache settings for $templateName',
+    async ({ templateName, cache }) => {
+      // Arrange
+      // Act
+      const loader = new CacheLayerLoader(options, stubFactory as any);
+      await loader.load(templateName, cache);
 
-  //     // Assert
-  //     const actual = (
-  //       await getQueryResults(
-  //         "select * from information_schema.tables where table_schema = 'vulcan'"
-  //       )
-  //     ).map((row) => {
-  //       return {
-  //         table: row['table_name'],
-  //         schema: row['table_schema'],
-  //       };
-  //     });
-  //     expect(actual).toEqual(
-  //       expect.arrayContaining([
-  //         {
-  //           table: cache.cacheTableName,
-  //           schema: vulcanCacheSchemaName,
-  //         },
-  //       ])
-  //     );
-  //   },
-  //   // Set 50s timeout to test cache loader export and load data
-  //   50 * 10000
-  // );
+      // Assert
+      const actual = (
+        await getQueryResults(
+          "select * from information_schema.tables where table_schema = 'vulcan'"
+        )
+      ).map((row) => {
+        return {
+          table: row['table_name'],
+          schema: row['table_schema'],
+        };
+      });
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          {
+            table: cache.cacheTableName,
+            schema: vulcanCacheSchemaName,
+          },
+        ])
+      );
+    },
+    // Set 50s timeout to test cache loader export and load data
+    50 * 10000
+  );
   it.each([
     {
       templateName: 'template-1',

--- a/packages/core/test/containers/cacheLayer.spec.ts
+++ b/packages/core/test/containers/cacheLayer.spec.ts
@@ -1,6 +1,7 @@
 import {
   CacheLayerLoader,
   cacheLayerModule,
+  cacheLayerPersistentFileName,
   CacheLayerStoreFormatType,
   cacheProfileName,
   DataResult,
@@ -89,11 +90,21 @@ it('Cache layer module should add "vulcan.cache" profile and bind "duckdb" type 
 
   expect(dsFromTestDuck.injectedProfiles).toEqual([
     { name: 'test-duck', type: 'duckdb', allow: '*' },
-    { name: cacheProfileName, type: 'duckdb', allow: '*' },
+    {
+      name: cacheProfileName,
+      type: 'duckdb',
+      allow: '*',
+      connection: { ['persistent-path']: cacheLayerPersistentFileName },
+    },
   ]);
   expect(dsFromCacheLayer.injectedProfiles).toEqual([
     { name: 'test-duck', type: 'duckdb', allow: '*' },
-    { name: cacheProfileName, type: 'duckdb', allow: '*' },
+    {
+      name: cacheProfileName,
+      type: 'duckdb',
+      allow: '*',
+      connection: { ['persistent-path']: cacheLayerPersistentFileName },
+    },
   ]);
 });
 


### PR DESCRIPTION
## Description

 - Make caching layer datasource can be persistent 
    - It's will reduce the memory usage when loading parquet file to cache 
 - Skip exporting data if parquet file exists when loading cache
    - avoid exporting/downloading data if the parquet files in path is still fresh
