### PR TITLE
Feature: extends CacheLayerInfo interface and Profile interface

### DIFF
--- a/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
+++ b/packages/core/src/lib/cache-layer/cacheLayerLoader.ts
@@ -43,7 +43,14 @@ export class CacheLayerLoader implements ICacheLayerLoader {
     templateName: string,
     cache: CacheLayerInfo
   ): Promise<void> {
-    const { cacheTableName, sql, profile, indexes, folderSubpath } = cache;
+    const {
+      cacheTableName,
+      sql,
+      profile,
+      indexes,
+      folderSubpath,
+      options: cacheOptions,
+    } = cache;
     const type = this.options.type!;
     const dataSource = this.dataSourceFactory(profile);
 
@@ -82,6 +89,7 @@ export class CacheLayerLoader implements ICacheLayerLoader {
         directory,
         profileName: profile,
         type,
+        options: cacheOptions,
       });
     } else {
       this.logger.debug(

--- a/packages/core/src/models/artifact.ts
+++ b/packages/core/src/models/artifact.ts
@@ -118,6 +118,8 @@ export class CacheLayerInfo {
   indexes?: Record<string, string>;
   // cache folder subpath
   folderSubpath?: string;
+  // options pass to the data source
+  options?: any;
 }
 
 export class APISchema {

--- a/packages/core/src/models/extensions/dataSource.ts
+++ b/packages/core/src/models/extensions/dataSource.ts
@@ -19,6 +19,8 @@ export interface ExportOptions {
   directory: string;
   // The profile name to select to export data
   profileName: string;
+  // data source options
+  options?: any;
   // export file format type
   type: CacheLayerStoreFormatType | string;
 }

--- a/packages/core/src/models/profile.ts
+++ b/packages/core/src/models/profile.ts
@@ -29,4 +29,14 @@ export interface Profile<C = Record<string, any>> {
   cache?: C;
   /** What users have access to this profile */
   allow: ProfileAllowConstraints;
+  /** Properties that can be used when involking the dataSource method */
+  properties?: Record<string, any>;
 }
+
+// profile : by connection/pool/client setting 的變動
+// vulcan.yaml: by project 設定
+// api.yaml: by api/cache 執行設定
+
+// => use additional information when refreshing cache
+// => the userId changed by each api
+// => the root_user_id changed by project

--- a/packages/core/src/models/profile.ts
+++ b/packages/core/src/models/profile.ts
@@ -32,11 +32,3 @@ export interface Profile<C = Record<string, any>> {
   /** Properties that can be used when involking the dataSource method */
   properties?: Record<string, any>;
 }
-
-// profile : by connection/pool/client setting 的變動
-// vulcan.yaml: by project 設定
-// api.yaml: by api/cache 執行設定
-
-// => use additional information when refreshing cache
-// => the userId changed by each api
-// => the root_user_id changed by project

--- a/packages/extension-driver-canner/src/lib/cannerAdapter.ts
+++ b/packages/extension-driver-canner/src/lib/cannerAdapter.ts
@@ -36,14 +36,18 @@ export class CannerAdapter {
     headers?: Record<string, string>
   ): Promise<string[]> {
     this.logger.debug(`Create async request to Canner.`);
-    let data = await this.getWorkspaceRequestData('post', '/v2/async-queries', {
-      data: {
-        sql,
-        timeout: 600,
-        noLimit: true,
+    let data = await this.getWorkspaceRequestData(
+      'post',
+      '/v2/async-queries',
+      {
+        data: {
+          sql,
+          timeout: 600,
+          noLimit: true,
+        },
       },
-      headers,
-    });
+      headers
+    );
 
     const { id: requestId } = data;
     this.logger.debug(`Wait Async request to finished.`);
@@ -70,10 +74,7 @@ export class CannerAdapter {
     await this.prepare();
     try {
       const response = await axios({
-        headers: {
-          ...headers,
-          Authorization: `Token ${this.PAT}`,
-        },
+        headers: { ...headers, Authorization: `Token ${this.PAT}` },
         params: {
           workspaceSqlName: this.workspaceSqlName,
         },
@@ -84,7 +85,9 @@ export class CannerAdapter {
       return response.data;
     } catch (error: any) {
       const message = error.response
-        ? `response status: ${error.response.status}, response data: ${error.response.data}`
+        ? `response status: ${
+            error.response.status
+          }, response data: ${JSON.stringify(error.response.data)}`
         : `remote server does not response. request ${error.toJSON()}}`;
       throw new InternalError(
         `Failed to get workspace request "${urlPath}" data, ${message}`

--- a/packages/extension-driver-canner/src/lib/cannerAdapter.ts
+++ b/packages/extension-driver-canner/src/lib/cannerAdapter.ts
@@ -31,7 +31,10 @@ export class CannerAdapter {
   // When querying Canner enterprise, the Canner enterprise will save the query result as parquet files,
   // and store them in S3. This method will return the S3 urls of the query result.
   // For more Canner API ref: https://docs.cannerdata.com/reference/restful
-  public async createAsyncQueryResultUrls(sql: string): Promise<string[]> {
+  public async createAsyncQueryResultUrls(
+    sql: string,
+    headers?: Record<string, string>
+  ): Promise<string[]> {
     this.logger.debug(`Create async request to Canner.`);
     let data = await this.getWorkspaceRequestData('post', '/v2/async-queries', {
       data: {
@@ -39,6 +42,7 @@ export class CannerAdapter {
         timeout: 600,
         noLimit: true,
       },
+      headers,
     });
 
     const { id: requestId } = data;
@@ -60,12 +64,14 @@ export class CannerAdapter {
   private async getWorkspaceRequestData(
     method: string,
     urlPath: string,
-    options?: Record<string, any>
+    options?: Record<string, any>,
+    headers?: Record<string, string>
   ) {
     await this.prepare();
     try {
       const response = await axios({
         headers: {
+          ...headers,
           Authorization: `Token ${this.PAT}`,
         },
         params: {

--- a/packages/extension-driver-canner/src/lib/cannerDataSource.ts
+++ b/packages/extension-driver-canner/src/lib/cannerDataSource.ts
@@ -62,7 +62,7 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     sql,
     directory,
     profileName,
-    options: cannerpOtions,
+    options: cannerOptions,
   }: ExportOptions): Promise<void> {
     if (!this.poolMapping.has(profileName)) {
       throw new InternalError(`Profile instance ${profileName} not found`);
@@ -76,7 +76,7 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     const cannerAdapter = new CannerAdapter(connection);
     try {
       this.logger.debug('Send the async query to the Canner Enterprise');
-      const header = this.getCannerRequestHeader(properties, cannerpOtions);
+      const header = this.getCannerRequestHeader(properties, cannerOptions);
       const presignedUrls = await cannerAdapter.createAsyncQueryResultUrls(
         sql,
         header
@@ -96,7 +96,7 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     cannerOptions?: any
   ) {
     const header: Record<string, string> = {};
-    const { userId } = cannerOptions;
+    const userId = cannerOptions?.userId;
     const rootUserId = properties?.['rootUserId'];
     if (userId && rootUserId) {
       header[

--- a/packages/extension-driver-canner/src/lib/cannerDataSource.ts
+++ b/packages/extension-driver-canner/src/lib/cannerDataSource.ts
@@ -26,7 +26,7 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
   private logger = this.getLogger();
   protected poolMapping = new Map<
     string,
-    { pool: Pool; options?: PGOptions }
+    { pool: Pool; options?: PGOptions; properties?: Record<string, any> }
   >();
   protected UserPool = new Map<string, Pool>();
 
@@ -52,6 +52,7 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
       this.poolMapping.set(profile.name, {
         pool,
         options: profile.connection,
+        properties: profile.properties,
       });
       this.logger.debug(`Profile ${profile.name} initialized`);
     }
@@ -61,6 +62,7 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     sql,
     directory,
     profileName,
+    options: cannerpOtions,
   }: ExportOptions): Promise<void> {
     if (!this.poolMapping.has(profileName)) {
       throw new InternalError(`Profile instance ${profileName} not found`);
@@ -69,12 +71,16 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
     if (!fs.existsSync(directory)) {
       throw new InternalError(`Directory ${directory} not found`);
     }
-    const { options: connection } = this.poolMapping.get(profileName)!;
-
+    const { options: connection, properties } =
+      this.poolMapping.get(profileName)!;
     const cannerAdapter = new CannerAdapter(connection);
     try {
       this.logger.debug('Send the async query to the Canner Enterprise');
-      const presignedUrls = await cannerAdapter.createAsyncQueryResultUrls(sql);
+      const header = this.getCannerRequestHeader(properties, cannerpOtions);
+      const presignedUrls = await cannerAdapter.createAsyncQueryResultUrls(
+        sql,
+        header
+      );
       this.logger.debug(
         'Start fetching the query result parquet files from URLs'
       );
@@ -84,6 +90,21 @@ export class CannerDataSource extends DataSource<any, PGOptions> {
       this.logger.debug('Failed to export data from canner', error);
       throw error;
     }
+  }
+  private getCannerRequestHeader(
+    properties?: Record<string, any>,
+    cannerOptions?: any
+  ) {
+    const header: Record<string, string> = {};
+    const { userId } = cannerOptions;
+    const rootUserId = properties?.['rootUserId'];
+    if (userId && rootUserId) {
+      header[
+        'x-trino-session'
+      ] = `root_user_id=${rootUserId}, canner_user_id=${userId}`;
+      this.logger.debug(`Impersonate used: ${userId}`);
+    }
+    return header;
   }
 
   private async downloadFiles(urls: string[], directory: string) {

--- a/packages/extension-driver-canner/test/cannerDataSource.spec.ts
+++ b/packages/extension-driver-canner/test/cannerDataSource.spec.ts
@@ -55,6 +55,7 @@ it('Data source should export successfully', async () => {
       sql: 'select 1',
       directory,
       profileName: 'profile1',
+      options: {},
     } as ExportOptions)
   ).resolves.not.toThrow();
   expect(fs.readdirSync(directory).length).toBe(1);
@@ -86,6 +87,7 @@ it('Data source should throw error when fail to export data', async () => {
       sql: 'select 1',
       directory,
       profileName: 'profile1',
+      options: {},
     } as ExportOptions)
   ).rejects.toThrow();
   expect(fs.readdirSync(directory).length).toBe(0);
@@ -105,6 +107,7 @@ it('Data source should throw error when given directory is not exist', async () 
       sql: 'select 1',
       directory: directory,
       profileName: 'profile1',
+      options: {},
     } as ExportOptions)
   ).rejects.toThrow();
 }, 100000);
@@ -121,6 +124,7 @@ it('Data source should throw error when given profile name is not exist', async 
       sql: 'select 1',
       directory,
       profileName: 'profile not exist',
+      options: {},
     } as ExportOptions)
   ).rejects.toThrow();
 }, 100000);

--- a/packages/extension-driver-canner/test/cannerServer.ts
+++ b/packages/extension-driver-canner/test/cannerServer.ts
@@ -20,6 +20,7 @@ export class CannerServer {
         database: process.env['CANNER_WORKSPACE_SQL_NAME'],
       } as PGOptions,
       allow: '*',
+      properties: {},
     };
   }
 }

--- a/packages/extension-store-canner/README.md
+++ b/packages/extension-store-canner/README.md
@@ -63,6 +63,8 @@ export PROFILE_CANNER_DRIVER_PASSWORD=<password>
 export PROFILE_CANNER_DRIVER_HOST=<host>
 # Canner enterprise driver port, the default is 7432
 export PROFILE_CANNER_DRIVER_PORT=<port>
+# Canner enterprise root user id
+export PROFILE_CANNER_DRIVER_ROOT_USER_ID=<userId>
 ```
 
 ### Connect Canner Enterprise used storage.

--- a/packages/extension-store-canner/src/lib/canner/profileReader.ts
+++ b/packages/extension-store-canner/src/lib/canner/profileReader.ts
@@ -44,6 +44,7 @@ export class CannerProfileReader extends ProfileReader {
 
     // generate profiles from the indicator files of each workspaces
     const { user, password, host, port, max } = this.envConfig.profile;
+    const { rootUserId } = this.envConfig.properties;
     if (!user || !password || !host)
       throw new ConfigurationError(
         'Canner profile reader needs username, password, host properties.'
@@ -67,6 +68,9 @@ export class CannerProfileReader extends ProfileReader {
             max,
           },
           allow: '*',
+          properties: {
+            rootUserId,
+          },
         } as Profile<Record<string, any>>;
         this.logger.debug(`created "${profile.name}".`);
         return profile;

--- a/packages/extension-store-canner/src/lib/config.ts
+++ b/packages/extension-store-canner/src/lib/config.ts
@@ -70,7 +70,7 @@ export const getEnvConfig = (): CannerStoreConfig => {
         Number(process.env['PROFILE_CANNER_DRIVER_CONNECTION_POOL_MAX']) || 10,
     },
     properties: {
-      rootUserId: process.env['PROFILE_ROOT_USER_ID'],
+      rootUserId: process.env['PROFILE_CANNER_DRIVER_ROOT_USER_ID'],
     },
     storage: {
       provider: process.env['STORAGE_PROVIDER'],

--- a/packages/extension-store-canner/src/lib/config.ts
+++ b/packages/extension-store-canner/src/lib/config.ts
@@ -1,6 +1,11 @@
 export interface CannerStoreConfig {
   storage: StorageServiceOptions;
+  properties: CannnerDriverProfileProperties;
   profile: CannerDriverProfileOptions;
+}
+
+export interface CannnerDriverProfileProperties {
+  rootUserId?: string;
 }
 
 export interface CannerDriverProfileOptions {
@@ -63,6 +68,9 @@ export const getEnvConfig = (): CannerStoreConfig => {
       port: Number(process.env['PROFILE_CANNER_DRIVER_PORT']) || 7432,
       max:
         Number(process.env['PROFILE_CANNER_DRIVER_CONNECTION_POOL_MAX']) || 10,
+    },
+    properties: {
+      rootUserId: process.env['PROFILE_ROOT_USER_ID'],
     },
     storage: {
       provider: process.env['STORAGE_PROVIDER'],

--- a/packages/extension-store-canner/src/test/cannerProfileReader.spec.ts
+++ b/packages/extension-store-canner/src/test/cannerProfileReader.spec.ts
@@ -120,6 +120,7 @@ describe('Test CannerProfileReader', () => {
       user: 'canner',
       password: 'secret-password',
       port: 7432,
+      max: 10,
     };
     const expected = [
       {
@@ -129,6 +130,9 @@ describe('Test CannerProfileReader', () => {
           ...connectionInfo,
           database: fakeWorkspaces.ws1.sqlName,
         },
+        properties: {
+          rootUserId: 'fakeRootUserId',
+        },
         allow: '*',
       },
       {
@@ -137,6 +141,9 @@ describe('Test CannerProfileReader', () => {
         connection: {
           ...connectionInfo,
           database: fakeWorkspaces.ws2.sqlName,
+        },
+        properties: {
+          rootUserId: 'fakeRootUserId',
         },
         allow: '*',
       },
@@ -165,7 +172,9 @@ describe('Test CannerProfileReader', () => {
 
     sinon.default.stub(configModule, 'getEnvConfig').returns({
       storage: sinon.stubInterface<configModule.StorageServiceOptions>(),
-      properties: {},
+      properties: {
+        rootUserId: 'fakeRootUserId',
+      },
       profile: {
         ...connectionInfo,
       },

--- a/packages/extension-store-canner/src/test/cannerProfileReader.spec.ts
+++ b/packages/extension-store-canner/src/test/cannerProfileReader.spec.ts
@@ -98,6 +98,7 @@ describe('Test CannerProfileReader', () => {
 
       sinon.default.stub(configModule, 'getEnvConfig').returns({
         storage: sinon.stubInterface<configModule.StorageServiceOptions>(),
+        properties: {},
         profile: {
           host,
           password,
@@ -164,6 +165,7 @@ describe('Test CannerProfileReader', () => {
 
     sinon.default.stub(configModule, 'getEnvConfig').returns({
       storage: sinon.stubInterface<configModule.StorageServiceOptions>(),
+      properties: {},
       profile: {
         ...connectionInfo,
       },


### PR DESCRIPTION
## Description

Extends CacheLayerInfo interface and Profile interface to store properties that pass to the data source.


profile.yaml
```
 - name: duckdb
    type: duckdb
   connection:
      host: ...
      otherConnectionInfo
   allow: *
   // new added
   properties:
      some-configuration that can be read in the setting

```

API schema
```
urlPath: /artist/:id
cache:
 - cacheTableName: foo
   sql: 'select 1'
   profile: duckdb
   // new added
   options:
      foo: bar
profile: duckdb
```