### PR TITLE
Feature(Core, Extension-driver-canner): pass headers down to datasource & use info in API headers to connect to canner

### DIFF
--- a/packages/core/src/lib/data-query/executor.ts
+++ b/packages/core/src/lib/data-query/executor.ts
@@ -46,6 +46,7 @@ export class QueryExecutor implements IExecutor {
       parameterizer,
       dataSource: this.dataSourceFactory(profileName)!,
       profileName,
+      headers: {},
     });
   }
 }

--- a/packages/core/src/lib/data-query/executor.ts
+++ b/packages/core/src/lib/data-query/executor.ts
@@ -1,5 +1,6 @@
 import {
   DataSource,
+  IncomingHttpHeaders,
   PrepareParameterFunc,
   RequestParameter,
 } from '@vulcan-sql/core/models';
@@ -12,7 +13,8 @@ export interface IExecutor {
   createBuilder(
     profileName: string,
     query: string,
-    parameterizer: IParameterizer
+    parameterizer: IParameterizer,
+    headers?: IncomingHttpHeaders
   ): Promise<IDataQueryBuilder>;
   prepare: PrepareParameterFunc;
 }
@@ -39,14 +41,15 @@ export class QueryExecutor implements IExecutor {
   public async createBuilder(
     profileName: string,
     query: string,
-    parameterizer: IParameterizer
+    parameterizer: IParameterizer,
+    headers?: IncomingHttpHeaders
   ) {
     return new DataQueryBuilder({
       statement: query,
       parameterizer,
       dataSource: this.dataSourceFactory(profileName)!,
       profileName,
-      headers: {},
+      headers: headers || {},
     });
   }
 }

--- a/packages/core/src/lib/template-engine/built-in-extensions/cache/cacheTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/cache/cacheTagRunner.ts
@@ -25,7 +25,7 @@ export class CacheTagRunner extends TagRunner {
     this.executor = executor;
   }
 
-  public async run({ context, args, contentArgs }: TagRunnerOptions) {
+  public async run({ context, args, contentArgs, metadata }: TagRunnerOptions) {
     // Get the variable name, if the cache tag has variable name, then we use the variable and keep the builder in the variable, and make user could use by xxx.value() like the req feature.
     // However if the cache tag not has variable name, means you would like to get the result directly after query, then we will replace the original query main builder to the cache builder.
     const name = String(args[0]);
@@ -56,6 +56,9 @@ export class CacheTagRunner extends TagRunner {
       parameterizer
     );
     context.setVariable(name, builder);
+    // pass header to builder
+    const headers = metadata.getHeaders();
+    if (headers) builder.setHeaders(headers);
 
     // Set parameter back for upstream usage
     context.setVariable(PARAMETERIZER_VAR_NAME, parentParameterizer);

--- a/packages/core/src/lib/template-engine/built-in-extensions/cache/cacheTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/cache/cacheTagRunner.ts
@@ -50,15 +50,14 @@ export class CacheTagRunner extends TagRunner {
     // Set the default vulcan created cache table schema, so we could query the cache table directly, not need user to type schema in the SQL.
     query = `set schema=${vulcanCacheSchemaName};`.concat('\n').concat(query);
     // Create the builder which access "vulcan.cache" data source for cache layer query
+    const headers = metadata.getHeaders();
     const builder = await this.executor.createBuilder(
       cacheProfileName,
       query,
-      parameterizer
+      parameterizer,
+      headers
     );
     context.setVariable(name, builder);
-    // pass header to builder
-    const headers = metadata.getHeaders();
-    if (headers) builder.setHeaders(headers);
 
     // Set parameter back for upstream usage
     context.setVariable(PARAMETERIZER_VAR_NAME, parentParameterizer);

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
@@ -59,9 +59,9 @@ export class ReqTagRunner extends TagRunner {
       builder = await this.executor.createBuilder(
         profileName,
         query,
-        parameterizer
+        parameterizer,
+        headers
       );
-      if (headers) builder.setHeaders(headers);
       context.setVariable(name, builder);
     }
 

--- a/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/query-builder/reqTagRunner.ts
@@ -47,17 +47,21 @@ export class ReqTagRunner extends TagRunner {
       .join('\n')
       .replace(/--.*(?:\n|$)|\/\*[\s\S]*?\*\//g, ''); // remove single-line comments and multi-line comments
 
+    const headers = metadata.getHeaders();
     let builder: IDataQueryBuilder | undefined;
     // Replace to put the directly query cache builder to original query main builder of  "__wrapper__builder",
     // it means we can use the cache builder to execute the query directly and get result to be final result
     builder = context.lookup(CACHE_MAIN_BUILDER_VAR_NAME);
-    if (builder) context.setVariable(name, builder);
-    else {
+    if (builder) {
+      if (headers) builder.setHeaders(headers);
+      context.setVariable(name, builder);
+    } else {
       builder = await this.executor.createBuilder(
         profileName,
         query,
         parameterizer
       );
+      if (headers) builder.setHeaders(headers);
       context.setVariable(name, builder);
     }
 

--- a/packages/core/src/lib/template-engine/compiler.ts
+++ b/packages/core/src/lib/template-engine/compiler.ts
@@ -1,4 +1,8 @@
-import { DataResult, KoaRequest } from '@vulcan-sql/core/models';
+import {
+  DataResult,
+  IncomingHttpHeaders,
+  KoaRequest,
+} from '@vulcan-sql/core/models';
 import { Pagination } from '../../models/pagination';
 
 export interface TemplateLocation {
@@ -32,6 +36,7 @@ export interface ExecuteContext {
   user?: UserInfo;
   profileName: string;
   req?: KoaRequest;
+  headers?: IncomingHttpHeaders;
 }
 
 export interface Compiler {

--- a/packages/core/src/lib/template-engine/nunjucksExecutionMetadata.ts
+++ b/packages/core/src/lib/template-engine/nunjucksExecutionMetadata.ts
@@ -1,6 +1,6 @@
 import * as nunjucks from 'nunjucks';
 import { ExecuteContext, UserInfo } from './compiler';
-import { KoaRequest } from '@vulcan-sql/core/models';
+import { IncomingHttpHeaders, KoaRequest } from '@vulcan-sql/core/models';
 
 export const ReservedContextKeys = {
   CurrentProfileName: 'RESERVED_CURRENT_PROFILE_NAME',
@@ -12,12 +12,20 @@ export class NunjucksExecutionMetadata {
   private parameters: Record<string, any>;
   private userInfo?: UserInfo;
   private req?: KoaRequest;
+  private headers?: IncomingHttpHeaders;
 
-  constructor({ parameters = {}, profileName, user, req }: ExecuteContext) {
+  constructor({
+    parameters = {},
+    profileName,
+    user,
+    req,
+    headers,
+  }: ExecuteContext) {
     this.parameters = parameters;
     this.profileName = profileName;
     this.userInfo = user;
     this.req = req;
+    this.headers = headers;
   }
 
   /** Load from nunjucks context */
@@ -26,6 +34,7 @@ export class NunjucksExecutionMetadata {
       parameters: context.lookup('context')?.params || {},
       user: context.lookup('context')?.user || {},
       req: context.lookup('context')?.req || {},
+      headers: context.lookup('context')?.headers || {},
       profileName: context.lookup(ReservedContextKeys.CurrentProfileName)!,
     });
   }
@@ -38,6 +47,7 @@ export class NunjucksExecutionMetadata {
         user: this.userInfo,
         req: this.req,
         profile: this.profileName,
+        headers: this.headers,
       },
       [ReservedContextKeys.CurrentProfileName]: this.profileName,
     };
@@ -53,5 +63,9 @@ export class NunjucksExecutionMetadata {
 
   public getRequest() {
     return this.req;
+  }
+
+  public getHeaders() {
+    return this.headers;
   }
 }

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -30,8 +30,10 @@ import {
 import { Type } from 'class-transformer';
 import 'reflect-metadata';
 import { Request as KoaRequest } from 'koa';
+import { IncomingHttpHeaders } from 'http';
 
 export type { KoaRequest };
+export type { IncomingHttpHeaders };
 
 // Pagination mode should always be UPPERCASE because schema parser will transform the user inputs.
 export enum PaginationMode {

--- a/packages/core/src/models/extensions/dataSource.ts
+++ b/packages/core/src/models/extensions/dataSource.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Parameterized, SQLClauseOperation } from '@vulcan-sql/core/data-query';
-import { CacheLayerStoreFormatType, Profile } from '@vulcan-sql/core/models';
+import {
+  CacheLayerStoreFormatType,
+  IncomingHttpHeaders,
+  Profile,
+} from '@vulcan-sql/core/models';
 import { TYPES } from '@vulcan-sql/core/types';
 import { inject, multiInject, optional } from 'inversify';
 import { Readable } from 'stream';
@@ -58,6 +62,7 @@ export interface ExecuteOptions {
   /** The parameter bindings, we guarantee the order of the keys in the map is the same as the order when they were used in queries. */
   bindParams: BindParameters;
   profileName: string;
+  headers?: IncomingHttpHeaders;
 }
 
 export type PrepareParameterFunc = {

--- a/packages/core/test/data-query/builder/group-by-clause.spec.ts
+++ b/packages/core/test/data-query/builder/group-by-clause.spec.ts
@@ -35,6 +35,7 @@ describe('Test data query builder > group by clause', () => {
         dataSource: stubDataSource,
         parameterizer: stubParameterizer,
         profileName: '',
+        headers: {},
       });
       columns.map((column) => {
         builder = builder.groupBy(column);
@@ -62,6 +63,7 @@ describe('Test data query builder > group by clause', () => {
         dataSource: stubDataSource,
         parameterizer: stubParameterizer,
         profileName: '',
+        headers: {},
       });
       builder.groupBy(first, second, third);
 

--- a/packages/core/test/data-query/builder/having-clause.spec.ts
+++ b/packages/core/test/data-query/builder/having-clause.spec.ts
@@ -32,6 +32,7 @@ const createStubBuilder = ({ statement }: { statement: string }) =>
     dataSource: createStub().dataSource,
     parameterizer: createStub().parameterizer,
     profileName: '',
+    headers: {},
   });
 
 describe('Test data query builder > having clause', () => {

--- a/packages/core/test/data-query/builder/join-clause.spec.ts
+++ b/packages/core/test/data-query/builder/join-clause.spec.ts
@@ -29,6 +29,7 @@ const createStubBuilder = ({ statement }: { statement: string }) =>
     dataSource: createStub().dataSource,
     parameterizer: createStub().parameterizer,
     profileName: '',
+    headers: {},
   });
 
 describe('Test data query builder > join clause', () => {

--- a/packages/core/test/data-query/builder/limit-offset-clause.spec.ts
+++ b/packages/core/test/data-query/builder/limit-offset-clause.spec.ts
@@ -15,6 +15,7 @@ const createStubBuilder = ({ statement }: { statement: string }) =>
     dataSource: createStub().dataSource,
     parameterizer: createStub().parameterizer,
     profileName: '',
+    headers: {},
   });
 
 describe('Test data query builder > limit-offset by clause', () => {

--- a/packages/core/test/data-query/builder/order-by-clause.spec.ts
+++ b/packages/core/test/data-query/builder/order-by-clause.spec.ts
@@ -21,6 +21,7 @@ const createStubBuilder = ({ statement }: { statement: string }) =>
     dataSource: createStub().dataSource,
     parameterizer: createStub().parameterizer,
     profileName: '',
+    headers: {},
   });
 
 describe('Test data query builder > order by clause', () => {

--- a/packages/core/test/data-query/builder/parameterize.spec.ts
+++ b/packages/core/test/data-query/builder/parameterize.spec.ts
@@ -13,6 +13,7 @@ const createStubs = ({ statement }: { statement: string }) => {
       dataSource,
       parameterizer,
       profileName: '',
+      headers: {},
     }),
     dataSource,
     parameterizer,

--- a/packages/core/test/data-query/builder/select-clause.spec.ts
+++ b/packages/core/test/data-query/builder/select-clause.spec.ts
@@ -51,6 +51,7 @@ const createStubBuilder = ({ statement }: { statement: string }) =>
     dataSource: createStub().dataSource,
     parameterizer: createStub().parameterizer,
     profileName: '',
+    headers: {},
   });
 
 describe('Test data query builder > select clause', () => {

--- a/packages/core/test/data-query/builder/where-clause.spec.ts
+++ b/packages/core/test/data-query/builder/where-clause.spec.ts
@@ -25,6 +25,7 @@ const createStubBuilder = ({ statement }: { statement: string }) =>
     dataSource: createStub().dataSource,
     parameterizer: createStub().parameterizer,
     profileName: '',
+    headers: {},
   });
 
 jest.mock('uuid');

--- a/packages/core/test/template-engine/built-in-extensions/query-builder/operations.spec.ts
+++ b/packages/core/test/template-engine/built-in-extensions/query-builder/operations.spec.ts
@@ -23,6 +23,7 @@ const createTestCompilerWithBuilder = async () => {
         statement: query,
         parameterizer,
         dataSource,
+        headers: {},
       });
     }
   );

--- a/packages/extension-driver-canner/src/lib/cannerDataSource.ts
+++ b/packages/extension-driver-canner/src/lib/cannerDataSource.ts
@@ -170,12 +170,7 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     const userPoolKey = this.getUserPoolKey(password, database);
     if (this.UserPool.has(userPoolKey)) {
       const userPool = this.UserPool.get(userPoolKey);
-      if (!userPool) {
-        throw new InternalError(
-          `User pool ${userPoolKey} is not a Pool instance`
-        );
-      }
-      return userPool;
+      return userPool!;
     }
     const pool = new Pool({ ...poolOptions, password: password });
     this.UserPool.set(userPoolKey, pool);

--- a/packages/extension-driver-canner/src/lib/cannerDataSource.ts
+++ b/packages/extension-driver-canner/src/lib/cannerDataSource.ts
@@ -24,7 +24,11 @@ export interface PGOptions extends PoolConfig {
 @VulcanExtensionId('canner')
 export class CannerDataSource extends DataSource<any, PGOptions> {
   private logger = this.getLogger();
-  private poolMapping = new Map<string, { pool: Pool; options?: PGOptions }>();
+  protected poolMapping = new Map<
+    string,
+    { pool: Pool; options?: PGOptions }
+  >();
+  protected UserPool = new Map<string, Pool>();
 
   public override async onActivate() {
     const profiles = this.getProfiles().values();
@@ -108,14 +112,14 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     bindParams,
     profileName,
     operations,
+    headers,
   }: ExecuteOptions): Promise<DataResult> {
-    if (!this.poolMapping.has(profileName)) {
-      throw new InternalError(`Profile instance ${profileName} not found`);
-    }
-    const { pool, options } = this.poolMapping.get(profileName)!;
-    this.logger.debug(`Acquiring connection from ${profileName}`);
-    const client = await pool.connect();
     this.logger.debug(`Acquired connection from ${profileName}`);
+    const { options } = this.poolMapping.get(profileName)!;
+    const auth = headers?.['authorization'];
+    const password = auth?.trim().split(' ')[1];
+    const pool = this.getPool(profileName, password);
+    const client = await pool.connect();
     try {
       const builtSQL = buildSQL(sql, operations);
       const cursor = client.query(
@@ -148,6 +152,38 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     for (const { pool } of this.poolMapping.values()) {
       await pool.end();
     }
+  }
+
+  // use protected to make it testable
+  protected getPool(profileName: string, password?: string): Pool {
+    if (!this.poolMapping.has(profileName)) {
+      throw new InternalError(`Profile instance ${profileName} not found`);
+    }
+    const { pool: defaultPool, options: poolOptions } =
+      this.poolMapping.get(profileName)!;
+    this.logger.debug(`Acquiring connection from ${profileName}`);
+    if (!password) {
+      return defaultPool;
+    }
+    const database = poolOptions?.database || '';
+    const userPoolKey = this.getUserPoolKey(password, database);
+    if (this.UserPool.has(userPoolKey)) {
+      const userPool = this.UserPool.get(userPoolKey);
+      if (!userPool) {
+        throw new InternalError(
+          `User pool ${userPoolKey} is not a Pool instance`
+        );
+      }
+      return userPool;
+    }
+    const pool = new Pool({ ...poolOptions, password: password });
+    this.UserPool.set(userPoolKey, pool);
+    return pool;
+  }
+
+  // use protected to make it testable
+  protected getUserPoolKey(pat: string, database?: string) {
+    return `${pat}-${database}`;
   }
 
   private async getResultFromCursor(

--- a/packages/extension-driver-canner/test/cannerDataSource.spec.ts
+++ b/packages/extension-driver-canner/test/cannerDataSource.spec.ts
@@ -350,6 +350,8 @@ it('Should return the same pool when the profile and authentication is the same'
 
 it('Should return new user pool if user pool not exist', async () => {
   // Arrange
+  const profile1 = pg.getProfile('profile1');
+  const database = <string>profile1.connection.database;
   mockDataSource = new MockCannerDataSource({}, '', [
     pg.getProfile('profile1'),
   ]);
@@ -357,8 +359,46 @@ it('Should return new user pool if user pool not exist', async () => {
   // Act
   const pool1 = mockDataSource.getPool('profile1');
   const pool2 = mockDataSource.getPool('profile1', 'my-authentication');
+  const userPool = mockDataSource.getUserPool('my-authentication', database);
   // Assert
   expect(pool1 == pool2).toBeFalsy();
+  expect(userPool === pool2).toBeTruthy();
+}, 30000);
+
+it('Should return existing user pool if user pool exist', async () => {
+  // Arrange
+  const profile1 = pg.getProfile('profile1');
+  const database = <string>profile1.connection.database;
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+
+  // Act
+  const pool = mockDataSource.getPool('profile1', 'my-authentication');
+  const userPool = mockDataSource.getUserPool('my-authentication', database);
+  // Assert
+  expect(userPool === pool).toBeTruthy();
+}, 30000);
+
+it('Should return new user pool if user pool exist but not match', async () => {
+  // Arrange
+  const profile1 = pg.getProfile('profile1');
+  const database = <string>profile1.connection.database;
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+
+  // Act
+  expect(mockDataSource.getUserPool('my-authentication', database)).toBe(
+    undefined
+  );
+  mockDataSource.getPool('profile1', 'my-authentication');
+  // Assert
+  expect(
+    mockDataSource.getUserPool('my-authentication', database)
+  ).toBeDefined();
 }, 30000);
 
 it('Should return different pool with different authentication even the profile is the same', async () => {

--- a/packages/extension-driver-canner/test/cannerDataSource.spec.ts
+++ b/packages/extension-driver-canner/test/cannerDataSource.spec.ts
@@ -348,7 +348,7 @@ it('Should return the same pool when the profile and authentication is the same'
   expect(pool1 === pool2).toBeTruthy();
 }, 30000);
 
-it('Should return different pool if authentication exist in headers even the profile is the same', async () => {
+it('Should return new user pool if user pool not exist', async () => {
   // Arrange
   mockDataSource = new MockCannerDataSource({}, '', [
     pg.getProfile('profile1'),
@@ -372,4 +372,28 @@ it('Should return different pool with different authentication even the profile 
   const pool2 = mockDataSource.getPool('profile1', 'differ-authentication');
   // Assert
   expect(pool1 === pool2).toBeFalsy();
+}, 30000);
+
+it('Should throw error when the profile is not exist', async () => {
+  // Arrange
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+  // Act, Assert
+  expect(() => mockDataSource.getPool('profile2')).toThrow(
+    'Profile instance profile2 not found'
+  );
+}, 30000);
+
+it('Should return default pool when password was not given', async () => {
+  // Arrange
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+  // Act
+  const pool = mockDataSource.getPool('profile1');
+  // Assert
+  expect(pool).toBeDefined();
 }, 30000);

--- a/packages/extension-driver-canner/test/cannerDataSource.spec.ts
+++ b/packages/extension-driver-canner/test/cannerDataSource.spec.ts
@@ -1,5 +1,6 @@
 import { CannerServer } from './cannerServer';
 import { CannerDataSource, PGOptions } from '../src';
+import { MockCannerDataSource } from './mock';
 import { ExportOptions, InternalError, streamToArray } from '@vulcan-sql/core';
 import { Writable } from 'stream';
 import * as sinon from 'ts-sinon';
@@ -8,7 +9,9 @@ import { CannerAdapter } from '../src/lib/cannerAdapter';
 
 const pg = new CannerServer();
 let dataSource: CannerDataSource;
+let mockDataSource: MockCannerDataSource;
 
+const directory = 'tmp_test_canner';
 // restore all sinon mock/stub before each test
 beforeEach(() => {
   sinon.default.restore();
@@ -42,7 +45,7 @@ it('Data source should throw error when activating if any profile is invalid', a
 
 // export method should be executed successfully
 it('Data source should export successfully', async () => {
-  fs.mkdirSync('tmp', { recursive: true });
+  fs.mkdirSync(directory, { recursive: true });
   dataSource = new CannerDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
 
@@ -50,14 +53,14 @@ it('Data source should export successfully', async () => {
   await expect(
     dataSource.export({
       sql: 'select 1',
-      directory: 'tmp',
+      directory,
       profileName: 'profile1',
     } as ExportOptions)
   ).resolves.not.toThrow();
-  expect(fs.readdirSync('tmp').length).toBe(1);
+  expect(fs.readdirSync(directory).length).toBe(1);
 
   // clean up
-  fs.rmSync('tmp', { recursive: true, force: true });
+  fs.rmSync(directory, { recursive: true, force: true });
 }, 100000);
 
 it('Data source should throw error when fail to export data', async () => {
@@ -73,7 +76,7 @@ it('Data source should throw error when fail to export data', async () => {
       );
     });
 
-  fs.mkdirSync('tmp', { recursive: true });
+  fs.mkdirSync(directory, { recursive: true });
   dataSource = new CannerDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
 
@@ -81,14 +84,14 @@ it('Data source should throw error when fail to export data', async () => {
   await expect(
     dataSource.export({
       sql: 'select 1',
-      directory: 'tmp',
+      directory,
       profileName: 'profile1',
     } as ExportOptions)
   ).rejects.toThrow();
-  expect(fs.readdirSync('tmp').length).toBe(0);
+  expect(fs.readdirSync(directory).length).toBe(0);
 
   // clean up
-  fs.rmSync('tmp', { recursive: true, force: true });
+  fs.rmSync(directory, { recursive: true, force: true });
 }, 100000);
 
 it('Data source should throw error when given directory is not exist', async () => {
@@ -100,7 +103,7 @@ it('Data source should throw error when given directory is not exist', async () 
   await expect(
     dataSource.export({
       sql: 'select 1',
-      directory: 'tmp',
+      directory: directory,
       profileName: 'profile1',
     } as ExportOptions)
   ).rejects.toThrow();
@@ -110,13 +113,13 @@ it('Data source should throw error when given profile name is not exist', async 
   // Arrange
   dataSource = new CannerDataSource({}, '', [pg.getProfile('profile1')]);
   await dataSource.activate();
-  fs.mkdirSync('tmp', { recursive: true });
+  fs.mkdirSync(directory, { recursive: true });
 
   // Act, Assert
   await expect(
     dataSource.export({
       sql: 'select 1',
-      directory: 'tmp',
+      directory,
       profileName: 'profile not exist',
     } as ExportOptions)
   ).rejects.toThrow();
@@ -318,3 +321,55 @@ it('Data source should release connection when readable stream is destroyed', as
   expect(rows.length).toBe(1);
   // afterEach hook will timeout if any leak occurred.
 }, 300000);
+
+it('Should return the same pool when the profile is the same', async () => {
+  // Arrange
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+  // Act
+  const pool1 = mockDataSource.getPool('profile1');
+  const pool2 = mockDataSource.getPool('profile1');
+  // Assert
+  expect(pool1 === pool2).toBeTruthy();
+}, 30000);
+
+it('Should return the same pool when the profile and authentication is the same', async () => {
+  // Arrange
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+  // Act
+  const pool1 = mockDataSource.getPool('profile1', 'the-same-authentication');
+  const pool2 = mockDataSource.getPool('profile1', 'the-same-authentication');
+  // Assert
+  expect(pool1 === pool2).toBeTruthy();
+}, 30000);
+
+it('Should return different pool if authentication exist in headers even the profile is the same', async () => {
+  // Arrange
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+  // Act
+  const pool1 = mockDataSource.getPool('profile1');
+  const pool2 = mockDataSource.getPool('profile1', 'my-authentication');
+  // Assert
+  expect(pool1 == pool2).toBeFalsy();
+}, 30000);
+
+it('Should return different pool with different authentication even the profile is the same', async () => {
+  // Arrange
+  mockDataSource = new MockCannerDataSource({}, '', [
+    pg.getProfile('profile1'),
+  ]);
+  await mockDataSource.activate();
+  // Act
+  const pool1 = mockDataSource.getPool('profile1', 'authentication');
+  const pool2 = mockDataSource.getPool('profile1', 'differ-authentication');
+  // Assert
+  expect(pool1 === pool2).toBeFalsy();
+}, 30000);

--- a/packages/extension-driver-canner/test/mock/index.ts
+++ b/packages/extension-driver-canner/test/mock/index.ts
@@ -1,0 +1,1 @@
+export * from './mockCannerDataSource';

--- a/packages/extension-driver-canner/test/mock/mockCannerDataSource.ts
+++ b/packages/extension-driver-canner/test/mock/mockCannerDataSource.ts
@@ -16,12 +16,7 @@ export class MockCannerDataSource extends CannerDataSource {
     const userPoolKey = this.getUserPoolKey(password, database);
     if (this.UserPool.has(userPoolKey)) {
       const userPool = this.UserPool.get(userPoolKey);
-      if (!userPool) {
-        throw new InternalError(
-          `User pool ${userPoolKey} is not a Pool instance`
-        );
-      }
-      return userPool;
+      return userPool!;
     }
     const pool = new Pool({ ...poolOptions, password: password });
     this.UserPool.set(userPoolKey, pool);

--- a/packages/extension-driver-canner/test/mock/mockCannerDataSource.ts
+++ b/packages/extension-driver-canner/test/mock/mockCannerDataSource.ts
@@ -22,4 +22,14 @@ export class MockCannerDataSource extends CannerDataSource {
     this.UserPool.set(userPoolKey, pool);
     return pool;
   }
+
+  public setUserPool = (userPool: Pool, password: string, database: string) => {
+    const userPoolKey = this.getUserPoolKey(password, database);
+    this.UserPool.set(userPoolKey, userPool);
+  };
+
+  public getUserPool = (password: string, database: string) => {
+    const userPoolKey = this.getUserPoolKey(password, database);
+    return this.UserPool.get(userPoolKey);
+  };
 }

--- a/packages/extension-driver-canner/test/mock/mockCannerDataSource.ts
+++ b/packages/extension-driver-canner/test/mock/mockCannerDataSource.ts
@@ -1,0 +1,30 @@
+import { CannerDataSource } from '../../src';
+import { InternalError } from '@vulcan-sql/core';
+import { Pool } from 'pg';
+
+export class MockCannerDataSource extends CannerDataSource {
+  public override getPool(profileName: string, password?: string): Pool {
+    if (!this.poolMapping.has(profileName)) {
+      throw new InternalError(`Profile instance ${profileName} not found`);
+    }
+    const { pool: defaultPool, options: poolOptions } =
+      this.poolMapping.get(profileName)!;
+    if (!password) {
+      return defaultPool;
+    }
+    const database = poolOptions?.database || '';
+    const userPoolKey = this.getUserPoolKey(password, database);
+    if (this.UserPool.has(userPoolKey)) {
+      const userPool = this.UserPool.get(userPoolKey);
+      if (!userPool) {
+        throw new InternalError(
+          `User pool ${userPoolKey} is not a Pool instance`
+        );
+      }
+      return userPool;
+    }
+    const pool = new Pool({ ...poolOptions, password: password });
+    this.UserPool.set(userPoolKey, pool);
+    return pool;
+  }
+}

--- a/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
+++ b/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
@@ -93,10 +93,13 @@ export class DuckDBDataSource extends DataSource<any, DuckDBOptions> {
     bindParams,
     profileName,
     operations,
+    headers,
   }: ExecuteOptions): Promise<DataResult> {
     if (!this.dbMapping.has(profileName)) {
       throw new InternalError(`Profile instance ${profileName} not found`);
     }
+    console.log(`execute duckdb: ${sql}`);
+    console.log({ headers });
     const { db, configurationParameters, ...options } =
       this.dbMapping.get(profileName)!;
     const [firstDataSQL, restDataSQL] = buildSQL(sql, operations);

--- a/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
+++ b/packages/extension-driver-duckdb/src/lib/duckdbDataSource.ts
@@ -93,13 +93,10 @@ export class DuckDBDataSource extends DataSource<any, DuckDBOptions> {
     bindParams,
     profileName,
     operations,
-    headers,
   }: ExecuteOptions): Promise<DataResult> {
     if (!this.dbMapping.has(profileName)) {
       throw new InternalError(`Profile instance ${profileName} not found`);
     }
-    console.log(`execute duckdb: ${sql}`);
-    console.log({ headers });
     const { db, configurationParameters, ...options } =
       this.dbMapping.get(profileName)!;
     const [firstDataSQL, restDataSQL] = buildSQL(sql, operations);

--- a/packages/serve/src/lib/route/route-component/baseRoute.ts
+++ b/packages/serve/src/lib/route/route-component/baseRoute.ts
@@ -9,7 +9,7 @@ import { IRequestValidator } from './requestValidator';
 import { IRequestTransformer, RequestParameters } from './requestTransformer';
 import { IPaginationTransformer } from './paginationTransformer';
 import { Evaluator } from '@vulcan-sql/serve/evaluator';
-import { KoaRequest } from '@vulcan-sql/core';
+import { KoaRequest, IncomingHttpHeaders } from '@vulcan-sql/core';
 
 export interface TransformedRequest {
   reqParams: RequestParameters;
@@ -61,7 +61,8 @@ export abstract class BaseRoute implements IRoute {
   protected async handle(
     user: AuthUserInfo,
     transformed: TransformedRequest,
-    req: KoaRequest
+    req: KoaRequest,
+    headers: IncomingHttpHeaders
   ) {
     const { reqParams, pagination } = transformed;
     // could template name or template path, use for template engine
@@ -81,6 +82,7 @@ export abstract class BaseRoute implements IRoute {
         user,
         req,
         profileName: profile,
+        headers: headers,
       },
       pagination
     );

--- a/packages/serve/src/lib/route/route-component/graphQLRoute.ts
+++ b/packages/serve/src/lib/route/route-component/graphQLRoute.ts
@@ -20,7 +20,8 @@ export class GraphQLRoute extends BaseRoute {
     const transformed = await this.prepare(ctx);
     const authUser = ctx.state.user;
     const req = ctx.request as KoaRequest;
-    await this.handle(authUser, transformed, req);
+    const headers = ctx.headers;
+    await this.handle(authUser, transformed, req, headers);
     // TODO: get template engine handled result and return response by checking API schema
     return transformed;
   }

--- a/packages/serve/src/lib/route/route-component/restfulRoute.ts
+++ b/packages/serve/src/lib/route/route-component/restfulRoute.ts
@@ -1,6 +1,6 @@
 import { BaseRoute, RouteOptions } from './baseRoute';
 import { KoaContext } from '@vulcan-sql/serve/models';
-import { KoaRequest } from '@vulcan-sql/core';
+import { KoaRequest, IncomingHttpHeaders } from '@vulcan-sql/core';
 
 export class RestfulRoute extends BaseRoute {
   public readonly urlPath: string;
@@ -15,7 +15,8 @@ export class RestfulRoute extends BaseRoute {
     const transformed = await this.prepare(ctx);
     const authUser = ctx.state.user;
     const req = ctx.request as KoaRequest;
-    const result = await this.handle(authUser, transformed, req);
+    const headers = ctx.headers as IncomingHttpHeaders;
+    const result = await this.handle(authUser, transformed, req, headers);
     ctx.response.body = {
       data: result.getData(),
       columns: result.getColumns(),


### PR DESCRIPTION
## Description

To use the API request context(e.g.: some customized headers) in dataSource, we need to first inject the API context into NunjucksExecutionMetadata which stores global info and passes around tag runners, and inject API context into dataSource in each tag runner.

## Note
Pass API request context in the Nunjucks filter is not supported yet 

## Test
unit test ✅ 
manual integration test using canner driver ✅ 
 - can use headers to access canner

<img width="1680" alt="截圖 2023-09-04 下午2 41 44" src="https://github.com/Canner/vulcan-sql/assets/38731840/0f7272c5-73b7-4656-af45-2ecc1379e742">


