### PR TITLE
feat(core): add typeof filter

### DIFF
--- a/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/index.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/index.ts
@@ -1,4 +1,11 @@
 import { UniqueFilterBuilder } from './uniqueFilterBuilder';
 import { UniqueFilterRunner } from './uniqueFilterRunner';
+import { TypeofBuilder } from './typeofBuilder';
+import { TypeofRunner } from './typeofRunner';
 
-export default [UniqueFilterBuilder, UniqueFilterRunner];
+export default [
+  UniqueFilterBuilder,
+  UniqueFilterRunner,
+  TypeofBuilder,
+  TypeofRunner,
+];

--- a/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/typeofBuilder.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/typeofBuilder.ts
@@ -1,0 +1,9 @@
+import {
+  FilterBuilder,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+
+@VulcanInternalExtension()
+export class TypeofBuilder extends FilterBuilder {
+  public filterName = 'typeof';
+}

--- a/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/typeofRunner.ts
+++ b/packages/core/src/lib/template-engine/built-in-extensions/sql-helper/typeofRunner.ts
@@ -1,0 +1,15 @@
+import {
+  FilterRunner,
+  FilterRunnerTransformOptions,
+  VulcanInternalExtension,
+} from '@vulcan-sql/core/models';
+
+@VulcanInternalExtension()
+export class TypeofRunner extends FilterRunner {
+  public filterName = 'typeof';
+  public async transform({
+    value,
+  }: FilterRunnerTransformOptions): Promise<any> {
+    return typeof value;
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces a new filter called `typeof` that allows retrieving the type of a variable in templates. 
For example, you can now use 
`{% if context.params.foo|typeof == 'string' %}` 
to conditionally execute code based on the type of the `foo` variable.

## Issue ticket number
n/a

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
