### PR TITLE
Fix: query again instead of using cached result when exporting from canner

### DIFF
--- a/packages/extension-driver-canner/src/lib/cannerAdapter.ts
+++ b/packages/extension-driver-canner/src/lib/cannerAdapter.ts
@@ -44,6 +44,7 @@ export class CannerAdapter {
           sql,
           timeout: 600,
           noLimit: true,
+          cacheRefresh: true, // not use cached result
         },
       },
       headers


### PR DESCRIPTION
## Description

This PR fix the issue #324 according to the [Canner API Documentation](https://documenter.getpostman.com/view/21257531/2s93CGSc5k#8e91682d-5d3a-4f70-a2f5-9e90039a9c39) 

## Issue ticket number

closes #324

