### PR TITLE
Feature(CORE): Activity log extension

### DIFF
--- a/packages/core/src/containers/modules/extension.ts
+++ b/packages/core/src/containers/modules/extension.ts
@@ -3,6 +3,7 @@ import { ExtensionLoader } from '../../lib/extension-loader';
 import { ICoreOptions } from '../../models/coreOptions';
 import templateEngineModules from '../../lib/template-engine/built-in-extensions';
 import validatorModule from '../../lib/validators/built-in-validators';
+import LoggerModule from '../../lib/loggers';
 import {
   builtInCodeLoader,
   builtInTemplateProvider,
@@ -23,6 +24,7 @@ export const extensionModule = (options: ICoreOptions) =>
     for (const templateEngineModule of templateEngineModules) {
       loader.loadInternalExtensionModule(templateEngineModule);
     }
+    loader.loadInternalExtensionModule(LoggerModule);
     // Validator (single module)
     loader.loadInternalExtensionModule(validatorModule);
     // Template provider (single module)

--- a/packages/core/src/containers/types.ts
+++ b/packages/core/src/containers/types.ts
@@ -52,4 +52,6 @@ export const TYPES = {
   Extension_CompilerLoader: Symbol.for('Extension_CompilerLoader'),
   Extension_DataSource: Symbol.for('Extension_DataSource'),
   Extension_ProfileReader: Symbol.for('ProfileReader'),
+  // Logger
+  Extension_ActivityLogger: Symbol.for('Extension_ActivityLogger'),
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/utils';
 export * from './lib/validators';
+export * from './lib/loggers';
 export * from './lib/template-engine';
 export * from './lib/artifact-builder';
 export * from './lib/data-query';

--- a/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
@@ -4,7 +4,6 @@ import * as moment from 'moment';
 import { inject, injectable, interfaces } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
 import {
-  IActivityLogger,
   CacheLayerInfo,
   ICacheLayerOptions,
   cacheProfileName,

--- a/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
@@ -23,19 +23,15 @@ export class CacheLayerLoader implements ICacheLayerLoader {
   private options: ICacheLayerOptions;
   private cacheStorage: DataSource;
   private logger = getLogger({ scopeName: 'CORE' });
-  private activityLoggers: IActivityLogger;
   constructor(
     @inject(TYPES.CacheLayerOptions) options: CacheLayerOptions,
     @inject(TYPES.Factory_DataSource)
-    dataSourceFactory: interfaces.SimpleFactory<DataSource>,
-    @inject(TYPES.Extension_ActivityLogger)
-    activityLogger: IActivityLogger
+    dataSourceFactory: interfaces.SimpleFactory<DataSource>
   ) {
     this.dataSourceFactory = dataSourceFactory;
     this.options = options;
     // prepare cache data source
     this.cacheStorage = this.dataSourceFactory(cacheProfileName);
-    this.activityLoggers = activityLogger;
   }
 
   /**
@@ -50,7 +46,6 @@ export class CacheLayerLoader implements ICacheLayerLoader {
     const { cacheTableName, sql, profile, indexes, folderSubpath } = cache;
     const type = this.options.type!;
     const dataSource = this.dataSourceFactory(profile);
-    await this.activityLoggers.log({ a: 1 });
 
     // generate directory for cache file path to export
     // format => [folderPath]/[schema.templateSource]/[profileName]/[cacheTableName]]/[timestamp]

--- a/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
@@ -4,6 +4,7 @@ import * as moment from 'moment';
 import { inject, injectable, interfaces } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
 import {
+  IActivityLogger,
   CacheLayerInfo,
   ICacheLayerOptions,
   cacheProfileName,
@@ -22,16 +23,19 @@ export class CacheLayerLoader implements ICacheLayerLoader {
   private options: ICacheLayerOptions;
   private cacheStorage: DataSource;
   private logger = getLogger({ scopeName: 'CORE' });
-
+  private activityLoggers: IActivityLogger;
   constructor(
     @inject(TYPES.CacheLayerOptions) options: CacheLayerOptions,
     @inject(TYPES.Factory_DataSource)
-    dataSourceFactory: interfaces.SimpleFactory<DataSource>
+    dataSourceFactory: interfaces.SimpleFactory<DataSource>,
+    @inject(TYPES.Extension_ActivityLogger)
+    activityLogger: IActivityLogger
   ) {
     this.dataSourceFactory = dataSourceFactory;
     this.options = options;
     // prepare cache data source
     this.cacheStorage = this.dataSourceFactory(cacheProfileName);
+    this.activityLoggers = activityLogger;
   }
 
   /**
@@ -46,6 +50,7 @@ export class CacheLayerLoader implements ICacheLayerLoader {
     const { cacheTableName, sql, profile, indexes, folderSubpath } = cache;
     const type = this.options.type!;
     const dataSource = this.dataSourceFactory(profile);
+    await this.activityLoggers.log({ a: 1 });
 
     // generate directory for cache file path to export
     // format => [folderPath]/[schema.templateSource]/[profileName]/[cacheTableName]]/[timestamp]

--- a/packages/core/src/lib/cache-layer/cacheLayerRefresher.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerRefresher.ts
@@ -100,7 +100,6 @@ export class CacheLayerRefresher implements ICacheLayerRefresher {
   ) {
     const { urlPath } = schema;
     const { sql } = cache;
-    // if fn is not a function, return
     let refreshResult = RefreshResult.SUCCESS;
     const now = moment.utc().format('YYYY-MM-DD HH:mm:ss');
     const templateName = schema.templateSource.replace('/', '_');

--- a/packages/core/src/lib/cache-layer/cacheLayerRefresher.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerRefresher.ts
@@ -72,14 +72,14 @@ export class CacheLayerRefresher implements ICacheLayerRefresher {
               const refreshJob = new SimpleIntervalJob(
                 { milliseconds, runImmediately },
                 new AsyncTask(workerId, async () => {
-                  await this.sendActivityLogAfterLoad(schema, cache);
+                  await this.loadCacheAndSendActivityLog(schema, cache);
                 }),
                 { preventOverrun: true, id: workerId }
               );
               // add the job to schedule cache refresh task
               this.scheduler.addIntervalJob(refreshJob);
             } else {
-              await this.sendActivityLogAfterLoad(schema, cache);
+              await this.loadCacheAndSendActivityLog(schema, cache);
             }
           })
         );
@@ -94,7 +94,7 @@ export class CacheLayerRefresher implements ICacheLayerRefresher {
     this.scheduler.stop();
   }
 
-  private async sendActivityLogAfterLoad(
+  private async loadCacheAndSendActivityLog(
     schema: APISchema,
     cache: CacheLayerInfo
   ) {

--- a/packages/core/src/lib/cache-layer/cacheLayerRefresher.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerRefresher.ts
@@ -5,6 +5,8 @@ import { inject, injectable, multiInject } from 'inversify';
 import { TYPES } from '@vulcan-sql/core/types';
 import {
   APISchema,
+  ActivityLogContentOptions,
+  ActivityLogType,
   CacheLayerInfo,
   IActivityLogger,
 } from '@vulcan-sql/core/models';
@@ -111,11 +113,12 @@ export class CacheLayerRefresher implements ICacheLayerRefresher {
     } finally {
       // send activity log
       const content = {
+        isSuccess: refreshResult === RefreshResult.SUCCESS ? true : false,
+        activityLogType: ActivityLogType.CACHE_REFRESH,
         logTime: now,
         urlPath,
         sql,
-        refreshResult,
-      };
+      } as ActivityLogContentOptions;
       const activityLoggers = this.getActivityLoggers();
       for (const activityLogger of activityLoggers)
         activityLogger.log(content).catch((err: any) => {

--- a/packages/core/src/lib/loggers/httpLogger.ts
+++ b/packages/core/src/lib/loggers/httpLogger.ts
@@ -1,0 +1,41 @@
+import {
+  BaseActivityLogger,
+  ActivityLoggerType,
+} from '../../models/extensions/logger';
+import {
+  VulcanExtensionId,
+  VulcanInternalExtension,
+} from '../../models/extensions';
+import axios from 'axios';
+
+interface HttpLoggerConfig {
+  connection?: HttpLoggerConnectionConfig;
+}
+
+interface HttpLoggerConnectionConfig {
+  protocol?: string | undefined;
+  host?: string | undefined;
+  port?: number | string;
+  path?: string | undefined;
+  headers?: NodeJS.Dict<string | string[]> | undefined;
+}
+
+@VulcanInternalExtension('activity-log')
+@VulcanExtensionId(ActivityLoggerType.HTTP_LOGGER)
+export class HttpLogger extends BaseActivityLogger<HttpLoggerConfig> {
+  public async log(payload: any): Promise<void> {
+    const option = this.getOptions();
+    if (!option) {
+      throw new Error('Http logger option is not defined.');
+    }
+    // TODO-ac: should implement http logger
+    try {
+      // get connection info from option and use axios to send a post requet to the endpoint
+      const { protocol, host, port, path, headers } = option.connection!;
+      const url = `${protocol}://${host}:${port}${path}`;
+      await axios.post(url, payload, { headers: headers as any });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}

--- a/packages/core/src/lib/loggers/httpLogger.ts
+++ b/packages/core/src/lib/loggers/httpLogger.ts
@@ -7,7 +7,7 @@ import {
   VulcanInternalExtension,
 } from '../../models/extensions';
 import axios, { AxiosRequestHeaders } from 'axios';
-import { ConnectionConfig } from '../utils/url';
+import { ConnectionConfig, getUrl } from '../utils/url';
 
 export interface HttpLoggerConfig {
   connection?: HttpLoggerConnectionConfig;
@@ -29,7 +29,7 @@ export class HttpLogger extends BaseActivityLogger<HttpLoggerConfig> {
       throw new Error('Http logger connection should be provided');
     }
     const headers = option.connection.headers;
-    const url = this.getUrl(option.connection);
+    const url = getUrl(option.connection);
     try {
       // get connection info from option and use axios to send a post requet to the endpoint
       await this.sendActivityLog(url, payload, headers);
@@ -42,20 +42,13 @@ export class HttpLogger extends BaseActivityLogger<HttpLoggerConfig> {
     }
   }
 
-  protected sendActivityLog = async (
+  protected async sendActivityLog(
     url: string,
     payload: any,
     headers: AxiosRequestHeaders | undefined
-  ): Promise<void> => {
+  ): Promise<void> {
     await axios.post(url, payload, {
       headers: headers,
     });
-  };
-
-  protected getUrl = (connection: HttpLoggerConnectionConfig): string => {
-    const { ssl, host, port, path = '' } = connection;
-    const protocol = ssl ? 'https' : 'http';
-    const urlbase = `${protocol}://${host}:${port}`;
-    return new URL(path, urlbase).href;
-  };
+  }
 }

--- a/packages/core/src/lib/loggers/httpLogger.ts
+++ b/packages/core/src/lib/loggers/httpLogger.ts
@@ -33,6 +33,7 @@ export class HttpLogger extends BaseActivityLogger<HttpLoggerConfig> {
     try {
       // get connection info from option and use axios to send a post requet to the endpoint
       await this.sendActivityLog(url, payload, headers);
+      this.logger.debug(`Activity log sent`);
     } catch (err) {
       this.logger.debug(
         `Failed to send activity log to http logger, url: ${url}`
@@ -43,7 +44,7 @@ export class HttpLogger extends BaseActivityLogger<HttpLoggerConfig> {
 
   protected sendActivityLog = async (
     url: string,
-    payload: JSON,
+    payload: any,
     headers: AxiosRequestHeaders | undefined
   ): Promise<void> => {
     await axios.post(url, payload, {

--- a/packages/core/src/lib/loggers/index.ts
+++ b/packages/core/src/lib/loggers/index.ts
@@ -1,3 +1,4 @@
 import { HttpLogger } from './httpLogger';
+export * from './httpLogger';
 
 export default [HttpLogger];

--- a/packages/core/src/lib/loggers/index.ts
+++ b/packages/core/src/lib/loggers/index.ts
@@ -1,0 +1,3 @@
+import { HttpLogger } from './httpLogger';
+
+export default [HttpLogger];

--- a/packages/core/src/lib/template-engine/compiler-environment/base.ts
+++ b/packages/core/src/lib/template-engine/compiler-environment/base.ts
@@ -7,6 +7,7 @@ import * as nunjucks from 'nunjucks';
 export abstract class BaseCompilerEnvironment extends nunjucks.Environment {
   abstract getExtensions(): ExtensionBase[];
 
+  // initialize template engines extensions
   public async initializeExtensions() {
     const extensions = this.getExtensions();
     for (const extension of extensions) {

--- a/packages/core/src/lib/utils/url.ts
+++ b/packages/core/src/lib/utils/url.ts
@@ -1,0 +1,14 @@
+export interface ConnectionConfig {
+  ssl?: boolean | undefined;
+  host?: string | undefined;
+  port?: number | string;
+  path?: string | undefined;
+}
+
+export const getUrl = (connection: ConnectionConfig): string => {
+  const { ssl, host, port, path = '' } = connection;
+  const protocol = ssl ? 'https' : 'http';
+  let urlbase = `${protocol}://${host}`;
+  urlbase = port ? `${urlbase}:${port}` : urlbase;
+  return new URL(path, urlbase).href;
+};

--- a/packages/core/src/lib/utils/url.ts
+++ b/packages/core/src/lib/utils/url.ts
@@ -1,8 +1,8 @@
 export interface ConnectionConfig {
-  ssl?: boolean | undefined;
-  host?: string | undefined;
+  ssl?: boolean;
+  host?: string;
   port?: number | string;
-  path?: string | undefined;
+  path?: string;
 }
 
 export const getUrl = (connection: ConnectionConfig): string => {

--- a/packages/core/src/models/coreOptions.ts
+++ b/packages/core/src/models/coreOptions.ts
@@ -1,6 +1,7 @@
 import { IArtifactBuilderOptions } from './artifactBuilderOptions';
 import { ICacheLayerOptions } from './cacheLayerOptions';
 import { IDocumentOptions } from './documentOptions';
+import { IActivityLoggerOptions } from './loggerOptions';
 import { IProfilesLookupOptions } from './profilesLookupOptions';
 import { ITemplateEngineOptions } from './templateEngineOptions';
 
@@ -24,6 +25,7 @@ export interface ICoreOptions {
   extensions?: ExtensionAliases;
   document?: IDocumentOptions;
   profiles?: IProfilesLookupOptions;
+  'activity-log'?: IActivityLoggerOptions;
   cache?: ICacheLayerOptions;
   [moduleAlias: string]: any;
 }

--- a/packages/core/src/models/extensions/index.ts
+++ b/packages/core/src/models/extensions/index.ts
@@ -12,3 +12,4 @@ export * from './persistentStore';
 export * from './codeLoader';
 export * from './dataSource';
 export * from './profileReader';
+export * from './logger';

--- a/packages/core/src/models/extensions/logger.ts
+++ b/packages/core/src/models/extensions/logger.ts
@@ -31,7 +31,6 @@ export abstract class BaseActivityLogger<ActivityLoggerTypeOption>
     const option = this.getConfig()['options'][
       this.getExtensionId()!
     ] as ActivityLoggerTypeOption;
-    console.log('option', option);
     return option;
   }
 }

--- a/packages/core/src/models/extensions/logger.ts
+++ b/packages/core/src/models/extensions/logger.ts
@@ -1,0 +1,29 @@
+import { ExtensionBase } from './base';
+import { TYPES } from '@vulcan-sql/core/types';
+import { VulcanExtension } from './decorators';
+
+export enum ActivityLoggerType {
+  HTTP_LOGGER = 'http-logger',
+}
+
+export interface IActivityLogger {
+  log(content: any): Promise<void>;
+}
+
+@VulcanExtension(TYPES.Extension_ActivityLogger, { enforcedId: true })
+export abstract class BaseActivityLogger<ActivityLoggerTypeOption>
+  extends ExtensionBase
+  implements IActivityLogger
+{
+  public abstract log(context: any): Promise<void>;
+
+  protected getOptions(): ActivityLoggerTypeOption | undefined {
+    if (!this.getConfig()) return undefined;
+    if (!this.getConfig()['options']) return undefined;
+    const option = this.getConfig()['options'][
+      this.getExtensionId()!
+    ] as ActivityLoggerTypeOption;
+
+    return option;
+  }
+}

--- a/packages/core/src/models/extensions/logger.ts
+++ b/packages/core/src/models/extensions/logger.ts
@@ -1,6 +1,7 @@
 import { ExtensionBase } from './base';
 import { TYPES } from '@vulcan-sql/core/types';
 import { VulcanExtension } from './decorators';
+import { isEmpty } from 'lodash';
 
 export enum ActivityLoggerType {
   HTTP_LOGGER = 'http-logger',
@@ -20,8 +21,10 @@ export abstract class BaseActivityLogger<ActivityLoggerTypeOption>
 
   public isEnabled(): boolean {
     const config = this.getConfig();
-    if (!config) return false;
-    if (config.enabled === true) return true;
+    if (!config || isEmpty(config)) return false;
+    if (!config.enabled) return false;
+    if (!config['options']) return false;
+    if (config['options'][this.getExtensionId()!]) return true;
     else return false;
   }
 

--- a/packages/core/src/models/extensions/logger.ts
+++ b/packages/core/src/models/extensions/logger.ts
@@ -17,13 +17,20 @@ export abstract class BaseActivityLogger<ActivityLoggerTypeOption>
 {
   public abstract log(context: any): Promise<void>;
 
+  protected isEnabled(): boolean {
+    const config = this.getConfig();
+    if (!config) return false;
+    if (config.enabled === true) return true;
+    else return false;
+  }
+
   protected getOptions(): ActivityLoggerTypeOption | undefined {
     if (!this.getConfig()) return undefined;
     if (!this.getConfig()['options']) return undefined;
     const option = this.getConfig()['options'][
       this.getExtensionId()!
     ] as ActivityLoggerTypeOption;
-
+    console.log('option', option);
     return option;
   }
 }

--- a/packages/core/src/models/extensions/logger.ts
+++ b/packages/core/src/models/extensions/logger.ts
@@ -7,6 +7,7 @@ export enum ActivityLoggerType {
 }
 
 export interface IActivityLogger {
+  isEnabled(): boolean;
   log(content: any): Promise<void>;
 }
 
@@ -17,7 +18,7 @@ export abstract class BaseActivityLogger<ActivityLoggerTypeOption>
 {
   public abstract log(context: any): Promise<void>;
 
-  protected isEnabled(): boolean {
+  public isEnabled(): boolean {
     const config = this.getConfig();
     if (!config) return false;
     if (config.enabled === true) return true;

--- a/packages/core/src/models/extensions/logger.ts
+++ b/packages/core/src/models/extensions/logger.ts
@@ -7,6 +7,14 @@ export enum ActivityLoggerType {
   HTTP_LOGGER = 'http-logger',
 }
 
+export enum ActivityLogType {
+  CACHE_REFRESH = 'cache-refresh',
+  API_REQUEST = 'api-request',
+}
+export interface ActivityLogContentOptions {
+  isSuccess: boolean;
+  activityLogType: ActivityLogType;
+}
 export interface IActivityLogger {
   isEnabled(): boolean;
   log(content: any): Promise<void>;

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -8,3 +8,4 @@ export * from './documentOptions';
 export * from './profilesLookupOptions';
 export * from './cacheLayerOptions';
 export * from './profile';
+export * from './loggerOptions';

--- a/packages/core/src/models/loggerOptions.ts
+++ b/packages/core/src/models/loggerOptions.ts
@@ -1,0 +1,4 @@
+export interface IActivityLoggerOptions {
+  // different logger type settings
+  [loggerType: string]: any;
+}

--- a/packages/core/test/cache-layer/cacheLayerRefresher.spec.ts
+++ b/packages/core/test/cache-layer/cacheLayerRefresher.spec.ts
@@ -12,11 +12,31 @@ import {
   vulcanCacheSchemaName,
 } from '@vulcan-sql/core';
 import { MockDataSource, getQueryResults } from './mockDataSource';
+import { HttpLogger } from '../../src/lib/loggers/httpLogger';
 
 // This is a helper function that will flush all pending promises in the event loop when use the setInterval and the callback is promise (jest > 27 version).
 // reference: https://gist.github.com/apieceofbart/e6dea8d884d29cf88cdb54ef14ddbcc4
 const flushPromises = () =>
   new Promise(jest.requireActual('timers').setImmediate);
+
+jest.mock('../../src/lib/loggers/httpLogger', () => {
+  const originalModule = jest.requireActual('../../src/lib/loggers/httpLogger');
+  return {
+    ...originalModule,
+    HttpLogger: jest.fn().mockImplementation(() => {
+      return {
+        log: jest.fn().mockResolvedValue(true), // Spy on the add method
+      };
+    }),
+  };
+});
+const mockLogger = new HttpLogger(
+  {
+    enabled: true,
+    options: { 'http-logger': { connection: { host: 'localhost' } } },
+  },
+  'http-logger'
+);
 
 describe('Test cache layer refresher', () => {
   const folderPath = 'refresher-test-exported-parquets';
@@ -65,6 +85,10 @@ describe('Test cache layer refresher', () => {
     fs.rmSync(folderPath, { recursive: true, force: true });
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('Should fail to start when exist duplicate cache table name over than one API schema', async () => {
     // Arrange
     const schemas: Array<APISchema> = [
@@ -98,7 +122,7 @@ describe('Test cache layer refresher', () => {
         ] as Array<CacheLayerInfo>,
       },
     ];
-    const refresher = new CacheLayerRefresher(stubCacheLoader);
+    const refresher = new CacheLayerRefresher(stubCacheLoader, mockLogger);
 
     // Act, Assert
     await expect(() => refresher.start(schemas)).rejects.toThrow(
@@ -149,7 +173,7 @@ describe('Test cache layer refresher', () => {
         ] as Array<CacheLayerInfo>,
       },
     ];
-    const refresher = new CacheLayerRefresher(stubCacheLoader);
+    const refresher = new CacheLayerRefresher(stubCacheLoader, mockLogger);
 
     // Act, Assert
     await expect(() => refresher.start(schemas)).rejects.toThrow(
@@ -195,7 +219,7 @@ describe('Test cache layer refresher', () => {
       ];
       // Act
       const loader = new CacheLayerLoader(options, stubFactory as any);
-      const refresher = new CacheLayerRefresher(loader);
+      const refresher = new CacheLayerRefresher(loader, mockLogger);
       await refresher.start(schemas);
 
       // Assert
@@ -271,7 +295,7 @@ describe('Test cache layer refresher', () => {
 
     // Stub the load method to not do any thing.
     stubCacheLoader.load.resolves();
-    const refresher = new CacheLayerRefresher(stubCacheLoader);
+    const refresher = new CacheLayerRefresher(stubCacheLoader, mockLogger);
     // Act
     await refresher.start(schemas);
 
@@ -304,4 +328,98 @@ describe('Test cache layer refresher', () => {
     refresher.stop();
     jest.clearAllTimers();
   });
+
+  it(
+    'Should send activity log after cacheLoader execute "load" successfully',
+    async () => {
+      // Arrange
+      const schemas: Array<APISchema> = [
+        {
+          ...sinon.stubInterface<APISchema>(),
+          templateSource: 'template-1',
+          profiles: [profiles[0].name, profiles[1].name],
+          cache: [
+            {
+              cacheTableName: 'orders',
+              sql: sinon.default.stub() as any,
+              profile: profiles[0].name,
+            },
+            {
+              cacheTableName: 'products',
+              sql: sinon.default.stub() as any,
+              profile: profiles[1].name,
+            },
+          ] as Array<CacheLayerInfo>,
+        },
+        {
+          ...sinon.stubInterface<APISchema>(),
+          templateSource: 'template-2',
+          profiles: [profiles[2].name],
+          cache: [
+            {
+              cacheTableName: 'users',
+              sql: sinon.default.stub() as any,
+              profile: profiles[2].name,
+            },
+          ] as Array<CacheLayerInfo>,
+        },
+      ];
+      // Act
+      const loader = new CacheLayerLoader(options, stubFactory as any);
+      const refresher = new CacheLayerRefresher(loader, mockLogger);
+      await refresher.start(schemas);
+
+      // Assert
+      expect(mockLogger.log).toHaveBeenCalledTimes(3);
+      refresher.stop();
+    },
+    100 * 1000
+  );
+  // Should send activity log when cacheLoader failed on executing "load"
+  it(
+    'Should send activity log after cacheLoader execute "load" failed',
+    async () => {
+      const schemas: Array<APISchema> = [
+        {
+          ...sinon.stubInterface<APISchema>(),
+          templateSource: 'template-1',
+          profiles: [profiles[0].name, profiles[1].name],
+          cache: [
+            {
+              cacheTableName: 'orders',
+              sql: sinon.default.stub() as any,
+              profile: profiles[0].name,
+            },
+            {
+              cacheTableName: 'products',
+              sql: sinon.default.stub() as any,
+              profile: profiles[1].name,
+            },
+          ] as Array<CacheLayerInfo>,
+        },
+        {
+          ...sinon.stubInterface<APISchema>(),
+          templateSource: 'template-2',
+          profiles: [profiles[2].name],
+          cache: [
+            {
+              cacheTableName: 'users',
+              sql: sinon.default.stub() as any,
+              profile: profiles[2].name,
+            },
+          ] as Array<CacheLayerInfo>,
+        },
+      ];
+      // Act
+      const loader = new CacheLayerLoader(options, stubFactory as any);
+      stubCacheLoader.load.throws();
+      const refresher = new CacheLayerRefresher(loader, mockLogger);
+      await refresher.start(schemas);
+
+      // Assert
+      expect(mockLogger.log).toHaveBeenCalledTimes(3);
+      refresher.stop();
+    },
+    100 * 1000
+  );
 });

--- a/packages/core/test/cache-layer/cacheLayerRefresher.spec.ts
+++ b/packages/core/test/cache-layer/cacheLayerRefresher.spec.ts
@@ -25,6 +25,7 @@ jest.mock('../../src/lib/loggers/httpLogger', () => {
     ...originalModule,
     HttpLogger: jest.fn().mockImplementation(() => {
       return {
+        isEnabled: jest.fn().mockReturnValue(true),
         log: jest.fn().mockResolvedValue(true), // Spy on the add method
       };
     }),
@@ -122,7 +123,7 @@ describe('Test cache layer refresher', () => {
         ] as Array<CacheLayerInfo>,
       },
     ];
-    const refresher = new CacheLayerRefresher(stubCacheLoader, mockLogger);
+    const refresher = new CacheLayerRefresher(stubCacheLoader, [mockLogger]);
 
     // Act, Assert
     await expect(() => refresher.start(schemas)).rejects.toThrow(
@@ -173,7 +174,7 @@ describe('Test cache layer refresher', () => {
         ] as Array<CacheLayerInfo>,
       },
     ];
-    const refresher = new CacheLayerRefresher(stubCacheLoader, mockLogger);
+    const refresher = new CacheLayerRefresher(stubCacheLoader, [mockLogger]);
 
     // Act, Assert
     await expect(() => refresher.start(schemas)).rejects.toThrow(
@@ -219,7 +220,7 @@ describe('Test cache layer refresher', () => {
       ];
       // Act
       const loader = new CacheLayerLoader(options, stubFactory as any);
-      const refresher = new CacheLayerRefresher(loader, mockLogger);
+      const refresher = new CacheLayerRefresher(loader, [mockLogger]);
       await refresher.start(schemas);
 
       // Assert
@@ -295,7 +296,7 @@ describe('Test cache layer refresher', () => {
 
     // Stub the load method to not do any thing.
     stubCacheLoader.load.resolves();
-    const refresher = new CacheLayerRefresher(stubCacheLoader, mockLogger);
+    const refresher = new CacheLayerRefresher(stubCacheLoader, [mockLogger]);
     // Act
     await refresher.start(schemas);
 
@@ -366,7 +367,7 @@ describe('Test cache layer refresher', () => {
       ];
       // Act
       const loader = new CacheLayerLoader(options, stubFactory as any);
-      const refresher = new CacheLayerRefresher(loader, mockLogger);
+      const refresher = new CacheLayerRefresher(loader, [mockLogger]);
       await refresher.start(schemas);
 
       // Assert
@@ -413,7 +414,7 @@ describe('Test cache layer refresher', () => {
       // Act
       const loader = new CacheLayerLoader(options, stubFactory as any);
       stubCacheLoader.load.throws();
-      const refresher = new CacheLayerRefresher(loader, mockLogger);
+      const refresher = new CacheLayerRefresher(loader, [mockLogger]);
       await refresher.start(schemas);
 
       // Assert

--- a/packages/core/test/httplogger.spec.ts
+++ b/packages/core/test/httplogger.spec.ts
@@ -74,4 +74,30 @@ describe('Activity logs', () => {
     sinon.stub(httpLogger, 'sendActivityLog').throws();
     await expect(httpLogger.log({})).rejects.toThrow();
   });
+
+  // isEnabled should return false when logger is disabled
+  it.each([
+    {}, // empty config
+    {
+      enabled: false, // not enabled
+    },
+    {
+      enabled: false, // not enabled but has logger
+      options: {
+        'http-logger': { connection: { host: 'localhost', port: 80 } },
+      },
+    },
+    {
+      enabled: true, // enabled but do not have http-logger config
+      options: {
+        'non-http-logger': {},
+      },
+    },
+  ])(
+    'isEnabled should return false when logger is disabled',
+    async (config) => {
+      const httpLogger = createMockHttpLogger(config);
+      expect(httpLogger.isEnabled()).toBe(false);
+    }
+  );
 });

--- a/packages/core/test/httplogger.spec.ts
+++ b/packages/core/test/httplogger.spec.ts
@@ -1,0 +1,77 @@
+import sinon from 'ts-sinon';
+import { HttpLogger } from '../src/lib/loggers/httpLogger';
+class MockHttpLogger extends HttpLogger {
+  public override sendActivityLog = jest.fn();
+}
+const createMockHttpLogger = (config: any) => {
+  return new MockHttpLogger(config, 'httpLogger');
+};
+describe('Activity logs', () => {
+  it('should throw error when logger is enabled but connection is not provided', async () => {
+    const config = {
+      enabled: true,
+      options: {
+        'http-logger': {
+          connection: undefined,
+        },
+      },
+    };
+
+    const httpLogger = createMockHttpLogger(config);
+
+    await expect(httpLogger.log({})).rejects.toThrow(
+      'Http logger connection should be provided'
+    );
+  });
+
+  it('should not throw error when logger is disabled', async () => {
+    const config = {
+      enabled: false,
+    };
+
+    const httpLogger = createMockHttpLogger(config);
+
+    await expect(httpLogger.log({})).resolves.not.toThrow();
+  });
+
+  // should not throw error when logger is enabled and connection is provided
+  it('should not throw error when logger is enabled and connection is provided', async () => {
+    const config = {
+      enabled: true,
+      options: {
+        'http-logger': {
+          connection: {
+            ssl: true,
+            host: 'localhost',
+            port: 8080,
+            path: '/test',
+          },
+        },
+      },
+    };
+    const httpLogger = createMockHttpLogger(config);
+    sinon.stub(httpLogger, 'sendActivityLog').resolves();
+    await expect(httpLogger.log({})).resolves.not.toThrow();
+  });
+
+  // should throw error when logger is enabled and connection is provided but request fails
+  it('should throw error when logger is enabled and connection is provided but request fails', async () => {
+    const config = {
+      enabled: true,
+      options: {
+        'http-logger': {
+          connection: {
+            ssl: true,
+            host: 'localhost',
+            port: 8080,
+            path: '/test',
+          },
+        },
+      },
+    };
+    // stub sendActivityLog to throw error
+    const httpLogger = createMockHttpLogger(config);
+    sinon.stub(httpLogger, 'sendActivityLog').throws();
+    await expect(httpLogger.log({})).rejects.toThrow();
+  });
+});

--- a/packages/core/test/utils/url.spec.ts
+++ b/packages/core/test/utils/url.spec.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getUrl, ConnectionConfig } from '../../src/lib/utils/url';
 
 describe('url util functions', () => {

--- a/packages/core/test/utils/url.spec.ts
+++ b/packages/core/test/utils/url.spec.ts
@@ -1,0 +1,67 @@
+import { get } from 'lodash';
+import { getUrl, ConnectionConfig } from '../../src/lib/utils/url';
+
+describe('url util functions', () => {
+  it('should return url if all connection properties were set', () => {
+    const connection = {
+      ssl: true,
+      host: 'localhost',
+      port: 8080,
+      path: '/test',
+    } as ConnectionConfig;
+
+    const url = getUrl(connection);
+    expect(url).toBe('https://localhost:8080/test');
+  });
+
+  it('should return url if ssl or path is not set', () => {
+    const connection = {
+      host: 'localhost',
+    } as ConnectionConfig;
+
+    const url = getUrl(connection);
+    expect(url).toBe('http://localhost/');
+  });
+
+  it('should return url if host was an IP address', () => {
+    const connection = {
+      ssl: false,
+      host: '127.0.0.1',
+      port: 8080,
+      path: '/test',
+    } as ConnectionConfig;
+    const url = getUrl(connection);
+    expect(url).toBe('http://127.0.0.1:8080/test');
+  });
+
+  it.each([
+    {
+      ssl: false,
+      host: 'localhost',
+      port: 8080,
+      path: '/test',
+    },
+    {
+      host: 'localhost',
+      port: 8080,
+      path: '/test',
+    },
+  ])(
+    'should use protocal http if ssl was not set or set to false',
+    (connection) => {
+      const url = getUrl(connection);
+      expect(url).toBe('http://localhost:8080/test');
+    }
+  );
+
+  it('should return url if host was a DNS name and port was not set', () => {
+    const connection = {
+      ssl: true,
+      host: 'DNSName',
+      path: '/test',
+    } as ConnectionConfig;
+
+    const url = getUrl(connection);
+    expect(url).toBe('https://dnsname/test');
+  });
+});

--- a/packages/extension-authenticator-canner/src/lib/authenticator/pat.ts
+++ b/packages/extension-authenticator-canner/src/lib/authenticator/pat.ts
@@ -76,7 +76,7 @@ export class CannerPATAuthenticator extends BaseAuthenticator<CannerPATOptions> 
           operationName: 'UserMe',
           variables: {},
           query:
-            'query UserMe{userMe {accountRole attributes createdAt email groups {id name} lastName firstName username}}',
+            'query UserMe{userMe {id accountRole attributes createdAt email groups {id name} lastName firstName username}}',
         },
         {
           headers: {

--- a/packages/serve/src/lib/middleware/activityLogMiddleware.ts
+++ b/packages/serve/src/lib/middleware/activityLogMiddleware.ts
@@ -52,6 +52,7 @@ export class ActivityLogMiddleware extends BuiltInMiddleware<IActivityLoggerOpti
       duration,
       method: context.request.method,
       url: context.request.originalUrl,
+      href: context.request.href,
       ip: context.request.ip,
       header: context.request.header,
       params: context.params,

--- a/packages/serve/src/lib/middleware/activityLogMiddleware.ts
+++ b/packages/serve/src/lib/middleware/activityLogMiddleware.ts
@@ -1,0 +1,64 @@
+import {
+  TYPES as CORE_TYPES,
+  BaseActivityLogger,
+  VulcanInternalExtension,
+  IActivityLoggerOptions,
+  getLogger,
+} from '@vulcan-sql/core';
+import { Next, KoaContext, BuiltInMiddleware } from '@vulcan-sql/serve/models';
+import { inject, multiInject } from 'inversify';
+import moment = require('moment');
+
+const logger = getLogger({ scopeName: 'SERVE' });
+
+@VulcanInternalExtension('activity-log')
+export class ActivityLogMiddleware extends BuiltInMiddleware<IActivityLoggerOptions> {
+  private activityLoggers: BaseActivityLogger<any>[];
+  private activityLoggerMap: Record<string, BaseActivityLogger<any>> = {};
+  constructor(
+    @inject(CORE_TYPES.ExtensionConfig) config: any,
+    @inject(CORE_TYPES.ExtensionName) name: string,
+    @multiInject(CORE_TYPES.Extension_ActivityLogger)
+    activityLoggers: BaseActivityLogger<any>[]
+  ) {
+    super(config, name);
+    this.activityLoggers = activityLoggers;
+  }
+  public override async onActivate(): Promise<void> {
+    for (const logger of this.activityLoggers) {
+      if (logger.isEnabled()) {
+        const id = logger.getExtensionId();
+        this.activityLoggerMap[id!] = logger;
+      }
+    }
+  }
+  public async handle(context: KoaContext, next: Next) {
+    if (!this.enabled) return next();
+    const logTime = moment.utc().format('YYYY-MM-DD HH:mm:ss');
+    const startTime = Date.now();
+    await next();
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+    const body = context.response.body as any;
+    const error = body?.message;
+    const user = context.state.user;
+    for (const activityLogger of Object.values(this.activityLoggerMap)) {
+      const activityLog = {
+        logTime,
+        duration,
+        method: context.request.method,
+        url: context.request.originalUrl,
+        ip: context.request.ip,
+        header: context.request.header,
+        params: context.params,
+        query: context.request.query,
+        status: context.response.status,
+        error,
+        user,
+      };
+      activityLogger.log(activityLog).catch((e) => {
+        logger.debug(`Error when logging activity: ${e}`);
+      });
+    }
+  }
+}

--- a/packages/serve/src/lib/middleware/activityLogMiddleware.ts
+++ b/packages/serve/src/lib/middleware/activityLogMiddleware.ts
@@ -42,20 +42,20 @@ export class ActivityLogMiddleware extends BuiltInMiddleware<IActivityLoggerOpti
     const body = context.response.body as any;
     const error = body?.message;
     const user = context.state.user;
+    const activityLog = {
+      logTime,
+      duration,
+      method: context.request.method,
+      url: context.request.originalUrl,
+      ip: context.request.ip,
+      header: context.request.header,
+      params: context.params,
+      query: context.request.query,
+      status: context.response.status || context.status,
+      error,
+      user,
+    };
     for (const activityLogger of Object.values(this.activityLoggerMap)) {
-      const activityLog = {
-        logTime,
-        duration,
-        method: context.request.method,
-        url: context.request.originalUrl,
-        ip: context.request.ip,
-        header: context.request.header,
-        params: context.params,
-        query: context.request.query,
-        status: context.response.status,
-        error,
-        user,
-      };
       activityLogger.log(activityLog).catch((e) => {
         logger.debug(`Error when logging activity: ${e}`);
       });

--- a/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
@@ -66,7 +66,7 @@ export class AuthCredentialsMiddleware extends BaseAuthMiddleware {
       if (result.status === AuthStatus.INDETERMINATE) continue;
       // if state is failed, return directly
       if (result.status === AuthStatus.FAIL) {
-        context.response.status = 401;
+        context.status = 401;
         context.body = {
           type: result.type,
           message: result.message || 'verify token failed',

--- a/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authCredentialsMiddleware.ts
@@ -66,7 +66,7 @@ export class AuthCredentialsMiddleware extends BaseAuthMiddleware {
       if (result.status === AuthStatus.INDETERMINATE) continue;
       // if state is failed, return directly
       if (result.status === AuthStatus.FAIL) {
-        context.status = 401;
+        context.response.status = 401;
         context.body = {
           type: result.type,
           message: result.message || 'verify token failed',

--- a/packages/serve/src/lib/middleware/auth/authRouterMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authRouterMiddleware.ts
@@ -40,7 +40,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
   private mountTokenEndpoint() {
     this.router.post(`/auth/token`, async (context: KoaContext) => {
       if (isEmpty(context.request.body)) {
-        context.response.status = 400;
+        context.status = 400;
         context.body = { message: 'Please provide request parameters.' };
         return;
       }
@@ -50,7 +50,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
         const msg = `Please provide auth "type", supported types: ${Object.keys(
           this.options
         )}.`;
-        context.response.status = 400;
+        context.status = 400;
         context.body = { message: msg };
         return;
       }
@@ -59,7 +59,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
         const msg = `auth type "${type}" does not support, only supported: ${Object.keys(
           this.options
         )}.`;
-        context.response.status = 400;
+        context.status = 400;
         context.body = { message: msg };
         return;
       }
@@ -69,7 +69,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
         context.body = result;
         return;
       } catch (err) {
-        context.response.status = 400;
+        context.status = 400;
         context.body = {
           message: (err as Error).message,
         };
@@ -81,7 +81,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
     // The route should work after the token authenticated
     this.router.get(`/auth/user-profile`, async (context: KoaContext) => {
       if (!context.state.user) {
-        context.response.status = 404;
+        context.status = 404;
         context.body = {
           message: 'User profile not found.',
         };

--- a/packages/serve/src/lib/middleware/auth/authRouterMiddleware.ts
+++ b/packages/serve/src/lib/middleware/auth/authRouterMiddleware.ts
@@ -40,7 +40,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
   private mountTokenEndpoint() {
     this.router.post(`/auth/token`, async (context: KoaContext) => {
       if (isEmpty(context.request.body)) {
-        context.status = 400;
+        context.response.status = 400;
         context.body = { message: 'Please provide request parameters.' };
         return;
       }
@@ -50,7 +50,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
         const msg = `Please provide auth "type", supported types: ${Object.keys(
           this.options
         )}.`;
-        context.status = 400;
+        context.response.status = 400;
         context.body = { message: msg };
         return;
       }
@@ -59,7 +59,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
         const msg = `auth type "${type}" does not support, only supported: ${Object.keys(
           this.options
         )}.`;
-        context.status = 400;
+        context.response.status = 400;
         context.body = { message: msg };
         return;
       }
@@ -69,7 +69,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
         context.body = result;
         return;
       } catch (err) {
-        context.status = 400;
+        context.response.status = 400;
         context.body = {
           message: (err as Error).message,
         };
@@ -81,7 +81,7 @@ export class AuthRouterMiddleware extends BaseAuthMiddleware {
     // The route should work after the token authenticated
     this.router.get(`/auth/user-profile`, async (context: KoaContext) => {
       if (!context.state.user) {
-        context.status = 404;
+        context.response.status = 404;
         context.body = {
           message: 'User profile not found.',
         };

--- a/packages/serve/src/lib/middleware/index.ts
+++ b/packages/serve/src/lib/middleware/index.ts
@@ -23,10 +23,12 @@ import { ClassType, ExtensionBase } from '@vulcan-sql/core';
 import { DocRouterMiddleware } from './docRouterMiddleware';
 import { ErrorHandlerMiddleware } from './errorHandlerMIddleware';
 import { CatalogRouterMiddleware } from './catalogRouterMiddleware';
+import { ActivityLogMiddleware } from './activityLogMiddleware';
 
 // The array is the middleware running order
 export const BuiltInRouteMiddlewares: ClassType<ExtensionBase>[] = [
   RequestIdMiddleware,
+  ActivityLogMiddleware,
   ErrorHandlerMiddleware,
   AccessLogMiddleware,
   CorsMiddleware,

--- a/packages/serve/src/lib/middleware/index.ts
+++ b/packages/serve/src/lib/middleware/index.ts
@@ -7,6 +7,7 @@ export * from './response-format';
 export * from './enforceHttpsMiddleware';
 export * from './docRouterMiddleware';
 export * from './errorHandlerMIddleware';
+export * from './activityLogMiddleware';
 
 import { CorsMiddleware } from './corsMiddleware';
 import {

--- a/packages/serve/test/middlewares/built-in-middlewares/activityLogMiddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/activityLogMiddleware.spec.ts
@@ -80,6 +80,7 @@ describe('Test activity log middlewares', () => {
       activityLogType: ActivityLogType.API_REQUEST,
       method: ctx.request.method,
       url: ctx.request.originalUrl,
+      href: ctx.request.href,
       status: ctx.response.status,
       headers: ctx.request.headers,
       error: undefined,
@@ -101,6 +102,7 @@ describe('Test activity log middlewares', () => {
     expect(actual[0].activityLogType).toEqual(expected.activityLogType);
     expect(actual[0].method).toEqual(expected.method);
     expect(actual[0].url).toEqual(expected.url);
+    expect(actual[0].href).toEqual(expected.href);
     expect(actual[0].status).toEqual(expected.status);
     expect(actual[0].headers).toEqual(expected.headers);
     expect(actual[0].ip).toEqual(expected.ip);
@@ -154,6 +156,7 @@ describe('Test activity log middlewares', () => {
       activityLogType: ActivityLogType.API_REQUEST,
       method: ctx.request.method,
       url: ctx.request.originalUrl,
+      href: ctx.request.href,
       status: ctx.response.status,
       headers: ctx.request.headers,
       error: body.message,
@@ -175,6 +178,7 @@ describe('Test activity log middlewares', () => {
     expect(actual[0].activityLogType).toEqual(expected.activityLogType);
     expect(actual[0].method).toEqual(expected.method);
     expect(actual[0].url).toEqual(expected.url);
+    expect(actual[0].href).toEqual(expected.href);
     expect(actual[0].status).toEqual(expected.status);
     expect(actual[0].headers).toEqual(expected.headers);
     expect(actual[0].ip).toEqual(expected.ip);

--- a/packages/serve/test/middlewares/built-in-middlewares/activityLogMiddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/activityLogMiddleware.spec.ts
@@ -1,0 +1,177 @@
+import faker from '@faker-js/faker';
+import * as sinon from 'ts-sinon';
+import { Request, Response } from 'koa';
+import { IncomingHttpHeaders } from 'http';
+import { ParsedUrlQuery } from 'querystring';
+import { KoaContext } from '@vulcan-sql/serve/models';
+
+import { HttpLogger } from '../../../../core/src/lib/loggers/httpLogger';
+import { ActivityLogMiddleware } from '@vulcan-sql/serve/middleware/activityLogMiddleware';
+
+jest.mock('../../../../core/src/lib/loggers/httpLogger', () => {
+  const originalModule = jest.requireActual(
+    '../../../../core/src/lib/loggers/httpLogger'
+  );
+  return {
+    ...originalModule,
+    HttpLogger: jest.fn().mockImplementation(() => {
+      return {
+        getExtensionId: jest.fn().mockReturnValue('http-logger'),
+        isEnabled: jest.fn().mockReturnValue(true),
+        log: jest.fn().mockResolvedValue(true), // Spy on the add method
+      };
+    }),
+  };
+});
+const extensionConfig = {
+  enabled: true,
+  options: { 'http-logger': { connection: { host: 'localhost' } } },
+};
+const mockLogger = new HttpLogger(extensionConfig, 'http-logger');
+
+describe('Test activity log middlewares', () => {
+  afterEach(() => {
+    sinon.default.restore();
+    jest.clearAllMocks();
+  });
+  it('Should log with correct info when response is status 200', async () => {
+    // Arrange
+    const ctx: KoaContext = {
+      ...sinon.stubInterface<KoaContext>(),
+
+      params: {
+        uuid: faker.datatype.uuid(),
+      },
+      state: {
+        user: {
+          name: faker.name.firstName(),
+          attr: {
+            email: faker.internet.email(),
+            id: faker.datatype.uuid(),
+          },
+        },
+      },
+      request: {
+        ...sinon.stubInterface<Request>(),
+        ip: faker.internet.ip(),
+        method: faker.internet.httpMethod(),
+        originalUrl: faker.internet.url(),
+        header: {
+          ...sinon.stubInterface<IncomingHttpHeaders>(),
+          'X-Agent': 'test-normal-client',
+        },
+        query: {
+          ...sinon.stubInterface<ParsedUrlQuery>(),
+          sortby: 'name',
+        },
+      },
+      response: {
+        ...sinon.stubInterface<Response>(),
+        status: 200,
+        length: faker.datatype.number({ min: 100, max: 100000 }),
+        body: {
+          result: 'OK',
+        },
+      },
+    };
+
+    const expected = {
+      method: ctx.request.method,
+      url: ctx.request.originalUrl,
+      status: ctx.response.status,
+      headers: ctx.request.headers,
+      error: undefined,
+      ip: ctx.request.ip,
+      params: ctx.params,
+      user: ctx.state.user,
+    };
+    // Act
+    const middleware = new ActivityLogMiddleware(extensionConfig, '', [
+      mockLogger,
+    ]);
+    await middleware.activate();
+    await middleware.handle(ctx, async () => Promise.resolve());
+
+    // Assert
+    const logMock = mockLogger.log as jest.Mock;
+    const actual = logMock.mock.calls[0];
+    expect(actual[0].method).toEqual(expected.method);
+    expect(actual[0].url).toEqual(expected.url);
+    expect(actual[0].status).toEqual(expected.status);
+    expect(actual[0].headers).toEqual(expected.headers);
+    expect(actual[0].ip).toEqual(expected.ip);
+    expect(actual[0].params).toEqual(expected.params);
+    expect(actual[0].error).toEqual(expected.error);
+    expect(actual[0].user).toEqual(expected.user);
+  });
+  it('Should log with correct info when response is not status 200', async () => {
+    // Arrange
+    const ctx: KoaContext = {
+      ...sinon.stubInterface<KoaContext>(),
+
+      params: {
+        uuid: faker.datatype.uuid(),
+      },
+      state: {
+        user: {
+          name: faker.name.firstName(),
+          attr: {
+            email: faker.internet.email(),
+            id: faker.datatype.uuid(),
+          },
+        },
+      },
+      request: {
+        ...sinon.stubInterface<Request>(),
+        ip: faker.internet.ip(),
+        method: faker.internet.httpMethod(),
+        originalUrl: faker.internet.url(),
+        header: {
+          ...sinon.stubInterface<IncomingHttpHeaders>(),
+          'X-Agent': 'test-normal-client',
+        },
+        query: {
+          ...sinon.stubInterface<ParsedUrlQuery>(),
+          sortby: 'name',
+        },
+      },
+      response: {
+        ...sinon.stubInterface<Response>(),
+        status: 401,
+        body: {
+          message: 'Unauthorized',
+          result: 'OK',
+        },
+      },
+    };
+    const body = ctx.response.body as any;
+    const expected = {
+      method: ctx.request.method,
+      url: ctx.request.originalUrl,
+      status: ctx.response.status,
+      headers: ctx.request.headers,
+      error: body.message,
+      ip: ctx.request.ip,
+      params: ctx.params,
+      user: ctx.state.user,
+    };
+    // Act
+    const middleware = new ActivityLogMiddleware(extensionConfig, '', [
+      mockLogger,
+    ]);
+    await middleware.activate();
+    await middleware.handle(ctx, async () => Promise.resolve());
+
+    // Assert
+    const logMock = mockLogger.log as jest.Mock;
+    const actual = logMock.mock.calls[0];
+    expect(actual[0].method).toEqual(expected.method);
+    expect(actual[0].url).toEqual(expected.url);
+    expect(actual[0].status).toEqual(expected.status);
+    expect(actual[0].headers).toEqual(expected.headers);
+    expect(actual[0].ip).toEqual(expected.ip);
+    expect(actual[0].params).toEqual(expected.params);
+    expect(actual[0].error).toEqual(expected.error);
+    expect(actual[0].user).toEqual(expected.user);
+  });
+});

--- a/packages/serve/test/middlewares/built-in-middlewares/activityLogMiddleware.spec.ts
+++ b/packages/serve/test/middlewares/built-in-middlewares/activityLogMiddleware.spec.ts
@@ -5,7 +5,7 @@ import { IncomingHttpHeaders } from 'http';
 import { ParsedUrlQuery } from 'querystring';
 import { KoaContext } from '@vulcan-sql/serve/models';
 
-import { HttpLogger } from '@vulcan-sql/core';
+import { ActivityLogType, HttpLogger } from '@vulcan-sql/core';
 import { ActivityLogMiddleware } from '@vulcan-sql/serve/middleware/activityLogMiddleware';
 
 jest.mock('../../../../core/src/lib/loggers/httpLogger', () => {
@@ -76,6 +76,8 @@ describe('Test activity log middlewares', () => {
     };
 
     const expected = {
+      isSuccess: true,
+      activityLogType: ActivityLogType.API_REQUEST,
       method: ctx.request.method,
       url: ctx.request.originalUrl,
       status: ctx.response.status,
@@ -95,6 +97,8 @@ describe('Test activity log middlewares', () => {
     // Assert
     const logMock = mockLogger.log as jest.Mock;
     const actual = logMock.mock.calls[0];
+    expect(actual[0].isSuccess).toEqual(expected.isSuccess);
+    expect(actual[0].activityLogType).toEqual(expected.activityLogType);
     expect(actual[0].method).toEqual(expected.method);
     expect(actual[0].url).toEqual(expected.url);
     expect(actual[0].status).toEqual(expected.status);
@@ -146,6 +150,8 @@ describe('Test activity log middlewares', () => {
     };
     const body = ctx.response.body as any;
     const expected = {
+      isSucess: false,
+      activityLogType: ActivityLogType.API_REQUEST,
       method: ctx.request.method,
       url: ctx.request.originalUrl,
       status: ctx.response.status,
@@ -165,6 +171,8 @@ describe('Test activity log middlewares', () => {
     // Assert
     const logMock = mockLogger.log as jest.Mock;
     const actual = logMock.mock.calls[0];
+    expect(actual[0].isSuccess).toEqual(expected.isSucess);
+    expect(actual[0].activityLogType).toEqual(expected.activityLogType);
     expect(actual[0].method).toEqual(expected.method);
     expect(actual[0].url).toEqual(expected.url);
     expect(actual[0].status).toEqual(expected.status);


### PR DESCRIPTION
## Description

Add a activity log extension to send activity log like incoming request information and cache refreshing result.
Activity logs aim to provide a more specific and accurate information compared to the access log or debug logger stdout. 

## How to use
```
# vulcan.yaml
activity-log:
    enabled: true
    options:
        http-logger:
            connection:
                ssl: boolean. # use https or not
                host: string
                port: integer
                path: "url path"
```
After you set your project config, vulcan server will send activity log to remote server asynchronously when cache refreshing job is done and after processed an API request.

A cache refreshing activity log will contain info
```
logTime(timestamp in UTC) -- the time that refresh job started
urlPath -- indicate which API it belong
sql -- the sql statement that will be executed 
refreshResult -- Enum(success, failed), the result of refresh job
```

In an API request activity log will contain info
```
logTime(timestamp in UTC) -- the timestamp that server received the request
duration(ms) -- the approximate time that server handled the API request
method -- the request method
url -- the request url
ip -- the original IP
header -- the request headers
params -- the request params
query -- the request query parameters
status -- the response HTTP status
error -- the error message that VulcanSQL provided
user -- the attribute that the client user have (gain after authenticate)
```  

## Test
unit tests
Labs:
manually create a koa server on localhost with a router  "(POST)/test"
vulcan.yaml:
```
...
activity-log:
  enabled: true
  options:
    http-logger:  
      connection:
        host: localhost
        port: 8080
        path: test
```
 - Activity log should be send after refresh job done

![image](https://github.com/Canner/vulcan-sql/assets/38731840/d3cc546d-45d2-4dd0-8807-a3e98e23df37)

<img width="1376" alt="image" src="https://github.com/Canner/vulcan-sql/assets/38731840/ee909396-2a04-4375-97e8-a65a5c23b1cc">

 - Activity log should be send after processed API request
![image](https://github.com/Canner/vulcan-sql/assets/38731840/53ecd537-f1a5-41b9-992b-ac8eec211f48)

 
