### PR TITLE
Feature: Metadata Drawer

### DIFF
--- a/packages/admin-ui/components/modals/AddCaculatedFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddCaculatedFieldModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Modal, Form, Input } from 'antd';
+import { ModalAction } from '@vulcan-sql/admin-ui/hooks/useModalAction';
 import { FieldValue } from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector/FieldSelect';
 import { ModelFieldResposeData } from '@vulcan-sql/admin-ui/hooks/useModelFieldOptions';
 import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
@@ -14,17 +15,13 @@ export type CaculatedFieldValue = {
   customExpression?: string;
 };
 
-interface Props {
+type Props = ModalAction<CaculatedFieldValue> & {
   model: string;
-  visible: boolean;
-  onSubmit: (values: any) => Promise<void>;
-  onClose: () => void;
   loading?: boolean;
-  defaultValue?: CaculatedFieldValue;
 
   // The transientData is used to get the model fields which are not created in DB yet.
   transientData?: ModelFieldResposeData[];
-}
+};
 
 export default function AddCaculatedFieldModal(props: Props) {
   const {
@@ -39,8 +36,9 @@ export default function AddCaculatedFieldModal(props: Props) {
   const [form] = Form.useForm();
 
   useEffect(() => {
+    if (!visible) return;
     form.setFieldsValue(defaultValue || {});
-  }, [form, defaultValue]);
+  }, [form, defaultValue, visible]);
 
   const submit = () => {
     form

--- a/packages/admin-ui/components/modals/AddDimensionFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddDimensionFieldModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { Modal, Form, Input, Select } from 'antd';
+import { ModalAction } from '@vulcan-sql/admin-ui/hooks/useModalAction';
 import { GRANULARITY, COLUMN_TYPE } from '@vulcan-sql/admin-ui/utils/enum';
 import { FieldValue } from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector/FieldSelect';
 import ModelFieldSelector from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector';
@@ -16,17 +17,13 @@ export type DimensionFieldValue = {
   modelFields?: FieldValue[];
 };
 
-interface Props {
+type Props = ModalAction<DimensionFieldValue> & {
   model: string;
-  visible: boolean;
-  onSubmit: (values: any) => Promise<void>;
-  onClose: () => void;
   loading?: boolean;
-  defaultValue?: DimensionFieldValue;
 
   // The transientData is used to get the model fields which are not created in DB yet.
   transientData?: ModelFieldResposeData[];
-}
+};
 
 const granularityOptions = Object.values(GRANULARITY).map((value) => ({
   label: value,
@@ -59,8 +56,9 @@ export default function AddDimensionFieldModal(props: Props) {
   }, [modelFields]);
 
   useEffect(() => {
+    if (!visible) return;
     form.setFieldsValue(defaultValue || {});
-  }, [form, defaultValue]);
+  }, [form, defaultValue, visible]);
 
   const submit = () => {
     form

--- a/packages/admin-ui/components/modals/AddMeasureFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddMeasureFieldModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Modal, Form, Input } from 'antd';
+import { ModalAction } from '@vulcan-sql/admin-ui/hooks/useModalAction';
 import { FieldValue } from '@vulcan-sql/admin-ui/components/selectors/modelFieldSelector/FieldSelect';
 import { ModelFieldResposeData } from '@vulcan-sql/admin-ui/hooks/useModelFieldOptions';
 import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
@@ -14,17 +15,13 @@ export type MeasureFieldValue = {
   customExpression?: string;
 };
 
-interface Props {
+type Props = ModalAction<MeasureFieldValue> & {
   model: string;
-  visible: boolean;
-  onSubmit: (values: any) => Promise<void>;
-  onClose: () => void;
   loading?: boolean;
-  defaultValue?: MeasureFieldValue;
 
   // The transientData is used to get the model fields which are not created in DB yet.
   transientData?: ModelFieldResposeData[];
-}
+};
 
 export default function AddMeasureFieldModal(props: Props) {
   const {
@@ -39,8 +36,9 @@ export default function AddMeasureFieldModal(props: Props) {
   const [form] = Form.useForm();
 
   useEffect(() => {
+    if (!visible) return;
     form.setFieldsValue(defaultValue || {});
-  }, [form, defaultValue]);
+  }, [form, defaultValue, visible]);
 
   const submit = () => {
     form

--- a/packages/admin-ui/components/modals/AddRelationModal.tsx
+++ b/packages/admin-ui/components/modals/AddRelationModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
-import { Modal, Form, Input, Select, Row, Col } from 'antd';
 import { isEmpty } from 'lodash';
+import { Modal, Form, Input, Select, Row, Col } from 'antd';
+import { ModalAction } from '@vulcan-sql/admin-ui/hooks/useModalAction';
 import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
 import CombineFieldSelector from '@vulcan-sql/admin-ui/components/selectors/CombineFieldSelector';
 import { JOIN_TYPE } from '@vulcan-sql/admin-ui/utils/enum';
@@ -15,15 +16,11 @@ export type RelationFieldValue = { [key: string]: any } & Pick<
     description?: string;
   };
 
-interface Props {
+type Props = ModalAction<RelationFieldValue, RelationsDataType> & {
   model: string;
-  visible: boolean;
-  onSubmit: (values: RelationsDataType) => Promise<void>;
-  onClose: () => void;
   loading?: boolean;
-  defaultValue?: RelationFieldValue;
   allowSetDescription?: boolean;
-}
+};
 
 export default function RelationModal(props: Props) {
   const {
@@ -38,8 +35,9 @@ export default function RelationModal(props: Props) {
   const [form] = Form.useForm();
 
   useEffect(() => {
+    if (!visible) return;
     form.setFieldsValue(defaultValue || {});
-  }, [form, defaultValue]);
+  }, [form, defaultValue, visible]);
 
   const relationTypeOptions = Object.keys(JOIN_TYPE).map((key) => ({
     label: getJoinTypeText(key),

--- a/packages/admin-ui/components/modals/AddWindowFieldModal.tsx
+++ b/packages/admin-ui/components/modals/AddWindowFieldModal.tsx
@@ -46,8 +46,9 @@ export default function AddWindowFieldModal(props: Props) {
   const [form] = Form.useForm();
 
   useEffect(() => {
+    if (!visible) return;
     form.setFieldsValue(defaultValue || {});
-  }, [form, defaultValue]);
+  }, [form, defaultValue, visible]);
 
   const modelFieldOptions = useModelFieldOptions(transientData);
 

--- a/packages/admin-ui/components/modals/UpdateMetadataModal.tsx
+++ b/packages/admin-ui/components/modals/UpdateMetadataModal.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { Modal, Form, Input } from 'antd';
+import { ModalAction } from '@vulcan-sql/admin-ui/hooks/useModalAction';
+import { ERROR_TEXTS } from '@vulcan-sql/admin-ui/utils/error';
+
+interface MetadataValue {
+  displayName: string;
+  description?: string;
+}
+
+type Props = ModalAction<MetadataValue> & {
+  loading?: boolean;
+};
+
+export default function UpdateMetadataModal(props: Props) {
+  const { visible, loading, onSubmit, onClose, defaultValue } = props;
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (!visible) return;
+    form.setFieldsValue(defaultValue || {});
+  }, [form, defaultValue, visible]);
+
+  const submit = () => {
+    form
+      .validateFields()
+      .then(async (values) => {
+        await onSubmit({ ...defaultValue, ...values });
+        onClose();
+      })
+      .catch(console.error);
+  };
+
+  return (
+    <Modal
+      title="Update field metadata"
+      width={520}
+      visible={visible}
+      okText="Submit"
+      onOk={submit}
+      onCancel={onClose}
+      confirmLoading={loading}
+      maskClosable={false}
+      destroyOnClose
+      afterClose={() => form.resetFields()}
+    >
+      <Form form={form} preserve={false} layout="vertical">
+        <Form.Item
+          label="Name"
+          name="displayName"
+          required
+          rules={[
+            {
+              required: true,
+              message: ERROR_TEXTS.UPDATE_METADATA.NAME.REQUIRED,
+            },
+          ]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item label="Description" name="description">
+          <Input.TextArea showCount maxLength={300} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/packages/admin-ui/components/pages/modeling/MetadataDrawer.tsx
+++ b/packages/admin-ui/components/pages/modeling/MetadataDrawer.tsx
@@ -1,0 +1,209 @@
+import { useRouter } from 'next/router';
+import { Drawer, Button, Typography } from 'antd';
+import CompassOutlined from '@ant-design/icons/CompassOutlined';
+import { NODE_TYPE, Path } from '@vulcan-sql/admin-ui/utils/enum';
+import { DrawerAction } from '@vulcan-sql/admin-ui/hooks/useDrawerAction';
+import FieldTable from '@vulcan-sql/admin-ui/components/table/FieldTable';
+import CaculatedFieldTable from '@vulcan-sql/admin-ui/components/table/CaculatedFieldTable';
+import MeasureFieldTable from '@vulcan-sql/admin-ui/components/table/MeasureFieldTable';
+import DimensionFieldTable from '@vulcan-sql/admin-ui/components/table/DimensionFieldTable';
+import WindowFieldTable from '@vulcan-sql/admin-ui/components/table/WindowFieldTable';
+import RelationTableFormControl from '@vulcan-sql/admin-ui/components/tableFormControls/RelationTableFormControl';
+import { makeMetadataBaseTable } from '@vulcan-sql/admin-ui/components/table/MetadataBaseTable';
+import UpdateMetadataModal from '@vulcan-sql/admin-ui/components/modals/UpdateMetadataModal';
+
+interface MetadataData {
+  name: string;
+  description: string;
+  fields?: any[];
+  caculatedFields?: any[];
+  relations?: any[];
+  measures?: any[];
+  dimensions?: any[];
+  windows?: any[];
+  nodeType: NODE_TYPE;
+}
+
+type Props = DrawerAction<MetadataData>;
+
+const ModelMetadata = ({
+  name,
+  fields = [],
+  caculatedFields = [],
+  relations = [],
+}) => {
+  const FieldMetadataTable =
+    makeMetadataBaseTable(FieldTable)(UpdateMetadataModal);
+  const CaculatedFieldMetadataTable =
+    makeMetadataBaseTable(CaculatedFieldTable)(UpdateMetadataModal);
+
+  const submitRelation = async (value) => {
+    // TODO: waiting for API
+    console.log(value);
+  };
+
+  const deleteRelation = async (value) => {
+    // TODO: waiting for API
+    console.log(value);
+  };
+
+  // To convert edit value for update metadata modal
+  const editMetadataValue = (value) => {
+    return {
+      displayName: value.displayName || value.fieldName || value.name,
+      description: value.description,
+    };
+  };
+
+  const submitMetadata = (values) => {
+    // TODO: waiting for API
+    console.log(values);
+  };
+
+  return (
+    <>
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Fields ({fields.length})
+        </Typography.Text>
+        <FieldMetadataTable
+          dataSource={fields}
+          onEditValue={editMetadataValue}
+          onSubmitRemote={submitMetadata}
+        />
+      </div>
+
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Caculated fields ({caculatedFields.length})
+        </Typography.Text>
+        <CaculatedFieldMetadataTable
+          dataSource={caculatedFields}
+          onEditValue={editMetadataValue}
+          onSubmitRemote={submitMetadata}
+        />
+      </div>
+
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Relations ({relations.length})
+        </Typography.Text>
+        <RelationTableFormControl
+          modalProps={{ model: name }}
+          value={relations}
+          onRemoteSubmit={submitRelation}
+          onRemoteDelete={deleteRelation}
+        />
+      </div>
+    </>
+  );
+};
+
+const MetricMetadata = ({
+  measures = [],
+  dimensions = undefined,
+  windows = undefined,
+}) => {
+  const MeasureFieldMetadataTable =
+    makeMetadataBaseTable(MeasureFieldTable)(UpdateMetadataModal);
+  const DimensionFieldMetadataTable =
+    makeMetadataBaseTable(DimensionFieldTable)(UpdateMetadataModal);
+  const WindowFieldMetadataTable =
+    makeMetadataBaseTable(WindowFieldTable)(UpdateMetadataModal);
+
+  // To convert edit value for update metadata modal
+  const editMetadataValue = (value) => {
+    return {
+      displayName: value.displayName || value.fieldName || value.name,
+      description: value.description,
+    };
+  };
+
+  const submitMetadata = (values) => {
+    // TODO: waiting for API
+    console.log(values);
+  };
+
+  return (
+    <>
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Measures ({measures.length})
+        </Typography.Text>
+        <MeasureFieldMetadataTable
+          dataSource={measures}
+          onEditValue={editMetadataValue}
+          onSubmitRemote={submitMetadata}
+        />
+      </div>
+
+      {!!dimensions && (
+        <div className="mb-6">
+          <Typography.Text className="d-block gray-7 mb-2">
+            Dimensions ({dimensions.length})
+          </Typography.Text>
+          <DimensionFieldMetadataTable
+            dataSource={dimensions}
+            onEditValue={editMetadataValue}
+            onSubmitRemote={submitMetadata}
+          />
+        </div>
+      )}
+
+      {!!windows && (
+        <div className="mb-6">
+          <Typography.Text className="d-block gray-7 mb-2">
+            Windows ({windows.length})
+          </Typography.Text>
+          <WindowFieldMetadataTable
+            dataSource={windows}
+            onEditValue={editMetadataValue}
+            onSubmitRemote={submitMetadata}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default function MetadataDrawer(props: Props) {
+  const { visible, defaultValue, onClose } = props;
+  const { name, description, nodeType = NODE_TYPE.MODEL } = defaultValue;
+  const router = useRouter();
+
+  const goToExplore = () => {
+    router.push(Path.Explore);
+  };
+
+  return (
+    <Drawer
+      visible={visible}
+      title={name}
+      width={750}
+      closable
+      destroyOnClose
+      onClose={onClose}
+      footer={
+        <div className="text-right">
+          <Button
+            type="primary"
+            icon={<CompassOutlined />}
+            onClick={goToExplore}
+          >
+            Explore data
+          </Button>
+        </div>
+      }
+    >
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Description
+        </Typography.Text>
+        <div>{description || '-'}</div>
+      </div>
+
+      {nodeType === NODE_TYPE.MODEL && <ModelMetadata {...defaultValue} />}
+      {nodeType === NODE_TYPE.METRIC && <MetricMetadata {...defaultValue} />}
+    </Drawer>
+  );
+}

--- a/packages/admin-ui/components/pages/modeling/MetricDrawer.tsx
+++ b/packages/admin-ui/components/pages/modeling/MetricDrawer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Drawer, Form, FormInstance } from 'antd';
 import { FORM_MODE, METRIC_STEP } from '@vulcan-sql/admin-ui/utils/enum';
+import { DrawerAction } from '@vulcan-sql/admin-ui/hooks/useDrawerAction';
 import MetricBasicForm, {
   ButtonGroup as MetricBasicButtonGroup,
   ButtonProps as MetricBasicButtonProps,
@@ -10,13 +11,7 @@ import MetricDetailForm, {
   ButtonProps as MetricDetailButtonProps,
 } from './form/MetricDetailForm';
 
-interface Props {
-  visible: boolean;
-  formMode: FORM_MODE;
-  onClose: () => void;
-  onSubmit: (values: any) => Promise<void>;
-  defaultValue?: any;
-}
+type Props = DrawerAction;
 
 const DynamicForm = (props: {
   formMode: FORM_MODE;
@@ -56,8 +51,9 @@ export default function MetricDrawer(props: Props) {
   const [form] = Form.useForm();
 
   useEffect(() => {
+    if (!visible) return;
     form.setFieldsValue(defaultValue || {});
-  }, [form, defaultValue]);
+  }, [form, defaultValue, visible]);
 
   const afterVisibleChange = (visible: boolean) => {
     if (!visible) {

--- a/packages/admin-ui/components/pages/modeling/ModelDrawer.tsx
+++ b/packages/admin-ui/components/pages/modeling/ModelDrawer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Drawer, Form, FormInstance } from 'antd';
 import { FORM_MODE, MODEL_STEP } from '@vulcan-sql/admin-ui/utils/enum';
+import { DrawerAction } from '@vulcan-sql/admin-ui/hooks/useDrawerAction';
 import ModelBasicForm, {
   ButtonGroup as ModelBasicButtonGroup,
   ButtonProps as ModelBasicButtonProps,
@@ -10,13 +11,7 @@ import ModelDetailForm, {
   ButtonProps as ModelDetailButtonProps,
 } from './form/ModelDetailForm';
 
-interface Props {
-  visible: boolean;
-  formMode: FORM_MODE;
-  onClose: () => void;
-  onSubmit: (values: any) => Promise<void>;
-  defaultValue?: any;
-}
+type Props = DrawerAction;
 
 const DynamicForm = (props: {
   formMode: FORM_MODE;
@@ -56,8 +51,9 @@ export default function ModelDrawer(props: Props) {
   const [form] = Form.useForm();
 
   useEffect(() => {
+    if (!visible) return;
     form.setFieldsValue(defaultValue || {});
-  }, [form, defaultValue]);
+  }, [form, defaultValue, visible]);
 
   const afterVisibleChange = (visible: boolean) => {
     if (!visible) {

--- a/packages/admin-ui/components/table/CaculatedFieldTable.tsx
+++ b/packages/admin-ui/components/table/CaculatedFieldTable.tsx
@@ -33,11 +33,19 @@ export default function CaculatedFieldTable(props: Props) {
     [dataSource]
   );
 
+  const tableData = useMemo(
+    () =>
+      (dataSource || []).map((record, index) => ({
+        ...record,
+        key: `${record.fieldName}-${index}`,
+      })),
+    [dataSource]
+  );
+
   return (
     <Table
-      rowKey={(record, index) => `${record.fieldName}-${index}`}
-      dataSource={dataSource}
-      showHeader={dataSource.length > 0}
+      dataSource={tableData}
+      showHeader={tableData.length > 0}
       columns={tableColumns}
       pagination={{
         hideOnSinglePage: true,

--- a/packages/admin-ui/components/table/CaculatedFieldTable.tsx
+++ b/packages/admin-ui/components/table/CaculatedFieldTable.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { Table, TableProps } from 'antd';
+import { CaculatedFieldValue } from '@vulcan-sql/admin-ui/components/modals/AddCaculatedFieldModal';
+
+type Props = Pick<TableProps<CaculatedFieldValue>, 'dataSource'> &
+  Partial<Pick<TableProps<CaculatedFieldValue>, 'columns'>>;
+
+export const getCaculatedFieldTableColumns = () => {
+  return [
+    {
+      title: 'Name',
+      dataIndex: 'fieldName',
+      width: 150,
+    },
+    {
+      title: 'Expression',
+      dataIndex: 'expression',
+      render: (expression, record) => {
+        // TODO: clarify the interface with backend
+        const argumentFields = record.modelFields.map((field) => field.name);
+        const argumentTexts = argumentFields.join('.');
+        return `${expression}${argumentTexts ? `(${argumentTexts})` : ''}`;
+      },
+    },
+  ];
+};
+
+export default function CaculatedFieldTable(props: Props) {
+  const { dataSource = [], columns = [] } = props;
+
+  const tableColumns = useMemo(
+    () => [...getCaculatedFieldTableColumns(), ...columns],
+    [dataSource]
+  );
+
+  return (
+    <Table
+      rowKey={(record, index) => `${record.fieldName}-${index}`}
+      dataSource={dataSource}
+      showHeader={dataSource.length > 0}
+      columns={tableColumns}
+      pagination={{
+        hideOnSinglePage: true,
+        pageSize: 10,
+        size: 'small',
+      }}
+    />
+  );
+}

--- a/packages/admin-ui/components/table/DimensionFieldTable.tsx
+++ b/packages/admin-ui/components/table/DimensionFieldTable.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { Table, TableProps } from 'antd';
+import { DimensionFieldValue } from '@vulcan-sql/admin-ui/components/modals/AddDimensionFieldModal';
+
+type Props = Pick<TableProps<DimensionFieldValue>, 'dataSource'> &
+  Partial<Pick<TableProps<DimensionFieldValue>, 'columns'>>;
+
+export const getDimensionFieldTableColumns = () => {
+  return [
+    {
+      title: 'Name',
+      dataIndex: 'fieldName',
+    },
+  ];
+};
+
+export default function DimensionFieldTable(props: Props) {
+  const { dataSource = [], columns = [] } = props;
+
+  const tableColumns = useMemo(
+    () => [...getDimensionFieldTableColumns(), ...columns],
+    [dataSource]
+  );
+
+  return (
+    <Table
+      rowKey={(record, index) => `${record.fieldName}-${index}`}
+      dataSource={dataSource}
+      showHeader={dataSource.length > 0}
+      columns={tableColumns}
+      pagination={{
+        hideOnSinglePage: true,
+        pageSize: 10,
+        size: 'small',
+      }}
+    />
+  );
+}

--- a/packages/admin-ui/components/table/DimensionFieldTable.tsx
+++ b/packages/admin-ui/components/table/DimensionFieldTable.tsx
@@ -22,11 +22,19 @@ export default function DimensionFieldTable(props: Props) {
     [dataSource]
   );
 
+  const tableData = useMemo(
+    () =>
+      (dataSource || []).map((record, index) => ({
+        ...record,
+        key: `${record.fieldName}-${index}`,
+      })),
+    [dataSource]
+  );
+
   return (
     <Table
-      rowKey={(record, index) => `${record.fieldName}-${index}`}
-      dataSource={dataSource}
-      showHeader={dataSource.length > 0}
+      dataSource={tableData}
+      showHeader={tableData.length > 0}
       columns={tableColumns}
       pagination={{
         hideOnSinglePage: true,

--- a/packages/admin-ui/components/table/FieldTable.tsx
+++ b/packages/admin-ui/components/table/FieldTable.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { Table, TableProps } from 'antd';
 
-type Props = Pick<TableProps<any>, 'dataSource'> &
-  Partial<Pick<TableProps<any>, 'columns'>>;
+type Props = Pick<TableProps<{ name: string; type: string }>, 'dataSource'> &
+  Partial<Pick<TableProps<{ name: string; type: string }>, 'columns'>>;
 
 export const getFieldTableColumns = () => {
   return [
@@ -26,11 +26,19 @@ export default function FieldTable(props: Props) {
     [dataSource]
   );
 
+  const tableData = useMemo(
+    () =>
+      (dataSource || []).map((record, index) => ({
+        ...record,
+        key: `${record.name}-${index}`,
+      })),
+    [dataSource]
+  );
+
   return (
     <Table
-      rowKey={(record, index) => `${record.name}-${index}`}
-      dataSource={dataSource}
-      showHeader={dataSource.length > 0}
+      dataSource={tableData}
+      showHeader={tableData.length > 0}
       columns={tableColumns}
       pagination={{
         hideOnSinglePage: true,

--- a/packages/admin-ui/components/table/FieldTable.tsx
+++ b/packages/admin-ui/components/table/FieldTable.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { Table, TableProps } from 'antd';
+
+type Props = Pick<TableProps<any>, 'dataSource'> &
+  Partial<Pick<TableProps<any>, 'columns'>>;
+
+export const getFieldTableColumns = () => {
+  return [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      width: 150,
+    },
+    {
+      title: 'Type',
+      dataIndex: 'type',
+    },
+  ];
+};
+
+export default function FieldTable(props: Props) {
+  const { dataSource = [], columns = [] } = props;
+
+  const tableColumns = useMemo(
+    () => [...getFieldTableColumns(), ...columns],
+    [dataSource]
+  );
+
+  return (
+    <Table
+      rowKey={(record, index) => `${record.name}-${index}`}
+      dataSource={dataSource}
+      showHeader={dataSource.length > 0}
+      columns={tableColumns}
+      pagination={{
+        hideOnSinglePage: true,
+        pageSize: 10,
+        size: 'small',
+      }}
+    />
+  );
+}

--- a/packages/admin-ui/components/table/MeasureFieldTable.tsx
+++ b/packages/admin-ui/components/table/MeasureFieldTable.tsx
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import { Table, TableProps } from 'antd';
+import { MeasureFieldValue } from '@vulcan-sql/admin-ui/components/modals/AddMeasureFieldModal';
+
+type Props = Pick<TableProps<MeasureFieldValue>, 'dataSource'> &
+  Partial<Pick<TableProps<MeasureFieldValue>, 'columns'>>;
+
+export const getMeasureFieldTableColumns = () => {
+  return [
+    {
+      title: 'Name',
+      dataIndex: 'fieldName',
+    },
+    {
+      title: 'Expression',
+      dataIndex: 'expression',
+      render: (expression, record) => {
+        // TODO: clarify the interface with backend
+        const argumentFields = record.modelFields.map((field) => field.name);
+        const argumentTexts = argumentFields.join('.');
+        return `${expression}${argumentTexts ? `(${argumentTexts})` : ''}`;
+      },
+    },
+  ];
+};
+
+export default function MeasureFieldTable(props: Props) {
+  const { dataSource = [], columns = [] } = props;
+
+  const tableColumns = useMemo(
+    () => [...getMeasureFieldTableColumns(), ...columns],
+    [dataSource]
+  );
+
+  return (
+    <Table
+      rowKey={(record, index) => `${record.fieldName}-${index}`}
+      dataSource={dataSource}
+      showHeader={dataSource.length > 0}
+      columns={tableColumns}
+      pagination={{
+        hideOnSinglePage: true,
+        pageSize: 10,
+        size: 'small',
+      }}
+    />
+  );
+}

--- a/packages/admin-ui/components/table/MeasureFieldTable.tsx
+++ b/packages/admin-ui/components/table/MeasureFieldTable.tsx
@@ -32,11 +32,19 @@ export default function MeasureFieldTable(props: Props) {
     [dataSource]
   );
 
+  const tableData = useMemo(
+    () =>
+      (dataSource || []).map((record, index) => ({
+        ...record,
+        key: `${record.fieldName}-${index}`,
+      })),
+    [dataSource]
+  );
+
   return (
     <Table
-      rowKey={(record, index) => `${record.fieldName}-${index}`}
-      dataSource={dataSource}
-      showHeader={dataSource.length > 0}
+      dataSource={tableData}
+      showHeader={tableData.length > 0}
       columns={tableColumns}
       pagination={{
         hideOnSinglePage: true,

--- a/packages/admin-ui/components/table/MetadataBaseTable.tsx
+++ b/packages/admin-ui/components/table/MetadataBaseTable.tsx
@@ -1,0 +1,96 @@
+import { Space, Button, TableProps } from 'antd';
+import EditOutlined from '@ant-design/icons/EditOutlined';
+import React, { useMemo } from 'react';
+import useModalAction from '@vulcan-sql/admin-ui/hooks/useModalAction';
+
+interface Props<MData> {
+  dataSource: any[];
+  metadataIndex?: Record<string, string>;
+  onEditValue?: (value: any) => any;
+  onSubmitRemote?: (value: any) => void;
+  modalProps?: Partial<MData>;
+}
+
+const defaultIndex = {
+  description: 'description',
+};
+
+export const getMetadataColumns = (
+  dataIndex: Record<string, string> = defaultIndex
+) => [
+  {
+    title: 'Description',
+    dataIndex: dataIndex?.description,
+    width: 220,
+    render: (text) => text || '-',
+  },
+];
+
+export const makeMetadataBaseTable =
+  <TData,>(BaseTable: React.FC<Partial<TableProps<TData>>>) =>
+  <MData,>(ModalComponent?: React.FC<Partial<MData>>) => {
+    const isEditable = !!ModalComponent;
+
+    const MetadataBaseTable = (props: Props<MData>) => {
+      const {
+        dataSource,
+        metadataIndex,
+        onEditValue = (value) => value,
+        onSubmitRemote,
+        modalProps,
+      } = props;
+
+      const modalComponent = useModalAction();
+
+      const actionColumns = useMemo(
+        () =>
+          isEditable
+            ? [
+                {
+                  key: 'action',
+                  width: 80,
+                  render: (record) => {
+                    return (
+                      <Space className="d-flex justify-end">
+                        <Button
+                          type="text"
+                          className="px-2"
+                          onClick={() =>
+                            modalComponent.openModal(onEditValue(record))
+                          }
+                        >
+                          <EditOutlined />
+                        </Button>
+                      </Space>
+                    );
+                  },
+                },
+              ]
+            : [],
+        [dataSource]
+      );
+
+      const submitModal = async (values: any) => {
+        onSubmitRemote && (await onSubmitRemote(values));
+      };
+
+      return (
+        <>
+          <BaseTable
+            dataSource={dataSource}
+            columns={[...getMetadataColumns(metadataIndex), ...actionColumns]}
+          />
+          {isEditable && (
+            <ModalComponent
+              {...modalComponent.state}
+              {...modalProps}
+              onClose={modalComponent.closeModal}
+              onSubmit={submitModal}
+            />
+          )}
+        </>
+      );
+    };
+
+    return MetadataBaseTable;
+  };

--- a/packages/admin-ui/components/table/RelationTable.tsx
+++ b/packages/admin-ui/components/table/RelationTable.tsx
@@ -29,11 +29,19 @@ export default function RelationTable(props: Props) {
     [dataSource]
   );
 
+  const tableData = useMemo(
+    () =>
+      (dataSource || []).map((record, index) => ({
+        ...record,
+        key: `${record.relationName}-${index}`,
+      })),
+    [dataSource]
+  );
+
   return (
     <Table
-      rowKey={(record, index) => `${record.relationName}-${index}`}
-      dataSource={dataSource}
-      showHeader={dataSource.length > 0}
+      dataSource={tableData}
+      showHeader={tableData.length > 0}
       columns={tableColumns}
       pagination={{
         hideOnSinglePage: true,

--- a/packages/admin-ui/components/table/RelationTable.tsx
+++ b/packages/admin-ui/components/table/RelationTable.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { Table, TableProps } from 'antd';
+import { getJoinTypeText } from '@vulcan-sql/admin-ui/utils/data';
+import { RelationFieldValue } from '@vulcan-sql/admin-ui/components/modals/AddRelationModal';
+
+type Props = Pick<TableProps<RelationFieldValue>, 'dataSource'> &
+  Partial<Pick<TableProps<RelationFieldValue>, 'columns'>>;
+
+export const getRelationTableColumns = () => {
+  return [
+    {
+      title: 'Name',
+      dataIndex: 'relationName',
+      width: 150,
+    },
+    {
+      title: 'Relation',
+      dataIndex: 'relationType',
+      render: (relationType) => getJoinTypeText(relationType),
+    },
+  ];
+};
+
+export default function RelationTable(props: Props) {
+  const { dataSource = [], columns = [] } = props;
+
+  const tableColumns = useMemo(
+    () => [...getRelationTableColumns(), ...columns],
+    [dataSource]
+  );
+
+  return (
+    <Table
+      rowKey={(record, index) => `${record.relationName}-${index}`}
+      dataSource={dataSource}
+      showHeader={dataSource.length > 0}
+      columns={tableColumns}
+      pagination={{
+        hideOnSinglePage: true,
+        pageSize: 10,
+        size: 'small',
+      }}
+    />
+  );
+}

--- a/packages/admin-ui/components/table/WindowFieldTable.tsx
+++ b/packages/admin-ui/components/table/WindowFieldTable.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { Table, TableProps } from 'antd';
+import { WindowFieldValue } from '@vulcan-sql/admin-ui/components/modals/AddWindowFieldModal';
+
+type Props = Pick<TableProps<WindowFieldValue>, 'dataSource'> &
+  Partial<Pick<TableProps<WindowFieldValue>, 'columns'>>;
+
+export const getWindowFieldTableColumns = () => {
+  return [
+    {
+      title: 'Name',
+      dataIndex: 'fieldName',
+    },
+  ];
+};
+
+export default function WindowFieldTable(props: Props) {
+  const { dataSource = [], columns = [] } = props;
+
+  const tableColumns = useMemo(
+    () => [...getWindowFieldTableColumns(), ...columns],
+    [dataSource]
+  );
+
+  return (
+    <Table
+      rowKey={(record, index) => `${record.fieldName}-${index}`}
+      dataSource={dataSource}
+      showHeader={dataSource.length > 0}
+      columns={tableColumns}
+      pagination={{
+        hideOnSinglePage: true,
+        pageSize: 10,
+        size: 'small',
+      }}
+    />
+  );
+}

--- a/packages/admin-ui/components/table/WindowFieldTable.tsx
+++ b/packages/admin-ui/components/table/WindowFieldTable.tsx
@@ -22,11 +22,19 @@ export default function WindowFieldTable(props: Props) {
     [dataSource]
   );
 
+  const tableData = useMemo(
+    () =>
+      (dataSource || []).map((record, index) => ({
+        ...record,
+        key: `${record.fieldName}-${index}`,
+      })),
+    [dataSource]
+  );
+
   return (
     <Table
-      rowKey={(record, index) => `${record.fieldName}-${index}`}
-      dataSource={dataSource}
-      showHeader={dataSource.length > 0}
+      dataSource={tableData}
+      showHeader={tableData.length > 0}
       columns={tableColumns}
       pagination={{
         hideOnSinglePage: true,

--- a/packages/admin-ui/components/tableFormControls/CaculatedFieldTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/CaculatedFieldTableFormControl.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import { makeTableFormControl } from './base';
 import AddCaculatedFieldModal, {
   CaculatedFieldValue,
 } from '@vulcan-sql/admin-ui/components/modals/AddCaculatedFieldModal';
+import { getCaculatedFieldTableColumns } from '@vulcan-sql/admin-ui/components/table/CaculatedFieldTable';
 
 export type CaculatedFieldTableValue = CaculatedFieldValue[];
 
@@ -10,28 +12,6 @@ type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
 const TableFormControl = makeTableFormControl(AddCaculatedFieldModal);
 
 export default function CaculatedFieldTableFormControl(props: Props) {
-  return (
-    <TableFormControl
-      {...props}
-      columns={[
-        {
-          title: 'Name',
-          dataIndex: 'fieldName',
-          width: 180,
-        },
-        {
-          title: 'Expression',
-          dataIndex: 'expression',
-          render: (expression, record) => {
-            // TODO: clarify the interface with backend
-            const argumentFields = record.modelFields.map(
-              (field) => field.name
-            );
-            const argumentTexts = argumentFields.join('.');
-            return `${expression}${argumentTexts ? `(${argumentTexts})` : ''}`;
-          },
-        },
-      ]}
-    />
-  );
+  const columns = useMemo(getCaculatedFieldTableColumns, [props.value]);
+  return <TableFormControl {...props} columns={columns} />;
 }

--- a/packages/admin-ui/components/tableFormControls/DimensionTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/DimensionTableFormControl.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import { makeTableFormControl } from './base';
 import AddDimensionFieldModal, {
   DimensionFieldValue,
 } from '@vulcan-sql/admin-ui/components/modals/AddDimensionFieldModal';
+import { getDimensionFieldTableColumns } from '@vulcan-sql/admin-ui/components/table/DimensionFieldTable';
 
 export type DimensionTableValue = DimensionFieldValue[];
 
@@ -10,15 +12,6 @@ type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
 const TableFormControl = makeTableFormControl(AddDimensionFieldModal);
 
 export default function DimensionTableFormControl(props: Props) {
-  return (
-    <TableFormControl
-      {...props}
-      columns={[
-        {
-          title: 'Name',
-          dataIndex: 'fieldName',
-        },
-      ]}
-    />
-  );
+  const columns = useMemo(getDimensionFieldTableColumns, [props.value]);
+  return <TableFormControl {...props} columns={columns} />;
 }

--- a/packages/admin-ui/components/tableFormControls/MeasureTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/MeasureTableFormControl.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import { makeTableFormControl } from './base';
 import AddMeasureFieldModal, {
   MeasureFieldValue,
 } from '@vulcan-sql/admin-ui/components/modals/AddMeasureFieldModal';
+import { getMeasureFieldTableColumns } from '@vulcan-sql/admin-ui/components/table/MeasureFieldTable';
 
 export type MeasureTableValue = MeasureFieldValue[];
 
@@ -10,28 +12,6 @@ type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
 const TableFormControl = makeTableFormControl(AddMeasureFieldModal);
 
 export default function MeasureTableFormControl(props: Props) {
-  return (
-    <TableFormControl
-      {...props}
-      columns={[
-        {
-          title: 'Name',
-          dataIndex: 'fieldName',
-          width: 180,
-        },
-        {
-          title: 'Expression',
-          dataIndex: 'expression',
-          render: (expression, record) => {
-            // TODO: clarify the interface with backend
-            const argumentFields = record.modelFields.map(
-              (field) => field.name
-            );
-            const argumentTexts = argumentFields.join('.');
-            return `${expression}${argumentTexts ? `(${argumentTexts})` : ''}`;
-          },
-        },
-      ]}
-    />
-  );
+  const columns = useMemo(getMeasureFieldTableColumns, [props.value]);
+  return <TableFormControl {...props} columns={columns} />;
 }

--- a/packages/admin-ui/components/tableFormControls/RelationTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/RelationTableFormControl.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { makeTableFormControl } from './base';
+import AddRelationModal, {
+  RelationFieldValue,
+} from '@vulcan-sql/admin-ui/components/modals/AddRelationModal';
+import { getRelationTableColumns } from '@vulcan-sql/admin-ui/components/table/RelationTable';
+import { getMetadataColumns } from '@vulcan-sql/admin-ui/components/table/MetadataBaseTable';
+
+export type RelationTableValue = RelationFieldValue[];
+
+type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
+
+const TableFormControl = makeTableFormControl(AddRelationModal);
+
+export default function RelationTableFormControl(props: Props) {
+  const columns = useMemo(getRelationTableColumns, [props.value]);
+  return (
+    <TableFormControl
+      {...props}
+      // Relation has metadata directly in table form control
+      columns={[...columns, ...getMetadataColumns()]}
+    />
+  );
+}

--- a/packages/admin-ui/components/tableFormControls/WindowTableFormControl.tsx
+++ b/packages/admin-ui/components/tableFormControls/WindowTableFormControl.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import { makeTableFormControl } from './base';
 import AddWindowFieldModal, {
   WindowFieldValue,
 } from '@vulcan-sql/admin-ui/components/modals/AddWindowFieldModal';
+import { getWindowFieldTableColumns } from '@vulcan-sql/admin-ui/components/table/WindowFieldTable';
 
 export type WindowTableValue = WindowFieldValue[];
 
@@ -10,15 +12,6 @@ type Props = Omit<React.ComponentProps<typeof TableFormControl>, 'columns'>;
 const TableFormControl = makeTableFormControl(AddWindowFieldModal);
 
 export default function WindowTableFormControl(props: Props) {
-  return (
-    <TableFormControl
-      {...props}
-      columns={[
-        {
-          title: 'Name',
-          dataIndex: 'fieldName',
-        },
-      ]}
-    />
-  );
+  const columns = useMemo(getWindowFieldTableColumns, [props.value]);
+  return <TableFormControl {...props} columns={columns} />;
 }

--- a/packages/admin-ui/components/tableFormControls/base.tsx
+++ b/packages/admin-ui/components/tableFormControls/base.tsx
@@ -10,6 +10,8 @@ interface Props<MData> {
   value?: Record<string, any>[];
   disabled?: boolean;
   onChange?: (value: Record<string, any>[]) => void;
+  onRemoteSubmit?: (value: Record<string, any>[]) => void;
+  onRemoteDelete?: (value: Record<string, any>[]) => void;
   modalProps?: Partial<MData>;
 }
 
@@ -21,7 +23,15 @@ export const makeTableFormControl = <MData,>(
   ModalComponent: React.FC<Partial<MData>>
 ) => {
   const TableFormControl = (props: Props<MData>) => {
-    const { columns, onChange, value, modalProps, disabled } = props;
+    const {
+      columns,
+      onChange,
+      onRemoteSubmit,
+      onRemoteDelete,
+      value,
+      modalProps,
+      disabled,
+    } = props;
     const [internalValue, setInternalValue] = useState(
       setupInternalId(value || [])
     );
@@ -67,11 +77,17 @@ export const makeTableFormControl = <MData,>(
       [internalValue]
     );
 
-    const removeData = (id) => {
+    const removeData = async (id) => {
+      // It means directly update to the db
+      if (onRemoteDelete) return await onRemoteDelete(id);
+
       setInternalValue(internalValue.filter((record) => record._id !== id));
     };
 
-    const submitModal = (item) => {
+    const submitModal = async (item) => {
+      // It means directly update to the db
+      if (onRemoteSubmit) return await onRemoteSubmit(item);
+
       const isNewItem = !item._id;
       if (isNewItem) item._id = uuidv4();
 

--- a/packages/admin-ui/hooks/useDrawerAction.tsx
+++ b/packages/admin-ui/hooks/useDrawerAction.tsx
@@ -1,6 +1,15 @@
 import { useState } from 'react';
 import { FORM_MODE } from '@vulcan-sql/admin-ui/utils/enum';
 
+export interface DrawerAction<TData = any> {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit?: (values: any) => Promise<void>;
+  formMode?: FORM_MODE;
+  // use as form default value or view data
+  defaultValue?: TData;
+}
+
 export default function useDrawerAction() {
   const [visible, setVisible] = useState(false);
   const [formMode, setFormMode] = useState(FORM_MODE.CREATE);

--- a/packages/admin-ui/hooks/useModalAction.tsx
+++ b/packages/admin-ui/hooks/useModalAction.tsx
@@ -1,6 +1,14 @@
 import { useState } from 'react';
 import { FORM_MODE } from '@vulcan-sql/admin-ui/utils/enum';
 
+export interface ModalAction<TData = any, SData = any> {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit?: (values: SData) => Promise<void>;
+  formMode?: FORM_MODE;
+  defaultValue?: TData;
+}
+
 export default function useModalAction() {
   const [visible, setVisible] = useState(false);
   const [formMode, setFormMode] = useState(FORM_MODE.CREATE);

--- a/packages/admin-ui/pages/component.tsx
+++ b/packages/admin-ui/pages/component.tsx
@@ -12,6 +12,7 @@ import AddWindowFieldModal from '@vulcan-sql/admin-ui/components/modals/AddWindo
 import AddRelationModal from '@vulcan-sql/admin-ui/components/modals/AddRelationModal';
 import ModelDrawer from '@vulcan-sql/admin-ui/components/pages/modeling/ModelDrawer';
 import MetricDrawer from '@vulcan-sql/admin-ui/components/pages/modeling/MetricDrawer';
+import MetadataDrawer from '@vulcan-sql/admin-ui/components/pages/modeling/MetadataDrawer';
 import useDrawerAction from '@vulcan-sql/admin-ui/hooks/useDrawerAction';
 
 const ModelFieldSelector = dynamic(
@@ -36,6 +37,7 @@ export default function Component() {
 
   const modelDrawer = useDrawerAction();
   const metricDrawer = useDrawerAction();
+  const metadataDrawer = useDrawerAction();
 
   const fieldOptions = useModelFieldOptions();
   const modelFields = Form.useWatch('modelFields', form);
@@ -91,6 +93,10 @@ export default function Component() {
       <Button onClick={() => modelDrawer.openDrawer()}>Model drawer</Button>
 
       <Button onClick={() => metricDrawer.openDrawer()}>Metric drawer</Button>
+
+      <Button onClick={() => metadataDrawer.openDrawer()}>
+        Metadata drawer
+      </Button>
 
       <AddCaculatedFieldModal
         model="Customer"
@@ -196,6 +202,61 @@ export default function Component() {
         onClose={metricDrawer.closeDrawer}
         onSubmit={async (values) => {
           console.log(values);
+        }}
+      />
+
+      <MetadataDrawer
+        {...metadataDrawer.state}
+        onClose={metadataDrawer.closeDrawer}
+        onSubmit={async (values) => {
+          console.log(values);
+        }}
+        // defaultValue={{
+        //   name: 'Customer',
+        //   nodeType: NODE_TYPE.MODEL,
+        //   description: 'customer_description',
+        //   fields: [
+        //     {
+        //       name: 'custKey',
+        //       type: 'UUID',
+        //     },
+        //   ],
+        //   caculatedFields: [
+        //     {
+        //       fieldName: 'test',
+        //       expression: 'Sum',
+        //       modelFields: [
+        //         { nodeType: NODE_TYPE.MODEL, name: 'customer' },
+        //         { nodeType: NODE_TYPE.FIELD, name: 'custKey', type: 'UUID' },
+        //       ],
+        //     },
+        //   ],
+        //   relations: [],
+        // }}
+        defaultValue={{
+          name: 'Metric',
+          nodeType: NODE_TYPE.METRIC,
+          description: 'metric description',
+          measures: [
+            {
+              fieldName: 'test',
+              expression: 'Sum',
+              modelFields: [
+                { nodeType: NODE_TYPE.MODEL, name: 'customer' },
+                { nodeType: NODE_TYPE.FIELD, name: 'custKey', type: 'UUID' },
+              ],
+            },
+          ],
+          dimensions: [
+            {
+              fieldName: 'test',
+              expression: 'Sum',
+              modelFields: [
+                { nodeType: NODE_TYPE.MODEL, name: 'customer' },
+                { nodeType: NODE_TYPE.FIELD, name: 'custKey', type: 'UUID' },
+              ],
+            },
+          ],
         }}
       />
     </Form>

--- a/packages/admin-ui/utils/error/dictionary.ts
+++ b/packages/admin-ui/utils/error/dictionary.ts
@@ -67,6 +67,11 @@ export const ERROR_TEXTS = {
       REQUIRED: 'Please select a relation type.',
     },
   },
+  UPDATE_METADATA: {
+    NAME: {
+      REQUIRED: 'Please input name.',
+    },
+  },
   MODELING_CREATE_MODEL: {
     NAME: {
       REQUIRED: 'Please input model name.',


### PR DESCRIPTION
## Description

- View Metadata Drawer
- Update Metadata Popup
- The caculated field will remain update in model drawer which metadata drawer not provide update caculated fields, only can update it’s metadata.

<img width="809" alt="image" src="https://github.com/Canner/vulcan-sql/assets/9657305/765af171-6062-4572-8e91-91c687c2938b">

<img width="1437" alt="image" src="https://github.com/Canner/vulcan-sql/assets/9657305/21078a97-365a-4978-9379-7e08e4ba8f6c">

<img width="793" alt="image" src="https://github.com/Canner/vulcan-sql/assets/9657305/6467201d-608d-4f7e-8b09-044f05e57417">

## Issue ticket number

closes #xx

## Additional Context

<!--
Describe your commits, tell us what might be impacted ...etc.
-->
