### PR TITLE
Feature: Metric Drawer

### DIFF
--- a/packages/admin-ui/components/form/ExpressionProperties.tsx
+++ b/packages/admin-ui/components/form/ExpressionProperties.tsx
@@ -1,0 +1,78 @@
+import { Form, FormInstance, Input } from 'antd';
+import FunctionOutlined from '@ant-design/icons/FunctionOutlined';
+import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
+import useExpressionFieldOptions, {
+  CUSTOM_EXPRESSION_VALUE,
+} from '@vulcan-sql/admin-ui/hooks/useExpressionFieldOptions';
+import ModelFieldSelector from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector';
+import { modelFieldSelectorValidator } from '@vulcan-sql/admin-ui/utils/validator';
+import ExpressionSelector from '../selectors/ExpressionSelector';
+import useModelFieldOptions, {
+  ModelFieldResposeData,
+} from '@vulcan-sql/admin-ui/hooks/useModelFieldOptions';
+
+interface Props {
+  model: string;
+  form: FormInstance;
+
+  // The transientData is used to get the model fields which are not created in DB yet.
+  transientData?: ModelFieldResposeData[];
+}
+
+export default function ExpressionProperties(props: Props) {
+  const { form, model, transientData } = props;
+
+  const expression = Form.useWatch('expression', form);
+
+  const expressionOptions = useExpressionFieldOptions();
+  const modelFieldOptions = useModelFieldOptions(transientData);
+
+  return (
+    <>
+      <Form.Item
+        label="Select an expression"
+        name="expression"
+        required
+        rules={[
+          {
+            required: true,
+            message: ERROR_TEXTS.EXPRESS_PROPERTIES.EXPRESSION.REQUIRED,
+          },
+        ]}
+      >
+        <ExpressionSelector options={expressionOptions} />
+      </Form.Item>
+      <div className="py-1" />
+      {expression === CUSTOM_EXPRESSION_VALUE ? (
+        <div className="bg-gray-2 px-10 py-4">
+          <Form.Item
+            label="Expression"
+            required
+            name="customExpression"
+            rules={[
+              {
+                required: true,
+                message: ERROR_TEXTS.EXPRESS_PROPERTIES.CUSTOM_FIELD.REQUIRED,
+              },
+            ]}
+          >
+            <Input addonBefore={<FunctionOutlined />} />
+          </Form.Item>
+        </div>
+      ) : (
+        <Form.Item
+          name="modelFields"
+          rules={[
+            {
+              validator: modelFieldSelectorValidator(
+                ERROR_TEXTS.EXPRESS_PROPERTIES.MODEL_FIELD
+              ),
+            },
+          ]}
+        >
+          <ModelFieldSelector model={model} options={modelFieldOptions} />
+        </Form.Item>
+      )}
+    </>
+  );
+}

--- a/packages/admin-ui/components/modals/AddDimensionFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddDimensionFieldModal.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo } from 'react';
+import { Modal, Form, Input, Select } from 'antd';
+import { GRANULARITY, COLUMN_TYPE } from '@vulcan-sql/admin-ui/utils/enum';
+import { FieldValue } from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector/FieldSelect';
+import ModelFieldSelector from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector';
+import { modelFieldSelectorValidator } from '@vulcan-sql/admin-ui/utils/validator';
+import useModelFieldOptions, {
+  ModelFieldResposeData,
+} from '@vulcan-sql/admin-ui/hooks/useModelFieldOptions';
+import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
+import Link from 'next/link';
+
+export type DimensionFieldValue = {
+  [key: string]: any;
+  fieldName: string;
+  modelFields?: FieldValue[];
+};
+
+interface Props {
+  model: string;
+  visible: boolean;
+  onSubmit: (values: any) => Promise<void>;
+  onClose: () => void;
+  loading?: boolean;
+  defaultValue?: DimensionFieldValue;
+
+  // The transientData is used to get the model fields which are not created in DB yet.
+  transientData?: ModelFieldResposeData[];
+}
+
+const granularityOptions = Object.values(GRANULARITY).map((value) => ({
+  label: value,
+  value,
+}));
+
+export default function AddDimensionFieldModal(props: Props) {
+  const {
+    model,
+    transientData,
+    visible,
+    loading,
+    onSubmit,
+    onClose,
+    defaultValue,
+  } = props;
+  const [form] = Form.useForm();
+
+  const modelFields: FieldValue[] = Form.useWatch('modelFields', form);
+
+  const modelFieldOptions = useModelFieldOptions(transientData);
+
+  const isGranularityShow = useMemo(() => {
+    const selectedField = modelFields
+      ? modelFields[modelFields.length - 1]
+      : null;
+    return [COLUMN_TYPE.DATE, COLUMN_TYPE.TIMESTAMP].includes(
+      selectedField?.type as COLUMN_TYPE
+    );
+  }, [modelFields]);
+
+  useEffect(() => {
+    form.setFieldsValue(defaultValue || {});
+  }, [form, defaultValue]);
+
+  const submit = () => {
+    form
+      .validateFields()
+      .then(async (values) => {
+        await onSubmit({ ...defaultValue, ...values });
+        onClose();
+      })
+      .catch(console.error);
+  };
+
+  return (
+    <Modal
+      title="Add dimension"
+      width={750}
+      visible={visible}
+      okText="Submit"
+      onOk={submit}
+      onCancel={onClose}
+      confirmLoading={loading}
+      maskClosable={false}
+      destroyOnClose
+      afterClose={() => form.resetFields()}
+    >
+      <div className="mb-4">
+        Morem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate
+        libero et velit interdum, ac aliquet odio mattis.{' '}
+        <Link href="" target="_blank" rel="noopener noreferrer">
+          Learn more
+        </Link>
+      </div>
+
+      <Form form={form} preserve={false} layout="vertical">
+        <Form.Item
+          label="Dimension name"
+          name="fieldName"
+          required
+          rules={[
+            {
+              required: true,
+              message: ERROR_TEXTS.ADD_DIMENSION_FIELD.FIELD_NAME.REQUIRED,
+            },
+          ]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item
+          name="modelFields"
+          rules={[
+            {
+              validator: modelFieldSelectorValidator(
+                ERROR_TEXTS.ADD_DIMENSION_FIELD.MODEL_FIELD
+              ),
+            },
+          ]}
+        >
+          <ModelFieldSelector model={model} options={modelFieldOptions} />
+        </Form.Item>
+        {isGranularityShow && (
+          <Form.Item
+            label="Granularity"
+            name="granularity"
+            required
+            rules={[
+              {
+                required: true,
+                message: ERROR_TEXTS.ADD_DIMENSION_FIELD.GRANULARITY.REQUIRED,
+              },
+            ]}
+          >
+            <Select
+              options={granularityOptions}
+              placeholder="Select granularity"
+            />
+          </Form.Item>
+        )}
+      </Form>
+    </Modal>
+  );
+}

--- a/packages/admin-ui/components/modals/AddMeasureFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddMeasureFieldModal.tsx
@@ -6,7 +6,7 @@ import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
 import ExpressionProperties from '@vulcan-sql/admin-ui/components/form/ExpressionProperties';
 import Link from 'next/link';
 
-export type CaculatedFieldValue = {
+export type MeasureFieldValue = {
   [key: string]: any;
   fieldName: string;
   expression: string;
@@ -20,13 +20,13 @@ interface Props {
   onSubmit: (values: any) => Promise<void>;
   onClose: () => void;
   loading?: boolean;
-  defaultValue?: CaculatedFieldValue;
+  defaultValue?: MeasureFieldValue;
 
   // The transientData is used to get the model fields which are not created in DB yet.
   transientData?: ModelFieldResposeData[];
 }
 
-export default function AddCaculatedFieldModal(props: Props) {
+export default function AddMeasureFieldModal(props: Props) {
   const {
     model,
     transientData,
@@ -54,7 +54,7 @@ export default function AddCaculatedFieldModal(props: Props) {
 
   return (
     <Modal
-      title="Add caculated field"
+      title="Add measure"
       width={750}
       visible={visible}
       okText="Submit"
@@ -75,13 +75,13 @@ export default function AddCaculatedFieldModal(props: Props) {
 
       <Form form={form} preserve={false} layout="vertical">
         <Form.Item
-          label="Field name"
+          label="Measure name"
           name="fieldName"
           required
           rules={[
             {
               required: true,
-              message: ERROR_TEXTS.ADD_CACULATED_FIELD.FIELD_NAME.REQUIRED,
+              message: ERROR_TEXTS.ADD_MEASURE_FIELD.FIELD_NAME.REQUIRED,
             },
           ]}
         >

--- a/packages/admin-ui/components/modals/AddRelationModal.tsx
+++ b/packages/admin-ui/components/modals/AddRelationModal.tsx
@@ -25,7 +25,7 @@ interface Props {
   allowSetDescription?: boolean;
 }
 
-function RelationModal(props: Props) {
+export default function RelationModal(props: Props) {
   const {
     allowSetDescription = true,
     defaultValue,
@@ -155,10 +155,4 @@ function RelationModal(props: Props) {
       </Form>
     </Modal>
   );
-}
-
-export default function AddRelationModal(props: Props) {
-  if (!props.visible) return null;
-
-  return <RelationModal {...props} />;
 }

--- a/packages/admin-ui/components/modals/AddWindowFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddWindowFieldModal.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo } from 'react';
+import { Modal, Form, Input, Select } from 'antd';
+import { COLUMN_TYPE, TIME_UNIT } from '@vulcan-sql/admin-ui/utils/enum';
+import { FieldValue } from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector/FieldSelect';
+import ModelFieldSelector from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector';
+import { modelFieldSelectorValidator } from '@vulcan-sql/admin-ui/utils/validator';
+import useModelFieldOptions, {
+  ModelFieldResposeData,
+} from '@vulcan-sql/admin-ui/hooks/useModelFieldOptions';
+import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
+import Link from 'next/link';
+
+export type WindowFieldValue = {
+  [key: string]: any;
+  fieldName: string;
+  modelFields?: FieldValue[];
+};
+
+interface Props {
+  model: string;
+  visible: boolean;
+  onSubmit: (values: any) => Promise<void>;
+  onClose: () => void;
+  loading?: boolean;
+  defaultValue?: WindowFieldValue;
+
+  // The transientData is used to get the model fields which are not created in DB yet.
+  transientData?: ModelFieldResposeData[];
+}
+
+const timeUnitOptions = Object.values(TIME_UNIT).map((value) => ({
+  label: value,
+  value,
+}));
+
+export default function AddDimensionFieldModal(props: Props) {
+  const {
+    model,
+    transientData,
+    visible,
+    loading,
+    onSubmit,
+    onClose,
+    defaultValue,
+  } = props;
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    form.setFieldsValue(defaultValue || {});
+  }, [form, defaultValue]);
+
+  const modelFieldOptions = useModelFieldOptions(transientData);
+
+  const filteredModelFieldOptions = useMemo(() => {
+    return (modelFieldOptions || []).filter((option) => {
+      return (
+        !!option.options ||
+        [COLUMN_TYPE.DATE, COLUMN_TYPE.TIMESTAMP].includes(
+          option.value?.type as COLUMN_TYPE
+        )
+      );
+    });
+  }, [modelFieldOptions]);
+
+  const submit = () => {
+    form
+      .validateFields()
+      .then(async (values) => {
+        await onSubmit({ ...defaultValue, ...values });
+        onClose();
+      })
+      .catch(console.error);
+  };
+
+  return (
+    <Modal
+      title="Add window"
+      width={750}
+      visible={visible}
+      okText="Submit"
+      onOk={submit}
+      onCancel={onClose}
+      confirmLoading={loading}
+      maskClosable={false}
+      destroyOnClose
+      afterClose={() => form.resetFields()}
+    >
+      <div className="mb-4">
+        Morem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate
+        libero et velit interdum, ac aliquet odio mattis.{' '}
+        <Link href="" target="_blank" rel="noopener noreferrer">
+          Learn more
+        </Link>
+      </div>
+
+      <Form form={form} preserve={false} layout="vertical">
+        <Form.Item
+          label="Window name"
+          name="fieldName"
+          required
+          rules={[
+            {
+              required: true,
+              message: ERROR_TEXTS.ADD_WINDOW_FIELD.FIELD_NAME.REQUIRED,
+            },
+          ]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item
+          name="modelFields"
+          rules={[
+            {
+              validator: modelFieldSelectorValidator(
+                ERROR_TEXTS.ADD_DIMENSION_FIELD.MODEL_FIELD
+              ),
+            },
+          ]}
+        >
+          <ModelFieldSelector
+            model={model}
+            options={filteredModelFieldOptions}
+          />
+        </Form.Item>
+        <Form.Item
+          label="Time unit"
+          name="timeUnit"
+          required
+          rules={[
+            {
+              required: true,
+              message: ERROR_TEXTS.ADD_WINDOW_FIELD.TIME_UNIT.REQUIRED,
+            },
+          ]}
+        >
+          <Select options={timeUnitOptions} placeholder="Select time unit" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/packages/admin-ui/components/modals/AddWindowFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddWindowFieldModal.tsx
@@ -33,7 +33,7 @@ const timeUnitOptions = Object.values(TIME_UNIT).map((value) => ({
   value,
 }));
 
-export default function AddDimensionFieldModal(props: Props) {
+export default function AddWindowFieldModal(props: Props) {
   const {
     model,
     transientData,

--- a/packages/admin-ui/components/pages/modeling/MetricDrawer.tsx
+++ b/packages/admin-ui/components/pages/modeling/MetricDrawer.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import { Drawer, Form, FormInstance } from 'antd';
+import { FORM_MODE, METRIC_STEP } from '@vulcan-sql/admin-ui/utils/enum';
+import MetricBasicForm, {
+  ButtonGroup as MetricBasicButtonGroup,
+  ButtonProps as MetricBasicButtonProps,
+} from './form/MetricBasicForm';
+import MetricDetailForm, {
+  ButtonGroup as MetricDetailButtonGroup,
+  ButtonProps as MetricDetailButtonProps,
+} from './form/MetricDetailForm';
+
+interface Props {
+  visible: boolean;
+  formMode: FORM_MODE;
+  onClose: () => void;
+  onSubmit: (values: any) => Promise<void>;
+  defaultValue?: any;
+}
+
+const DynamicForm = (props: {
+  formMode: FORM_MODE;
+  step: METRIC_STEP;
+  form: FormInstance;
+}) => {
+  return (
+    {
+      [METRIC_STEP.ONE]: <MetricBasicForm {...props} />,
+      [METRIC_STEP.TWO]: <MetricDetailForm {...props} />,
+    }[props.step] || null
+  );
+};
+
+const DynamicButtonGroup = (
+  props: { step: METRIC_STEP; form: FormInstance } & MetricBasicButtonProps &
+    MetricDetailButtonProps
+) => {
+  return (
+    {
+      [METRIC_STEP.ONE]: <MetricBasicButtonGroup {...props} />,
+      [METRIC_STEP.TWO]: <MetricDetailButtonGroup {...props} />,
+    }[props.step] || null
+  );
+};
+
+const getDrawerTitle = (formMode: FORM_MODE) =>
+  ({
+    [FORM_MODE.CREATE]: 'Create a metric',
+    [FORM_MODE.EDIT]: 'Update a metric',
+  }[formMode]);
+
+export default function MetricDrawer(props: Props) {
+  const { visible, formMode, defaultValue, onClose, onSubmit } = props;
+  const [internalValues, setInternalValues] = useState(defaultValue || null);
+  const [step, setStep] = useState(METRIC_STEP.ONE);
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    form.setFieldsValue(defaultValue || {});
+  }, [form, defaultValue]);
+
+  const afterVisibleChange = (visible: boolean) => {
+    if (!visible) {
+      setStep(METRIC_STEP.ONE);
+      form.resetFields();
+      setInternalValues(null);
+    }
+  };
+
+  const preview = () => {
+    form
+      .validateFields()
+      .then((values) => {
+        console.log({ ...internalValues, ...values });
+      })
+      .catch(console.error);
+  };
+
+  const back = () => {
+    setStep(METRIC_STEP.ONE);
+  };
+
+  const next = () => {
+    form
+      .validateFields()
+      .then((values) => {
+        setInternalValues({ ...internalValues, ...values });
+        setStep(METRIC_STEP.TWO);
+      })
+      .catch(console.error);
+  };
+
+  const submit = () => {
+    form
+      .validateFields()
+      .then(async (values) => {
+        await onSubmit({ ...internalValues, ...values });
+        onClose();
+      })
+      .catch(console.error);
+  };
+
+  return (
+    <Drawer
+      visible={visible}
+      title={getDrawerTitle(formMode)}
+      width={750}
+      closable
+      destroyOnClose
+      afterVisibleChange={afterVisibleChange}
+      onClose={onClose}
+      footer={
+        <DynamicButtonGroup
+          step={step}
+          form={form}
+          onCancel={onClose}
+          onBack={back}
+          onNext={next}
+          onSubmit={submit}
+          onPreview={preview}
+        />
+      }
+      extra={<>Step {step}/2</>}
+    >
+      <DynamicForm formMode={formMode} step={step} form={form} />
+    </Drawer>
+  );
+}

--- a/packages/admin-ui/components/pages/modeling/form/MetricBasicForm.tsx
+++ b/packages/admin-ui/components/pages/modeling/form/MetricBasicForm.tsx
@@ -1,0 +1,40 @@
+import { Form, FormInstance, Space, Button } from 'antd';
+import BasicInfoProperties from './BasicInfoProperties';
+import CacheProperties from './CacheProperties';
+import { FORM_MODE } from '@vulcan-sql/admin-ui/utils/enum';
+import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
+
+export interface ButtonProps {
+  onCancel: () => void;
+  onNext: () => void;
+}
+
+export default function ModelBasicForm(props: {
+  form: FormInstance;
+  formMode: FORM_MODE;
+}) {
+  const { form } = props;
+  return (
+    <Form form={form} layout="vertical">
+      <BasicInfoProperties
+        form={form}
+        label="Metric name"
+        name="metricName"
+        errorTexts={ERROR_TEXTS.MODELING_CREATE_METRIC}
+      />
+      <CacheProperties form={form} />
+    </Form>
+  );
+}
+
+export const ButtonGroup = (props: ButtonProps) => {
+  const { onNext, onCancel } = props;
+  return (
+    <Space className="d-flex justify-end">
+      <Button onClick={onCancel}>Cancel</Button>
+      <Button type="primary" onClick={onNext}>
+        Next
+      </Button>
+    </Space>
+  );
+};

--- a/packages/admin-ui/components/pages/modeling/form/MetricDetailForm.tsx
+++ b/packages/admin-ui/components/pages/modeling/form/MetricDetailForm.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from 'react';
+import { Form, FormInstance, Select, Radio, Button, Space } from 'antd';
+import { FORM_MODE } from '@vulcan-sql/admin-ui/utils/enum';
+import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
+import PreviewDataContent from './PreviewDataContent';
+import MeasureTableFormControl, {
+  MeasureTableValue,
+} from '@vulcan-sql/admin-ui/components/tableFormControls/MeasureTableFormControl';
+import DimensionTableFormControl, {
+  DimensionTableValue,
+} from '@vulcan-sql/admin-ui/components/tableFormControls/DimensionTableFormControl';
+import WindowTableFormControl, {
+  WindowTableValue,
+} from '@vulcan-sql/admin-ui/components/tableFormControls/WindowTableFormControl';
+import useMetricDetailFormOptions from '@vulcan-sql/admin-ui/hooks/useMetricDetailFormOptions';
+
+export interface ButtonProps {
+  form: FormInstance;
+  onPreview: () => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  onBack: () => void;
+}
+
+const RADIO_VALUE = {
+  SIMPLE: 'simple',
+  CUMULATIVE: 'cumulative',
+};
+
+const getPreviewColumns = (
+  measures: MeasureTableValue,
+  dimensions: DimensionTableValue,
+  windows: WindowTableValue
+) => {
+  return [
+    measures.map((field) => field.fieldName),
+    dimensions.map((field) => field.fieldName),
+    windows.map((field) => field.fieldName),
+  ]
+    .flat()
+    .map((name) => ({
+      title: name,
+      dataIndex: name,
+    }));
+};
+
+export default function ModelDetailForm(props: {
+  form: FormInstance;
+  formMode: FORM_MODE;
+}) {
+  const { form } = props;
+
+  const metricName = form.getFieldValue('metricName');
+  const metricType = Form.useWatch('metricType', form);
+  const measures = Form.useWatch('measures', form) || [];
+  const dimensions = Form.useWatch('dimensions', form) || [];
+  const windows = Form.useWatch('windows', form) || [];
+
+  const { modelMetricOptions } = useMetricDetailFormOptions();
+
+  const onMetricTypeChange = (value) => {
+    if (metricType !== value) {
+      form.setFieldsValue({
+        dimensions: undefined,
+        windows: undefined,
+      });
+    }
+  };
+
+  const previewColumns = useMemo(() => {
+    return getPreviewColumns(measures, dimensions, windows);
+  }, [measures, dimensions, windows]);
+
+  return (
+    <Form form={form} layout="vertical">
+      <Form.Item
+        label="Select a model or metric"
+        name="source"
+        required
+        rules={[
+          {
+            required: true,
+            message: ERROR_TEXTS.MODELING_CREATE_METRIC.SOURCE.REQUIRED,
+          },
+        ]}
+      >
+        <Select
+          placeholder="Select a model or metric"
+          options={modelMetricOptions}
+        />
+      </Form.Item>
+
+      <Form.Item
+        label="Type"
+        name="metricType"
+        initialValue={RADIO_VALUE.SIMPLE}
+      >
+        <Radio.Group onChange={onMetricTypeChange}>
+          <Radio value={RADIO_VALUE.SIMPLE}>Simple</Radio>
+          <Radio value={RADIO_VALUE.CUMULATIVE}>Cumulative</Radio>
+        </Radio.Group>
+      </Form.Item>
+
+      <Form.Item label="Measures" name="measures">
+        <MeasureTableFormControl modalProps={{ model: metricName }} />
+      </Form.Item>
+
+      {metricType === RADIO_VALUE.SIMPLE && (
+        <Form.Item label="Dimensions" name="dimensions">
+          <DimensionTableFormControl modalProps={{ model: metricName }} />
+        </Form.Item>
+      )}
+
+      {metricType === RADIO_VALUE.CUMULATIVE && (
+        <Form.Item label="Windows" name="windows">
+          <WindowTableFormControl modalProps={{ model: metricName }} />
+        </Form.Item>
+      )}
+
+      <Form.Item label="Data preview (50 rows)">
+        <PreviewDataContent columns={previewColumns} data={[]} />
+      </Form.Item>
+    </Form>
+  );
+}
+
+export const ButtonGroup = (props: ButtonProps) => {
+  const { form, onPreview, onCancel, onBack, onSubmit } = props;
+  const measures = Form.useWatch('measures', form) || [];
+  const dimensions = Form.useWatch('dimensions', form) || [];
+  const windows = Form.useWatch('windows', form) || [];
+
+  const canPreview = useMemo(() => {
+    return measures.length > 0 || dimensions.length > 0 || windows.length > 0;
+  }, [measures, dimensions, windows]);
+
+  return (
+    <div className="d-flex justify-space-between">
+      <Button onClick={onPreview} disabled={!canPreview}>
+        Preview data
+      </Button>
+      <Space className="d-flex justify-end">
+        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onBack}>Back</Button>
+        <Button type="primary" onClick={onSubmit}>
+          Submit
+        </Button>
+      </Space>
+    </div>
+  );
+};

--- a/packages/admin-ui/components/pages/modeling/form/ModelDetailForm.tsx
+++ b/packages/admin-ui/components/pages/modeling/form/ModelDetailForm.tsx
@@ -106,7 +106,7 @@ export default function ModelDetailForm(props: {
       <Form.Item
         label="Create model from"
         name="sourceType"
-        initialValue="table"
+        initialValue={RADIO_VALUE.TABLE}
       >
         <Radio.Group onChange={onSourceChange}>
           <Radio value={RADIO_VALUE.TABLE}>Table</Radio>

--- a/packages/admin-ui/components/pages/modeling/form/PreviewDataContent.tsx
+++ b/packages/admin-ui/components/pages/modeling/form/PreviewDataContent.tsx
@@ -1,13 +1,4 @@
 import { Table, TableColumnProps } from 'antd';
-import styled from 'styled-components';
-
-const Wrapper = styled.div`
-  .ant-table-has-header {
-    .ant-table-empty {
-      border: 1px solid var(--gray-4);
-    }
-  }
-`;
 
 interface Props {
   columns: TableColumnProps<any>[];
@@ -18,15 +9,13 @@ export default function PreviewDataContent(props: Props) {
   const { columns = [], data = [] } = props;
   const hasColumns = !!columns.length;
   return (
-    <Wrapper>
-      <Table
-        className={hasColumns ? 'ant-table-has-header' : ''}
-        showHeader={hasColumns}
-        dataSource={data}
-        columns={columns}
-        pagination={{ hideOnSinglePage: true, pageSize: 50, size: 'small' }}
-        scroll={{ y: 280 }}
-      />
-    </Wrapper>
+    <Table
+      className={hasColumns ? 'ant-table-has-header' : ''}
+      showHeader={hasColumns}
+      dataSource={data}
+      columns={columns}
+      pagination={{ hideOnSinglePage: true, pageSize: 50, size: 'small' }}
+      scroll={{ y: 280 }}
+    />
   );
 }

--- a/packages/admin-ui/components/selectors/DescriptiveSelector.tsx
+++ b/packages/admin-ui/components/selectors/DescriptiveSelector.tsx
@@ -3,13 +3,13 @@ import { Select, Space, Typography } from 'antd';
 import styled from 'styled-components';
 import { omit } from 'lodash';
 
-export interface Option {
+export interface Option<TContent = Record<string, any>> {
   [key: string]: any;
   label: string;
   value?: string;
   className?: string;
   disabled?: boolean;
-  content?: Record<string, any>;
+  content?: TContent;
   options?: Option[];
 }
 

--- a/packages/admin-ui/components/selectors/ExpressionSelector.tsx
+++ b/packages/admin-ui/components/selectors/ExpressionSelector.tsx
@@ -1,0 +1,35 @@
+import { Typography } from 'antd';
+import DescriptiveSelector, { Option } from './DescriptiveSelector';
+import React from 'react';
+
+export type ExpressionOption = Option<{
+  expression: string;
+  description: string;
+}>;
+
+interface Props extends React.ComponentProps<typeof DescriptiveSelector> {
+  options: ExpressionOption[];
+}
+
+export default function ExpressionSelector(props: Props) {
+  const { options, ...restProps } = props;
+  return (
+    <DescriptiveSelector
+      placeholder="Select an expression"
+      options={options}
+      {...restProps}
+      descriptiveContentRender={(content) => {
+        return (
+          <>
+            <div className="mb-1">{content?.description || '-'}</div>
+            {content?.expression && (
+              <Typography.Text className="mb-1" code>
+                {content.expression}
+              </Typography.Text>
+            )}
+          </>
+        );
+      }}
+    />
+  );
+}

--- a/packages/admin-ui/components/selectors/modelFieldSelector/index.tsx
+++ b/packages/admin-ui/components/selectors/modelFieldSelector/index.tsx
@@ -29,7 +29,7 @@ const Wrapper = styled.div`
 
 const SelectResult = makeIterable(FieldSelect);
 
-export default function RelationsSelector(props: Props) {
+export default function ModelFieldSelector(props: Props) {
   const wrapper = useRef<HTMLDivElement | null>(null);
   const { model, value = [], onChange, options } = props;
 

--- a/packages/admin-ui/components/table/SelectionRelationTable.tsx
+++ b/packages/admin-ui/components/table/SelectionRelationTable.tsx
@@ -8,6 +8,13 @@ import { ModelIcon } from '@vulcan-sql/admin-ui/utils/icons';
 
 const { Text } = Typography;
 
+const StyledTable = styled(Table)`
+  .ant-table-thead > tr > th {
+    color: var(--gray-7);
+    background-color: white;
+  }
+`;
+
 const StyledRow = styled(Row).attrs<{
   $isRowSelection: boolean;
 }>((props) => ({
@@ -100,8 +107,9 @@ function SelectionRelationTable(
       : undefined;
 
   return (
-    <Table
+    <StyledTable
       ref={ref}
+      className="ant-table-has-header"
       columns={columns}
       dataSource={dataSource}
       rowKey={(record) => JSON.stringify(record)}

--- a/packages/admin-ui/components/tableFormControls/CaculatedFieldTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/CaculatedFieldTableFormControl.tsx
@@ -17,16 +17,17 @@ export default function CaculatedFieldTableFormControl(props: Props) {
         {
           title: 'Name',
           dataIndex: 'fieldName',
+          width: 180,
         },
         {
           title: 'Expression',
           dataIndex: 'expression',
           render: (expression, record) => {
             // TODO: clarify the interface with backend
-            const argumentFields = (
-              record.modelFields.slice(1, record.modelFields.length) || []
-            ).map((field) => field.name);
-            const argumentTexts = argumentFields.join(', ');
+            const argumentFields = record.modelFields.map(
+              (field) => field.name
+            );
+            const argumentTexts = argumentFields.join('.');
             return `${expression}${argumentTexts ? `(${argumentTexts})` : ''}`;
           },
         },

--- a/packages/admin-ui/components/tableFormControls/DimensionTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/DimensionTableFormControl.tsx
@@ -1,0 +1,24 @@
+import { makeTableFormControl } from './base';
+import AddDimensionFieldModal, {
+  DimensionFieldValue,
+} from '@vulcan-sql/admin-ui/components/modals/AddDimensionFieldModal';
+
+export type DimensionTableValue = DimensionFieldValue[];
+
+type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
+
+const TableFormControl = makeTableFormControl(AddDimensionFieldModal);
+
+export default function DimensionTableFormControl(props: Props) {
+  return (
+    <TableFormControl
+      {...props}
+      columns={[
+        {
+          title: 'Name',
+          dataIndex: 'fieldName',
+        },
+      ]}
+    />
+  );
+}

--- a/packages/admin-ui/components/tableFormControls/MeasureTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/MeasureTableFormControl.tsx
@@ -17,16 +17,17 @@ export default function MeasureTableFormControl(props: Props) {
         {
           title: 'Name',
           dataIndex: 'fieldName',
+          width: 180,
         },
         {
           title: 'Expression',
           dataIndex: 'expression',
           render: (expression, record) => {
             // TODO: clarify the interface with backend
-            const argumentFields = (
-              record.modelFields.slice(1, record.modelFields.length) || []
-            ).map((field) => field.name);
-            const argumentTexts = argumentFields.join(', ');
+            const argumentFields = record.modelFields.map(
+              (field) => field.name
+            );
+            const argumentTexts = argumentFields.join('.');
             return `${expression}${argumentTexts ? `(${argumentTexts})` : ''}`;
           },
         },

--- a/packages/admin-ui/components/tableFormControls/MeasureTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/MeasureTableFormControl.tsx
@@ -1,15 +1,15 @@
 import { makeTableFormControl } from './base';
-import AddCaculatedFieldModal, {
-  CaculatedFieldValue,
-} from '@vulcan-sql/admin-ui/components/modals/AddCaculatedFieldModal';
+import AddMeasureFieldModal, {
+  MeasureFieldValue,
+} from '@vulcan-sql/admin-ui/components/modals/AddMeasureFieldModal';
 
-export type CaculatedFieldTableValue = CaculatedFieldValue[];
+export type MeasureTableValue = MeasureFieldValue[];
 
 type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
 
-const TableFormControl = makeTableFormControl(AddCaculatedFieldModal);
+const TableFormControl = makeTableFormControl(AddMeasureFieldModal);
 
-export default function CaculatedFieldTableFormControl(props: Props) {
+export default function MeasureTableFormControl(props: Props) {
   return (
     <TableFormControl
       {...props}

--- a/packages/admin-ui/components/tableFormControls/WindowTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/WindowTableFormControl.tsx
@@ -1,0 +1,24 @@
+import { makeTableFormControl } from './base';
+import AddWindowFieldModal, {
+  WindowFieldValue,
+} from '@vulcan-sql/admin-ui/components/modals/AddWindowFieldModal';
+
+export type WindowTableValue = WindowFieldValue[];
+
+type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
+
+const TableFormControl = makeTableFormControl(AddWindowFieldModal);
+
+export default function WindowTableFormControl(props: Props) {
+  return (
+    <TableFormControl
+      {...props}
+      columns={[
+        {
+          title: 'Name',
+          dataIndex: 'fieldName',
+        },
+      ]}
+    />
+  );
+}

--- a/packages/admin-ui/components/tableFormControls/base.tsx
+++ b/packages/admin-ui/components/tableFormControls/base.tsx
@@ -50,8 +50,8 @@ export const makeTableFormControl = <MData,>(
 
                 <Popconfirm
                   title="Sure to delete?"
+                  placement="topLeft"
                   okText="Delete"
-                  motion={null}
                   okButtonProps={{ danger: true }}
                   onConfirm={() => removeData(record._id)}
                 >

--- a/packages/admin-ui/hooks/useExpressionFieldOptions.tsx
+++ b/packages/admin-ui/hooks/useExpressionFieldOptions.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Option } from '@vulcan-sql/admin-ui/components/selectors/DescriptiveSelector';
+import { ExpressionOption } from '@vulcan-sql/admin-ui/components/selectors/ExpressionSelector';
 
 export const CUSTOM_EXPRESSION_VALUE = 'customExpression';
 
@@ -38,7 +38,7 @@ export default function useExpressionFieldOptions() {
           },
         ],
       },
-    ] as Option[];
+    ] as ExpressionOption[];
   }, []);
 
   return expressionOptions;

--- a/packages/admin-ui/hooks/useMetricDetailFormOptions.tsx
+++ b/packages/admin-ui/hooks/useMetricDetailFormOptions.tsx
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+
+export default function useMetricDetailFormOptions() {
+  const models = [
+    { name: 'Model1', columns: [{ name: 'custKey', type: 'UUID' }] },
+  ];
+
+  const metrics = [
+    { name: 'Metric1', columns: [{ name: 'custKey', type: 'UUID' }] },
+  ];
+
+  const modelMetricOptions = useMemo(() => {
+    return [...models, ...metrics].map((item) => ({
+      label: item.name,
+      value: item.name,
+    }));
+  }, [models, metrics]);
+
+  return {
+    modelMetricOptions,
+  };
+}

--- a/packages/admin-ui/hooks/useModelFieldOptions.tsx
+++ b/packages/admin-ui/hooks/useModelFieldOptions.tsx
@@ -18,6 +18,12 @@ export interface ModelFieldResposeData {
   }[];
 }
 
+export type ModelFieldOption = {
+  label: string | JSX.Element;
+  value?: SelectValue;
+  options?: ModelFieldOption[];
+};
+
 export default function useModelFieldOptions(
   transientData?: ModelFieldResposeData[]
 ) {
@@ -30,6 +36,10 @@ export default function useModelFieldOptions(
             {
               name: 'orders',
               properties: { type: 'Orders' },
+            },
+            {
+              name: 'orderDate',
+              properties: { type: 'TIMESTAMP' },
             },
           ],
         },
@@ -86,8 +96,8 @@ export default function useModelFieldOptions(
     };
   };
 
-  const columns = currentModel.columns.map(convertor) || [];
-  const relations = lineage.length
+  const columns: ModelFieldOption[] = currentModel.columns.map(convertor) || [];
+  const relations: ModelFieldOption[] = lineage.length
     ? [{ label: 'Relations', options: lineage.map(convertor) }]
     : [];
 

--- a/packages/admin-ui/pages/component.tsx
+++ b/packages/admin-ui/pages/component.tsx
@@ -1,13 +1,17 @@
 import dynamic from 'next/dynamic';
 import { useEffect } from 'react';
 import { Form, Button } from 'antd';
-import { NODE_TYPE } from '@vulcan-sql/admin-ui/utils/enum';
+import { JOIN_TYPE, NODE_TYPE } from '@vulcan-sql/admin-ui/utils/enum';
 import { useForm } from 'antd/lib/form/Form';
 import useModalAction from '@vulcan-sql/admin-ui/hooks/useModalAction';
 import useModelFieldOptions from '@vulcan-sql/admin-ui/hooks/useModelFieldOptions';
 import AddCaculatedFieldModal from '@vulcan-sql/admin-ui/components/modals/AddCaculatedFieldModal';
+import AddMeasureFieldModal from '@vulcan-sql/admin-ui/components/modals/AddMeasureFieldModal';
+import AddDimensionFieldModal from '@vulcan-sql/admin-ui/components/modals/AddDimensionFieldModal';
+import AddWindowFieldModal from '@vulcan-sql/admin-ui/components/modals/AddWindowFieldModal';
 import AddRelationModal from '@vulcan-sql/admin-ui/components/modals/AddRelationModal';
 import ModelDrawer from '@vulcan-sql/admin-ui/components/pages/modeling/ModelDrawer';
+import MetricDrawer from '@vulcan-sql/admin-ui/components/pages/modeling/MetricDrawer';
 import useDrawerAction from '@vulcan-sql/admin-ui/hooks/useDrawerAction';
 
 const ModelFieldSelector = dynamic(
@@ -25,9 +29,13 @@ export default function Component() {
   const [form] = useForm();
 
   const addCaculatedFieldModal = useModalAction();
+  const addMeasureFieldModal = useModalAction();
+  const addDimensionFieldModal = useModalAction();
+  const addWindowFieldModal = useModalAction();
   const addRelationModal = useModalAction();
 
   const modelDrawer = useDrawerAction();
+  const metricDrawer = useDrawerAction();
 
   const fieldOptions = useModelFieldOptions();
   const modelFields = Form.useWatch('modelFields', form);
@@ -66,9 +74,23 @@ export default function Component() {
         Add caculated field
       </Button>
 
+      <Button onClick={() => addMeasureFieldModal.openModal()}>
+        Add measure field
+      </Button>
+
+      <Button onClick={() => addDimensionFieldModal.openModal()}>
+        Add dimesion field
+      </Button>
+
+      <Button onClick={() => addWindowFieldModal.openModal()}>
+        Add window field
+      </Button>
+
       <Button onClick={addRelationModal.openModal}>Add relation field</Button>
 
       <Button onClick={() => modelDrawer.openDrawer()}>Model drawer</Button>
+
+      <Button onClick={() => metricDrawer.openDrawer()}>Metric drawer</Button>
 
       <AddCaculatedFieldModal
         model="Customer"
@@ -89,6 +111,33 @@ export default function Component() {
         // }}
       />
 
+      <AddMeasureFieldModal
+        model="Customer"
+        {...addMeasureFieldModal.state}
+        onSubmit={async (values) => {
+          console.log(values);
+        }}
+        onClose={addMeasureFieldModal.closeModal}
+      />
+
+      <AddDimensionFieldModal
+        model="Customer"
+        {...addDimensionFieldModal.state}
+        onSubmit={async (values) => {
+          console.log(values);
+        }}
+        onClose={addDimensionFieldModal.closeModal}
+      />
+
+      <AddWindowFieldModal
+        model="Customer"
+        {...addWindowFieldModal.state}
+        onSubmit={async (values) => {
+          console.log(values);
+        }}
+        onClose={addWindowFieldModal.closeModal}
+      />
+
       <AddRelationModal
         model="Customer"
         {...addRelationModal.state}
@@ -97,7 +146,7 @@ export default function Component() {
         }}
         onClose={addRelationModal.closeModal}
         defaultValue={{
-          relationType: 'ONE_TO_ONE',
+          relationType: JOIN_TYPE.ONE_TO_ONE,
           fromField: {
             model: 'Customer',
             field: 'orders',
@@ -139,6 +188,14 @@ export default function Component() {
           ],
           cached: true,
           cachedPeriod: '1m',
+        }}
+      />
+
+      <MetricDrawer
+        {...metricDrawer.state}
+        onClose={metricDrawer.closeDrawer}
+        onSubmit={async (values) => {
+          console.log(values);
         }}
       />
     </Form>

--- a/packages/admin-ui/styles/components/table.less
+++ b/packages/admin-ui/styles/components/table.less
@@ -10,25 +10,24 @@
     padding-left: 8px;
   }
 
-  .ant-table-thead > tr > th {
-    color: @gray-7;
-    background-color: white;
-  }
-  
   .ant-table-row:last-child .ant-table-cell {
     border-bottom: none;
   }
 
   &.ant-table-empty {
-    border: none;
-
     .ant-table-body {
       overflow: hidden !important;
     }
 
-    .ant-table-cell {
+    .ant-table-tbody .ant-table-cell {
       border-bottom: none;
     }
+  }
+}
+
+.ant-table-wrapper:not(.ant-table-has-header) {
+  .ant-table-empty {
+    border: none;
 
     .ant-empty-normal {
       margin: 80px 0;

--- a/packages/admin-ui/utils/enum/modeling.ts
+++ b/packages/admin-ui/utils/enum/modeling.ts
@@ -26,7 +26,29 @@ export enum CACHED_PERIOD {
   SECOND = 's',
 }
 
+export enum GRANULARITY {
+  DAY = 'day',
+  MONTH = 'month',
+  YEAR = 'year',
+}
+
+export enum TIME_UNIT {
+  YEAR = 'year',
+  QUARTER = 'quarter',
+  MONTH = 'month',
+  WEEK = 'week',
+  DAY = 'day',
+  HOUR = 'hour',
+  MINUTE = 'minute',
+  SECOND = 'second',
+}
+
 export enum MODEL_STEP {
+  ONE = '1',
+  TWO = '2',
+}
+
+export enum METRIC_STEP {
   ONE = '1',
   TWO = '2',
 }

--- a/packages/admin-ui/utils/error/dictionary.ts
+++ b/packages/admin-ui/utils/error/dictionary.ts
@@ -14,6 +14,35 @@ export const ERROR_TEXTS = {
     FIELD_NAME: {
       REQUIRED: 'Please input field name.',
     },
+  },
+  ADD_MEASURE_FIELD: {
+    FIELD_NAME: {
+      REQUIRED: 'Please input measure name.',
+    },
+  },
+  ADD_DIMENSION_FIELD: {
+    FIELD_NAME: {
+      REQUIRED: 'Please input dimension name.',
+    },
+    MODEL_FIELD: {
+      REQUIRED: 'Please select a field.',
+    },
+    GRANULARITY: {
+      REQUIRED: 'Please select granularity.',
+    },
+  },
+  ADD_WINDOW_FIELD: {
+    FIELD_NAME: {
+      REQUIRED: 'Please input window name.',
+    },
+    MODEL_FIELD: {
+      REQUIRED: 'Please select a field.',
+    },
+    TIME_UNIT: {
+      REQUIRED: 'Please select time unit.',
+    },
+  },
+  EXPRESS_PROPERTIES: {
     EXPRESSION: {
       REQUIRED: 'Please select an expression.',
     },
@@ -50,6 +79,14 @@ export const ERROR_TEXTS = {
     },
     FIELDS: {
       REQUIRED: 'Please select fields.',
+    },
+  },
+  MODELING_CREATE_METRIC: {
+    NAME: {
+      REQUIRED: 'Please input metric name.',
+    },
+    SOURCE: {
+      REQUIRED: 'Please select a model or metric.',
     },
   },
 };


### PR DESCRIPTION
## Description

- can create & update
- Metrics:
    - Name
    - From
        - Pick a model / metric
    - Type: Simple, Cumulative
        - Measure (語法跟 calculated field 支援的一致)
            - Type = Simple
                - Dimension
                    - pick a field
                    - 可以不斷透過 relation 連結到下個 model
                    - if field type = date or timestamp, 提供使用者選擇顆粒度 (granularity) 要 day/month/year
                    
            - Type = Cumulative
                - Window
                    - pick a field (僅能選擇 date, timestamp)
                    - Time Unit (選擇 YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND)

<img width="781" alt="image" src="https://github.com/Canner/vulcan-sql/assets/9657305/2e2969e9-318e-40d3-8ca8-9facd50a5331">

<img width="815" alt="image" src="https://github.com/Canner/vulcan-sql/assets/9657305/e2b77249-ed21-48be-b164-0d17b78b8427">

<img width="1440" alt="image" src="https://github.com/Canner/vulcan-sql/assets/9657305/c2b300a2-e764-4729-ad6f-b1a3dc3af654">

<img width="1436" alt="image" src="https://github.com/Canner/vulcan-sql/assets/9657305/9caea3dd-b3b5-42be-b340-afadfa307966">


## Issue ticket number

closes #xx

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
