### PR TITLE
Feature: Provide BASE_URL for Catalog Server Hosting

### DIFF
--- a/packages/catalog-server/lib/api.ts
+++ b/packages/catalog-server/lib/api.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 import { errorCode } from '@vulcan-sql/catalog-server/utils/errorCode';
+import getConfig from 'next/config';
+
+const { publicRuntimeConfig } = getConfig();
 
 enum API {
   Login = '/api/auth/login',
@@ -22,7 +25,7 @@ const handleError = ({ statusCode, errorMessage }) => {
 };
 
 export const axiosInstance = axios.create({
-  baseURL: process.env.API_URL || 'http://localhost:4200',
+  baseURL: publicRuntimeConfig.baseUrl,
   responseType: 'json',
   timeout: 30000,
   headers: {

--- a/packages/catalog-server/lib/apollo.ts
+++ b/packages/catalog-server/lib/apollo.ts
@@ -7,7 +7,7 @@ import {
 import { setContext } from '@apollo/client/link/context';
 
 const httpLink = createHttpLink({
-  uri: process.env.GQL_API_URL || 'http://localhost:4200/api/graphql',
+  uri: '/api/graphql',
 });
 
 const authLink = setContext((_, { headers }) => {

--- a/packages/catalog-server/next.config.js
+++ b/packages/catalog-server/next.config.js
@@ -12,6 +12,9 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+  publicRuntimeConfig: {
+    baseUrl: process.env.BASE_URL || 'http://localhost:4200',
+  },
   serverRuntimeConfig: {
     // Will only be available on the server side
     vulcanSQLHost: process.env.VULCAN_SQL_HOST || 'http://localhost:3000',


### PR DESCRIPTION
## Description

- Add `BASE_URL` env for catalog server hosting when needed

This adjustment is aligned with https://catalog-server.vercel.app

## Issue ticket number

closes N/A

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
